### PR TITLE
Fix issue DPTP-4756 Move ARN to Secrets

### DIFF
--- a/pkg/api/clusterprofile.go
+++ b/pkg/api/clusterprofile.go
@@ -1243,14 +1243,12 @@ func (cpl *ClusterProfilesList) Resolve() error {
 type ClusterProfilesMap map[ClusterProfile]ClusterProfileDetails
 
 type ClusterProfileDetails struct {
-	Name          ClusterProfile         `yaml:"name,omitempty" json:"name,omitempty"`
-	Owners        []ClusterProfileOwners `yaml:"owners,omitempty" json:"owners,omitempty"`
-	ClusterType   string                 `yaml:"cluster_type,omitempty" json:"cluster_type,omitempty"`
-	LeaseType     string                 `yaml:"lease_type,omitempty" json:"lease_type,omitempty"`
-	Secret        string                 `yaml:"secret,omitempty" json:"secret,omitempty"`
-	ConfigMap     string                 `yaml:"config_map,omitempty" json:"config_map,omitempty"`
-	HubRoleARN    string                 `yaml:"hub_role_arn,omitempty" json:"hub_role_arn,omitempty"`
-	TargetRoleARN string                 `yaml:"target_role_arn,omitempty" json:"target_role_arn,omitempty"`
+	Name        ClusterProfile         `yaml:"name,omitempty" json:"name,omitempty"`
+	Owners      []ClusterProfileOwners `yaml:"owners,omitempty" json:"owners,omitempty"`
+	ClusterType string                 `yaml:"cluster_type,omitempty" json:"cluster_type,omitempty"`
+	LeaseType   string                 `yaml:"lease_type,omitempty" json:"lease_type,omitempty"`
+	Secret      string                 `yaml:"secret,omitempty" json:"secret,omitempty"`
+	ConfigMap   string                 `yaml:"config_map,omitempty" json:"config_map,omitempty"`
 }
 
 type ClusterProfileKonfluxOwner struct {

--- a/pkg/api/constant.go
+++ b/pkg/api/constant.go
@@ -80,6 +80,8 @@ const (
 	ClusterProfileSecretNameParam = "CLUSTER_PROFILE_SECRET_NAME"
 	STSHubRoleARNParam            = "CI_STS_HUB_ROLE_ARN"
 	STSTargetRoleARNParam         = "CI_STS_TARGET_ROLE_ARN"
+	STSHubRoleARNSecretKey        = "hub_role_arn"
+	STSTargetRoleARNSecretKey     = "target_role_arn"
 
 	// SkipCensoringLabel is the label we use to mark a secret as not needing to be censored
 	SkipCensoringLabel = "ci.openshift.io/skip-censoring"

--- a/pkg/steps/lease.go
+++ b/pkg/steps/lease.go
@@ -280,24 +280,26 @@ func (s *leaseStep) handleClusterProfile(ctx context.Context, l *stepLease, name
 		return fmt.Errorf("resolve cluster profile %s: %w", s.clusterProfileName, err)
 	}
 
-	s.stsHubRoleARN = cpDetails.HubRoleARN
-	s.stsTargetRoleARN = cpDetails.TargetRoleARN
-
-	if err := s.importClusterProfileSecret(ctx, cpDetails.Secret); err != nil {
+	secretData, err := s.importClusterProfileSecret(ctx, cpDetails.Secret)
+	if err != nil {
 		return fmt.Errorf("import secret %s for cluster profile %s: %w", cpDetails.Secret, s.clusterProfileName, err)
 	}
+
+	s.stsHubRoleARN = string(secretData[api.STSHubRoleARNSecretKey])
+	s.stsTargetRoleARN = string(secretData[api.STSTargetRoleARNSecretKey])
 
 	s.clusterProfileSecretName = cpDetails.Secret
 	return nil
 }
 
-// importClusterProfileSecret retrieves the cluster profile secret name using config resolver,
-// and gets the secret from the ci namespace
-func (s *leaseStep) importClusterProfileSecret(ctx context.Context, secretName string) error {
+// importClusterProfileSecret retrieves the cluster profile secret from the
+// ci namespace, copies it into the test namespace, and returns the raw data
+// so callers can extract additional fields (e.g. STS role ARNs).
+func (s *leaseStep) importClusterProfileSecret(ctx context.Context, secretName string) (map[string][]byte, error) {
 	ciSecret := &coreapi.Secret{}
 	err := s.kubeClient.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: "ci", Name: secretName}, ciSecret)
 	if err != nil {
-		return fmt.Errorf("failed to get secret '%s' from ci namespace: %w", secretName, err)
+		return nil, fmt.Errorf("failed to get secret '%s' from ci namespace: %w", secretName, err)
 	}
 
 	newSecret := &coreapi.Secret{
@@ -311,7 +313,7 @@ func (s *leaseStep) importClusterProfileSecret(ctx context.Context, secretName s
 
 	created, err := util.UpsertImmutableSecret(ctx, s.kubeClient, newSecret)
 	if err != nil {
-		return fmt.Errorf("could not update secret %s: %w", newSecret.Name, err)
+		return nil, fmt.Errorf("could not update secret %s: %w", newSecret.Name, err)
 	}
 	if created {
 		logrus.Debugf("Created secret %s", newSecret.Name)
@@ -319,5 +321,5 @@ func (s *leaseStep) importClusterProfileSecret(ctx context.Context, secretName s
 		logrus.Debugf("Updated secret %s", newSecret.Name)
 	}
 
-	return nil
+	return ciSecret.Data, nil
 }

--- a/pkg/steps/lease_test.go
+++ b/pkg/steps/lease_test.go
@@ -478,15 +478,15 @@ func TestAcquireLeases(t *testing.T) {
 					Name:      "cluster-secrets-aws",
 				},
 				Data: map[string][]byte{
-					"k1": []byte("v1"),
+					"k1":                          []byte("v1"),
+					api.STSHubRoleARNSecretKey:    []byte("arn:aws:iam::111:role/hub"),
+					api.STSTargetRoleARNSecretKey: []byte("arn:aws:iam::222:role/target"),
 				},
 			}},
 			clusterProfiles: map[string]*api.ClusterProfileDetails{
 				"aws": {
-					Secret:        "cluster-secrets-aws",
-					LeaseType:     "aws-quota-slice",
-					HubRoleARN:    "arn:aws:iam::111:role/hub",
-					TargetRoleARN: "arn:aws:iam::222:role/target",
+					Secret:    "cluster-secrets-aws",
+					LeaseType: "aws-quota-slice",
 				},
 			},
 			wantProvides: map[string]string{
@@ -507,7 +507,9 @@ func TestAcquireLeases(t *testing.T) {
 							ResourceVersion: "999",
 						},
 						Data: map[string][]byte{
-							"k1": []byte("v1"),
+							"k1":                          []byte("v1"),
+							api.STSHubRoleARNSecretKey:    []byte("arn:aws:iam::111:role/hub"),
+							api.STSTargetRoleARNSecretKey: []byte("arn:aws:iam::222:role/target"),
 						},
 					},
 					{
@@ -517,7 +519,9 @@ func TestAcquireLeases(t *testing.T) {
 							ResourceVersion: "1",
 						},
 						Data: map[string][]byte{
-							"k1": []byte("v1"),
+							"k1":                          []byte("v1"),
+							api.STSHubRoleARNSecretKey:    []byte("arn:aws:iam::111:role/hub"),
+							api.STSTargetRoleARNSecretKey: []byte("arn:aws:iam::222:role/target"),
 						},
 						Immutable: ptr.To(true),
 					},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR addresses [DPTP-4756](https://redhat.atlassian.net/browse/DPTP-4756) by moving AWS IAM role ARNs from cluster profile configuration to Kubernetes secrets, improving the security posture of credential management in CI operations.

### Changes

**API/Configuration Changes:**
- Removed `HubRoleARN` and `TargetRoleARN` fields from the `ClusterProfileDetails` struct, which changes how cluster profile data is defined in YAML/JSON configurations
- Added two new secret key constants: `STSHubRoleARNSecretKey` (`"hub_role_arn"`) and `STSTargetRoleARNSecretKey` (`"target_role_arn"`) in `pkg/api/constant.go`

**Lease Step Refactoring:**
- Modified `handleClusterProfile()` to extract STS role ARNs from the cluster profile secret data instead of directly from the cluster profile struct
- Refactored `importClusterProfileSecret()` to return the raw secret data (`map[string][]byte`) rather than just an error, allowing callers to extract additional fields beyond the basic secret contents
- The function now provides clearer logging when secrets are created vs. updated

**Test Updates:**
- Updated test fixtures to reflect that STS hub/target role ARNs are now sourced from secret data keys rather than cluster profile fields
- The expected secrets now include the ARN entries in their data, and the CI parameters still provide these ARNs to downstream steps via environment variables

### Impact

The changes improve credential security by storing sensitive AWS IAM role ARNs in Kubernetes secrets (appropriate for sensitive data) rather than in cluster profile configurations. The STS role ARNs remain available to CI test steps through the same environment parameters (`CI_STS_HUB_ROLE_ARN` and `CI_STS_TARGET_ROLE_ARN`), so test execution behavior is unchanged, but the credentials are now managed more securely through the secrets infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->