### PR TITLE
Fix dispatcher reliability: capability parsing, crash-on-prom-failure, validation, and persistence

### DIFF
--- a/cmd/prow-job-dispatcher/main.go
+++ b/cmd/prow-job-dispatcher/main.go
@@ -269,19 +269,6 @@ func (cv *clusterVolume) findClusterForJobConfig(cloudProvider string, jc *prowc
 	return cluster, utilerrors.NewAggregate(errs)
 }
 
-func extractCapabilities(labels map[string]string) []string {
-	var capabilities []string
-	prefix := "capability/"
-
-	for key, value := range labels {
-		if strings.HasPrefix(key, prefix) {
-			capabilities = append(capabilities, value)
-		}
-	}
-
-	return capabilities
-}
-
 func isBlockedClusterRelocationException(jobName string) bool {
 	for _, re := range blockedClusterRelocationJobExceptions {
 		if re.MatchString(jobName) {
@@ -312,7 +299,7 @@ func findClusterAssigmentsForJobs(jc *prowconfig.JobConfig, path string, config 
 
 		blockedForJob := blockedClustersForJob(jobBase.Name, string(determinedCluster), blocked)
 		c := dispatcher.DetermineTargetCluster(cluster, string(determinedCluster), string(config.Default), canBeRelocated, blockedForJob)
-		pjs[jobBase.Name] = dispatcher.ProwJobData{Cluster: c, Capabilities: extractCapabilities(jobBase.Labels)}
+		pjs[jobBase.Name] = dispatcher.ProwJobData{Cluster: c, Capabilities: dispatcher.ExtractCapabilities(jobBase.Labels)}
 		logrus.WithField("job", jobBase.Name).WithField("cluster", c).Info("found cluster for job")
 		return nil
 	}
@@ -320,7 +307,7 @@ func findClusterAssigmentsForJobs(jc *prowconfig.JobConfig, path string, config 
 	var errs []error
 	for k := range jc.PresubmitsStatic {
 		for _, job := range jc.PresubmitsStatic[k] {
-			if _, ok := pjs[job.Name]; !ok || !slices.Equal(pjs[job.Name].Capabilities, extractCapabilities(job.Labels)) {
+			if _, ok := pjs[job.Name]; !ok || !slices.Equal(pjs[job.Name].Capabilities, dispatcher.ExtractCapabilities(job.Labels)) {
 				if err := getClusterForMissingJob(mostUsedCluster, job.JobBase, pjs); err != nil {
 					errs = append(errs, err)
 				}
@@ -330,7 +317,7 @@ func findClusterAssigmentsForJobs(jc *prowconfig.JobConfig, path string, config 
 
 	for k := range jc.PostsubmitsStatic {
 		for _, job := range jc.PostsubmitsStatic[k] {
-			if _, ok := pjs[job.Name]; !ok || !slices.Equal(pjs[job.Name].Capabilities, extractCapabilities(job.Labels)) {
+			if _, ok := pjs[job.Name]; !ok || !slices.Equal(pjs[job.Name].Capabilities, dispatcher.ExtractCapabilities(job.Labels)) {
 				if err := getClusterForMissingJob(mostUsedCluster, job.JobBase, pjs); err != nil {
 					errs = append(errs, err)
 				}
@@ -338,7 +325,7 @@ func findClusterAssigmentsForJobs(jc *prowconfig.JobConfig, path string, config 
 		}
 	}
 	for _, job := range jc.Periodics {
-		if _, ok := pjs[job.Name]; !ok || !slices.Equal(pjs[job.Name].Capabilities, extractCapabilities(job.Labels)) {
+		if _, ok := pjs[job.Name]; !ok || !slices.Equal(pjs[job.Name].Capabilities, dispatcher.ExtractCapabilities(job.Labels)) {
 			if err := getClusterForMissingJob(mostUsedCluster, job.JobBase, pjs); err != nil {
 				errs = append(errs, err)
 			}
@@ -357,7 +344,7 @@ func (cv *clusterVolume) addToVolume(cluster string, jobBase prowconfig.JobBase,
 
 	blockedForJob := blockedClustersForJob(jobBase.Name, string(determinedCluster), cv.blocked)
 	c := dispatcher.DetermineTargetCluster(cluster, string(determinedCluster), string(config.Default), canBeRelocated, blockedForJob)
-	cv.pjs[jobBase.Name] = dispatcher.ProwJobData{Cluster: c, Capabilities: extractCapabilities(jobBase.Labels)}
+	cv.pjs[jobBase.Name] = dispatcher.ProwJobData{Cluster: c, Capabilities: dispatcher.ExtractCapabilities(jobBase.Labels)}
 	if determinedCloudProvider := config.IsInBuildFarm(api.Cluster(c)); determinedCloudProvider != "" {
 		cv.clusterVolumeMap[string(determinedCloudProvider)][c] = cv.clusterVolumeMap[string(determinedCloudProvider)][c] + jobVolumes[jobBase.Name]
 		return nil
@@ -757,6 +744,9 @@ func main() {
 				return
 			}
 			prowjobs.Regenerate(pjs)
+			if err := dispatcher.WriteGob(o.jobsStoragePath, pjs); err != nil {
+				logrus.WithError(err).Error("continuing on cache memory, error writing Gob file after delta dispatch")
+			}
 		}
 
 		dispatchWrapper = func(forceDispatch bool) {
@@ -789,7 +779,8 @@ func main() {
 
 			jobVolumes, err := promVolumes.GetJobVolumes()
 			if err != nil {
-				logrus.WithError(err).Fatal("failed to get job volumes")
+				logrus.WithError(err).Error("failed to get job volumes")
+				return
 			}
 
 			addEnabledClusters(config, enabled,
@@ -803,6 +794,10 @@ func main() {
 			pjs, err := dispatchJobs(o.prowJobConfigDir, config, jobVolumes, blocked, promVolumes.CalculateVolumeDistribution(configClusterMap), configClusterMap)
 			if err != nil {
 				logrus.WithError(err).Error("failed to dispatch")
+				return
+			}
+			if pjs == nil {
+				logrus.Warn("no build farm clusters configured, skipping regeneration")
 				return
 			}
 			prowjobs.Regenerate(pjs)

--- a/pkg/dispatcher/config.go
+++ b/pkg/dispatcher/config.go
@@ -118,13 +118,17 @@ func DetermineCloud(jobBase prowconfig.JobBase) string {
 	return ""
 }
 
-func extractRequiredCapabilities(labels map[string]string) []string {
+// ExtractCapabilities returns a sorted list of capability values from labels of
+// the form "capability/<name>: <name>" (key suffix must equal value).
+// The result is sorted to ensure deterministic comparison with slices.Equal.
+func ExtractCapabilities(labels map[string]string) []string {
 	var capabilities []string
 	for key, value := range labels {
 		if strings.HasPrefix(key, "capability/") && strings.TrimPrefix(key, "capability/") == value {
 			capabilities = append(capabilities, value)
 		}
 	}
+	sort.Strings(capabilities)
 	return capabilities
 }
 
@@ -172,7 +176,7 @@ func (config *Config) DetermineClusterForJob(jobBase prowconfig.JobBase, path st
 			return api.Cluster(cluster), false, nil
 		}
 
-		requiredCapabilities := extractRequiredCapabilities(jobBase.Labels)
+		requiredCapabilities := ExtractCapabilities(jobBase.Labels)
 		if len(requiredCapabilities) > 0 {
 			matchingClusters := []string{}
 			matchingClustersByProvider := map[string][]string{}
@@ -361,6 +365,9 @@ func LoadConfig(configPath string) (*Config, error) {
 	if len(errs) > 0 {
 		return nil, utilerrors.NewAggregate(errs)
 	}
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
 	return config, nil
 }
 
@@ -383,7 +390,7 @@ func (config *Config) Validate() error {
 	}
 	// sort for tests
 	sort.Strings(matches)
-	if len(matches) > 1 {
+	if len(matches) > 0 {
 		return fmt.Errorf("there are job names occurring more than once: %s", matches)
 	}
 	return nil

--- a/pkg/dispatcher/gob.go
+++ b/pkg/dispatcher/gob.go
@@ -2,7 +2,9 @@ package dispatcher
 
 import (
 	"encoding/gob"
+	"fmt"
 	"os"
+	"path/filepath"
 )
 
 func ReadGob(filename string, data interface{}) error {
@@ -13,26 +15,32 @@ func ReadGob(filename string, data interface{}) error {
 	defer file.Close()
 
 	decoder := gob.NewDecoder(file)
-	err = decoder.Decode(data)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return decoder.Decode(data)
 }
 
+// WriteGob atomically writes data to filename by writing to a temporary file
+// in the same directory and then renaming it. This prevents corruption if the
+// process is interrupted mid-write.
 func WriteGob(filename string, data interface{}) error {
-	file, err := os.Create(filename)
+	dir := filepath.Dir(filename)
+	tmp, err := os.CreateTemp(dir, filepath.Base(filename)+".tmp.*")
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create temp file: %w", err)
 	}
-	defer file.Close()
+	tmpName := tmp.Name()
 
-	encoder := gob.NewEncoder(file)
-	err = encoder.Encode(data)
-	if err != nil {
-		return err
+	if err := gob.NewEncoder(tmp).Encode(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return fmt.Errorf("failed to encode gob: %w", err)
 	}
-
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("failed to close temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, filename); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("failed to rename temp file: %w", err)
+	}
 	return nil
 }


### PR DESCRIPTION
- Unify capability extraction into a single exported ExtractCapabilities function in pkg/dispatcher.
- Change logrus.Fatal to logrus.Error+return when GetJobVolumes fails. A transient Prometheus timeout no longer kills the entire dispatcher process.
- Fix Validate() off-by-one: len(matches) > 1 should be > 0, so a single duplicated job name across groups is now caught. Also call Validate() from LoadConfig() so it runs in production, not only tests.
- Skip Regenerate and downstream side-effects when dispatchJobs returns nil (no build farm clusters configured) instead of wiping all in-memory state. This prevents the HTTP API from either serving stale assignments to removed clusters or returning 404 for every job.
- Persist delta dispatch results to the gob file so assignments survive process restarts.
- Make gob writes atomic via temp file + rename to prevent corruption on crash mid-write.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dispatcher Reliability Fixes

This PR fixes multiple correctness and reliability issues in the Prow Job Dispatcher (the service that assigns Prow jobs to OpenShift CI build clusters), with practical effects for CI operators and users:

- Unified capability parsing
  - Introduces a single exported ExtractCapabilities(labels map[string]string) []string in pkg/dispatcher. Capabilities are deterministically sorted and used everywhere the dispatcher matches cluster capabilities to job requirements, removing duplicated parsing logic and making capability-driven assignment consistent.

- Prevent dispatcher process exits on transient Prometheus failures
  - Replaces a logrus.Fatal call when GetJobVolumes fails with logging + early return. A transient Prometheus timeout or similar error will no longer terminate the dispatcher process.

- Stronger, production-run validation
  - Fixes an off-by-one in Validate() so a single duplicated job name across groups is now treated as an error (len(matches) > 0). LoadConfig() now invokes Validate(), so validation runs during normal production config loading (not only in tests), catching configuration mistakes earlier.

- Preserve existing assignments when no build-farm clusters are configured
  - If dispatchJobs returns nil (indicating no build-farm clusters configured), the dispatcher now skips regeneration and downstream side-effects instead of clearing in-memory state. This prevents the HTTP API from serving 404s or losing previously cached assignments when cluster configuration is temporarily missing.

- Durable, atomic persistence of dispatch results
  - Delta dispatch results are now persisted to the Gob cache so incremental assignment updates survive process restarts (assignments are no longer lost between full dispatch runs).
  - Gob writes are performed atomically by writing to a temp file and renaming it into place, preventing cache corruption if the dispatcher crashes mid-write.

Overall impact: dispatcher restarts and transient monitoring failures are far less likely to cause lost assignments or process downtime; config issues are detected earlier; capability-based assignment is consistent and deterministic; on-disk assignment cache is durable and crash-resistant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->