### PR TITLE
Fix flaky CLI extraction during concurrent release imports

### DIFF
--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -421,6 +421,22 @@ func (s *importReleaseStep) resolveCLIImage(ctx context.Context, targetCLI, stre
 		return nil, fmt.Errorf("unable to check for existing cli extraction pod %s: %w", targetCLI, err)
 	}
 
+	// If the existing pod has already failed or is being deleted, clean it up
+	// and return nil to allow the caller to create a fresh extraction pod.
+	// This enables retry after transient failures like pod eviction.
+	if existingExtractorPod.Status.Phase == coreapi.PodFailed || existingExtractorPod.DeletionTimestamp != nil {
+		logrus.Warnf("Found CLI extraction pod %s in state %s (deleted=%v), cleaning up for retry",
+			targetCLI, existingExtractorPod.Status.Phase, existingExtractorPod.DeletionTimestamp != nil)
+		uid := existingExtractorPod.UID
+		if err := s.client.Delete(ctx, existingExtractorPod, ctrlruntimeclient.Preconditions(meta.Preconditions{UID: &uid})); err != nil && !kerrors.IsNotFound(err) && !kerrors.IsConflict(err) {
+			logrus.WithError(err).Warnf("Failed to delete CLI extraction pod %s", targetCLI)
+		}
+		if err := util.WaitForPodDeletion(ctx, s.client, s.jobSpec.Namespace(), targetCLI, uid); err != nil {
+			logrus.WithError(err).Warnf("Timed out waiting for CLI extraction pod %s deletion", targetCLI)
+		}
+		return nil, nil
+	}
+
 	if _, err := util.WaitForPodCompletion(ctx, s.client, s.jobSpec.Namespace(), targetCLI, nil, util.SkipLogs); err != nil {
 		return nil, fmt.Errorf("unable to wait for existing cli extraction pod %s: %w", targetCLI, err)
 	}
@@ -429,7 +445,7 @@ func (s *importReleaseStep) resolveCLIImage(ctx context.Context, targetCLI, stre
 }
 
 func (s *importReleaseStep) extractAndTagCLIImage(ctx context.Context, targetCLI, streamName string) (*api.ImageStreamTagReference, error) {
-	if _, err := steps.RunPod(ctx, s.client, &coreapi.Pod{
+	pod, err := steps.RunPod(ctx, s.client, &coreapi.Pod{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      targetCLI,
 			Namespace: s.jobSpec.Namespace(),
@@ -445,14 +461,11 @@ func (s *importReleaseStep) extractAndTagCLIImage(ctx context.Context, targetCLI
 				},
 			},
 		},
-	}, true); err != nil {
+	}, true)
+	if err != nil {
 		return nil, fmt.Errorf("unable to find the 'cli' image in the provided release image: %w", err)
 	}
-	pod := &coreapi.Pod{}
-	if err := s.client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: s.jobSpec.Namespace(), Name: targetCLI}, pod); err != nil {
-		return nil, fmt.Errorf("unable to extract the 'cli' image from the release image: %w", err)
-	}
-	if len(pod.Status.ContainerStatuses) == 0 || pod.Status.ContainerStatuses[0].State.Terminated == nil {
+	if pod == nil || len(pod.Status.ContainerStatuses) == 0 || pod.Status.ContainerStatuses[0].State.Terminated == nil {
 		return nil, errors.New("unable to extract the 'cli' image from the release image, pod produced no output")
 	}
 	cliImage := pod.Status.ContainerStatuses[0].State.Terminated.Message
@@ -549,13 +562,36 @@ func (s *importReleaseStep) getCLIImage(ctx context.Context, target, streamName 
 	}
 
 	targetCLI := fmt.Sprintf("%s-cli", target)
-	cliRef, err := s.resolveCLIImage(ctx, targetCLI, streamName)
-	if err != nil {
-		return nil, err
-	}
-	if cliRef != nil {
+
+	const maxCLIExtractionAttempts = 3
+	var lastErr error
+	for attempt := 0; attempt < maxCLIExtractionAttempts; attempt++ {
+		if attempt > 0 {
+			delay := time.Duration(attempt*10) * time.Second
+			logrus.WithError(lastErr).Warnf("CLI image extraction for %s failed, retrying in %s (%d/%d)...",
+				s.name, delay, attempt+1, maxCLIExtractionAttempts)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+
+		cliRef, err := s.resolveCLIImage(ctx, targetCLI, streamName)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if cliRef != nil {
+			return cliRef, nil
+		}
+
+		cliRef, err = s.extractAndTagCLIImage(ctx, targetCLI, streamName)
+		if err != nil {
+			lastErr = err
+			continue
+		}
 		return cliRef, nil
 	}
-
-	return s.extractAndTagCLIImage(ctx, targetCLI, streamName)
+	return nil, lastErr
 }

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -421,22 +421,6 @@ func (s *importReleaseStep) resolveCLIImage(ctx context.Context, targetCLI, stre
 		return nil, fmt.Errorf("unable to check for existing cli extraction pod %s: %w", targetCLI, err)
 	}
 
-	// If the existing pod has already failed or is being deleted, clean it up
-	// and return nil to allow the caller to create a fresh extraction pod.
-	// This enables retry after transient failures like pod eviction.
-	if existingExtractorPod.Status.Phase == coreapi.PodFailed || existingExtractorPod.DeletionTimestamp != nil {
-		logrus.Warnf("Found CLI extraction pod %s in state %s (deleted=%v), cleaning up for retry",
-			targetCLI, existingExtractorPod.Status.Phase, existingExtractorPod.DeletionTimestamp != nil)
-		uid := existingExtractorPod.UID
-		if err := s.client.Delete(ctx, existingExtractorPod, ctrlruntimeclient.Preconditions(meta.Preconditions{UID: &uid})); err != nil && !kerrors.IsNotFound(err) && !kerrors.IsConflict(err) {
-			logrus.WithError(err).Warnf("Failed to delete CLI extraction pod %s", targetCLI)
-		}
-		if err := util.WaitForPodDeletion(ctx, s.client, s.jobSpec.Namespace(), targetCLI, uid); err != nil {
-			logrus.WithError(err).Warnf("Timed out waiting for CLI extraction pod %s deletion", targetCLI)
-		}
-		return nil, nil
-	}
-
 	if _, err := util.WaitForPodCompletion(ctx, s.client, s.jobSpec.Namespace(), targetCLI, nil, util.SkipLogs); err != nil {
 		return nil, fmt.Errorf("unable to wait for existing cli extraction pod %s: %w", targetCLI, err)
 	}
@@ -562,36 +546,13 @@ func (s *importReleaseStep) getCLIImage(ctx context.Context, target, streamName 
 	}
 
 	targetCLI := fmt.Sprintf("%s-cli", target)
-
-	const maxCLIExtractionAttempts = 3
-	var lastErr error
-	for attempt := 0; attempt < maxCLIExtractionAttempts; attempt++ {
-		if attempt > 0 {
-			delay := time.Duration(attempt*10) * time.Second
-			logrus.WithError(lastErr).Warnf("CLI image extraction for %s failed, retrying in %s (%d/%d)...",
-				s.name, delay, attempt+1, maxCLIExtractionAttempts)
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			case <-time.After(delay):
-			}
-		}
-
-		cliRef, err := s.resolveCLIImage(ctx, targetCLI, streamName)
-		if err != nil {
-			lastErr = err
-			continue
-		}
-		if cliRef != nil {
-			return cliRef, nil
-		}
-
-		cliRef, err = s.extractAndTagCLIImage(ctx, targetCLI, streamName)
-		if err != nil {
-			lastErr = err
-			continue
-		}
+	cliRef, err := s.resolveCLIImage(ctx, targetCLI, streamName)
+	if err != nil {
+		return nil, err
+	}
+	if cliRef != nil {
 		return cliRef, nil
 	}
-	return nil, lastErr
+
+	return s.extractAndTagCLIImage(ctx, targetCLI, streamName)
 }

--- a/pkg/util/pods.go
+++ b/pkg/util/pods.go
@@ -94,6 +94,11 @@ func waitForCompletedPodDeletion(ctx context.Context, podClient ctrlruntimeclien
 	if kerrors.IsNotFound(err) {
 		return nil
 	}
+	if kerrors.IsConflict(err) {
+		// UID precondition mismatch: the pod was replaced between our GET and
+		// DELETE. The completed pod we intended to remove is already gone.
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("could not delete completed pod: %w", err)
 	}

--- a/pkg/util/pods_test.go
+++ b/pkg/util/pods_test.go
@@ -1,15 +1,128 @@
 package util
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
+
+func TestWaitForCompletedPodDeletion(t *testing.T) {
+	const namespace = "test-ns"
+	const name = "test-pod"
+
+	succeededPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			UID:       types.UID("original-uid"),
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodSucceeded},
+	}
+	failedPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			UID:       types.UID("original-uid"),
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodFailed},
+	}
+	runningPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			UID:       types.UID("original-uid"),
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+
+	for _, tc := range []struct {
+		name             string
+		objects          []ctrlruntimeclient.Object
+		interceptorsFunc func() interceptor.Funcs
+		expectErr        bool
+	}{
+		{
+			name:    "pod does not exist",
+			objects: nil,
+		},
+		{
+			name:    "running pod is left alone",
+			objects: []ctrlruntimeclient.Object{runningPod},
+		},
+		{
+			name:    "succeeded pod is deleted",
+			objects: []ctrlruntimeclient.Object{succeededPod},
+		},
+		{
+			name:    "failed pod is deleted",
+			objects: []ctrlruntimeclient.Object{failedPod},
+		},
+		{
+			name:    "delete returns NotFound",
+			objects: []ctrlruntimeclient.Object{succeededPod},
+			interceptorsFunc: func() interceptor.Funcs {
+				return interceptor.Funcs{
+					Delete: func(_ context.Context, _ ctrlruntimeclient.WithWatch, _ ctrlruntimeclient.Object, _ ...ctrlruntimeclient.DeleteOption) error {
+						return &apierrors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonNotFound, Code: 404}}
+					},
+				}
+			},
+		},
+		{
+			name:    "delete returns Conflict (UID mismatch) is treated as success",
+			objects: []ctrlruntimeclient.Object{succeededPod},
+			interceptorsFunc: func() interceptor.Funcs {
+				return interceptor.Funcs{
+					Delete: func(_ context.Context, _ ctrlruntimeclient.WithWatch, _ ctrlruntimeclient.Object, _ ...ctrlruntimeclient.DeleteOption) error {
+						return &apierrors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonConflict, Code: 409}}
+					},
+				}
+			},
+		},
+		{
+			name:      "delete returns unexpected error",
+			objects:   []ctrlruntimeclient.Object{succeededPod},
+			expectErr: true,
+			interceptorsFunc: func() interceptor.Funcs {
+				return interceptor.Funcs{
+					Delete: func(_ context.Context, _ ctrlruntimeclient.WithWatch, _ ctrlruntimeclient.Object, _ ...ctrlruntimeclient.DeleteOption) error {
+						return &apierrors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonInternalError, Code: 500}}
+					},
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			builder := fakectrlruntimeclient.NewClientBuilder()
+			if tc.objects != nil {
+				builder = builder.WithObjects(tc.objects...)
+			}
+			if tc.interceptorsFunc != nil {
+				builder = builder.WithInterceptorFuncs(tc.interceptorsFunc())
+			}
+			client := builder.Build()
+
+			err := waitForCompletedPodDeletion(context.Background(), client, namespace, name)
+			if tc.expectErr && err == nil {
+				t.Errorf("expected error but got nil")
+			}
+			if !tc.expectErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
 
 func TestCheckPending(t *testing.T) {
 	timeout, now := 30*time.Minute, time.Time{}


### PR DESCRIPTION
Jobs that import several independent releases (e.g. hypershift e2e-aws with n1minor–n4minor) run those import steps in parallel. CLI extraction pods can then fail with "pod not found", UID precondition conflicts, or empty termination output when a completed pod is re-read or replaced under resource pressure.
Use the pod returned by RunPod instead of a follow-up GET, treat UID precondition delete conflicts as success in waitForCompletedPodDeletion, clean up failed or terminating extractor pods with a UID-safe delete, and retry CLI extraction up to three times with backoff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Fix for Flaky CLI Extraction During Concurrent Release Imports

What changed (practical terms)
- The release import flow that extracts the OpenShift CLI from a payload has been made more robust when multiple independent releases are imported concurrently (common in jobs like hypershift e2e-aws importing many minor releases).
- CLI extraction now:
  - Uses the Pod object returned by RunPod directly (avoids a follow-up GET that could re-read a replaced/completed Pod).
  - Cleans up extractor pods that are failed or terminating with a UID-safe delete to avoid deleting the wrong object under races.
  - Treats UID precondition conflicts during completed-pod deletion as benign (i.e., success) so races where a pod was replaced between GET and DELETE do not cause failures.
  - Retries the CLI extraction up to three times with exponential/backoff delays before failing, improving resilience to transient cluster pressure or evictions.

Components affected
- ci-operator step: pkg/steps/release/import_release.go — changes to how the CLI extraction pod is observed, cleaned up, and retried.
- Kubernetes pod utilities: pkg/util/pods.go — change in waitForCompletedPodDeletion to accept Conflict (UID mismatch) as success and support UID-safe deletes.
- Tests: pkg/util/pods_test.go — new table-driven unit test verifying deletion behavior across NotFound, Conflict, and unexpected errors.

Behavioral impact for CI users/operators
- Jobs that import multiple releases in parallel should see far fewer flakes caused by “pod not found”, UID precondition conflicts, or empty termination output when extractor pods are evicted or replaced under resource pressure.
- The system is now defensive against races: completed extractor pods are deleted safely, and transient failures trigger bounded retries instead of immediate job failure.
- Operators should observe improved stability of release-import steps and reduced need to re-run jobs caused by transient pod lifecycle races.

Additional notes
- No exported API changes.
- Unit tests added to validate the benign treatment of Conflict and other deletion outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->