### PR TITLE
New metal-perfscale-osp-nfv cluster profile

### DIFF
--- a/pkg/api/clusterprofile.go
+++ b/pkg/api/clusterprofile.go
@@ -126,6 +126,7 @@ const (
 	ClusterProfileMetalPerfscaleBMCPT     ClusterProfile = "metal-perfscale-cpt"
 	ClusterProfileMetalPerfscaleJetlag    ClusterProfile = "metal-perfscale-jetlag"
 	ClusterProfileMetalPerfscaleOSP       ClusterProfile = "metal-perfscale-osp"
+	ClusterProfileMetalPerfscaleOspNfv    ClusterProfile = "metal-perfscale-osp-nfv"
 	ClusterProfileMetalPerfscaleSelfSched ClusterProfile = "metal-perfscale-selfsched"
 	ClusterProfileMetalPerfscaleTelco     ClusterProfile = "metal-perfscale-telco"
 	ClusterProfileNutanix                 ClusterProfile = "nutanix"
@@ -343,6 +344,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileMetalPerfscaleBMCPT,
 		ClusterProfileMetalPerfscaleJetlag,
 		ClusterProfileMetalPerfscaleOSP,
+		ClusterProfileMetalPerfscaleOspNfv,
 		ClusterProfileMetalPerfscaleSelfSched,
 		ClusterProfileMetalPerfscaleTelco,
 		ClusterProfileNutanix,
@@ -621,6 +623,8 @@ func (p ClusterProfile) ClusterType() string {
 		return "metal-perfscale-jetlag"
 	case ClusterProfileMetalPerfscaleOSP:
 		return "metal-perfscale-osp"
+	case ClusterProfileMetalPerfscaleOspNfv:
+		return "metal-perfscale-osp-nfv"
 	case ClusterProfileMetalPerfscaleSelfSched:
 		return "metal-perfscale-selfsched"
 	case ClusterProfileMetalPerfscaleTelco:
@@ -957,6 +961,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "metal-perfscale-jetlag-quota-slice"
 	case ClusterProfileMetalPerfscaleOSP:
 		return "metal-perfscale-osp-quota-slice"
+	case ClusterProfileMetalPerfscaleOspNfv:
+		return "metal-perfscale-osp-nfv-quota-slice"
 	case ClusterProfileMetalPerfscaleSelfSched:
 		return "metal-perfscale-selfsched-quota-slice"
 	case ClusterProfileMetalPerfscaleTelco:


### PR DESCRIPTION
new cluster profile added for Openstack NFV jobs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds support for a new `metal-perfscale-osp-nfv` cluster profile to the CI infrastructure, enabling OpenStack NFV (Network Function Virtualization) jobs to run on dedicated performance-scale testing hardware.

## Changes

Modified `pkg/api/clusterprofile.go` to register the new cluster profile:
- Added the `ClusterProfileMetalPerfscaleOspNfv` constant with value `"metal-perfscale-osp-nfv"`
- Integrated it into the cluster profile registry so it's recognized as a valid profile option
- Mapped it to the cluster type identifier `"metal-perfscale-osp-nfv"`
- Configured the corresponding lease type as `"metal-perfscale-osp-nfv-quota-slice"` for resource quota management

## Impact

CI job configurations can now specify `cluster_profile: metal-perfscale-osp-nfv` to run tests on OpenStack NFV-based metal infrastructure. The ci-operator will correctly route these jobs to use the appropriate cloud environment and manage resource quotas through the quota-slice lease system, following the same pattern as existing metal-perfscale profiles (CPT, Jetlag, OSP, Telco, etc.).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->