### PR TITLE
qci-appci: Add multi cluster token service

### DIFF
--- a/cmd/qci-appci/main.go
+++ b/cmd/qci-appci/main.go
@@ -22,7 +22,9 @@ import (
 
 	authenticationv1 "k8s.io/api/authentication/v1"
 	authorizationv1 "k8s.io/api/authorization/v1"
+	aggerrs "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/clientcmd"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/prow/pkg/config/secret"
 	"sigs.k8s.io/prow/pkg/interrupts"
@@ -32,18 +34,19 @@ import (
 )
 
 type options struct {
-	listenAddr        string
-	exposedHost       string
-	gracePeriod       time.Duration
-	robotUsernameFile string
-	robotPasswordFile string
-	tokenSecretFile   string
-	tokenValidityRaw  string
-	tokenValidity     time.Duration
-	tlsCertFile       string
-	tlsKeyFile        string
-	intervalRaw       string
-	interval          time.Duration
+	listenAddr             string
+	exposedHost            string
+	gracePeriod            time.Duration
+	robotUsernameFile      string
+	robotPasswordFile      string
+	tokenSecretFile        string
+	tokenValidityRaw       string
+	tokenValidity          time.Duration
+	tlsCertFile            string
+	tlsKeyFile             string
+	intervalRaw            string
+	interval               time.Duration
+	supplementalKubeconfig string
 }
 
 func gatherOptions() (*options, error) {
@@ -59,6 +62,7 @@ func gatherOptions() (*options, error) {
 	fs.StringVar(&o.tlsCertFile, "tls-cert-file", "", "Path to a tls cert file. Must not be empty.")
 	fs.StringVar(&o.tlsKeyFile, "tls-key-file", "", "Path to a tls key file. Must not be empty.")
 	fs.StringVar(&o.intervalRaw, "interval", "30s", "Parseable duration string that specifies the period to refresh robot's quay.io bearer token")
+	fs.StringVar(&o.supplementalKubeconfig, "supplemental-kubeconfig", "", "Supplemental cluster used to check tokens validity")
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		return nil, fmt.Errorf("failed to parse flags: %w", err)
 	}
@@ -132,7 +136,24 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to create proxy handler")
 	}
-	handler := getRouter(proxyHandler, opts.exposedHost, newTokenService(ctx, ocClient), appTokenService, secret.GetSecret, opts.robotUsernameFile, opts.robotPasswordFile)
+
+	var tokenService ClusterTokenService = newTokenService(ctx, inClusterConfig.Host, ocClient)
+	if opts.supplementalKubeconfig != "" {
+		config, err := clientcmd.BuildConfigFromFlags("", opts.supplementalKubeconfig)
+		if err != nil {
+			logrus.WithError(err).Fatal("Failed to read supplemental kubeconfig")
+		}
+
+		supplementalOCClient, err := ctrlruntimeclient.New(config, ctrlruntimeclient.Options{})
+		if err != nil {
+			logrus.WithError(err).Fatal("Failed to create supplemental oc client")
+		}
+
+		supplementalTokenService := newTokenService(ctx, config.Host, supplementalOCClient)
+		tokenService = newMultiClusterTokenService(tokenService, supplementalTokenService)
+	}
+
+	handler := getRouter(proxyHandler, opts.exposedHost, tokenService, appTokenService, secret.GetSecret, opts.robotUsernameFile, opts.robotPasswordFile)
 	interrupts.ListenAndServeTLS(&http.Server{Addr: opts.listenAddr, Handler: handler}, opts.tlsCertFile, opts.tlsKeyFile, opts.gracePeriod)
 	interrupts.WaitForGracefulShutdown()
 }
@@ -374,19 +395,62 @@ type QuayService interface {
 
 type ClusterTokenService interface {
 	Validate(token string) (bool, error)
+	Host() string
 }
 
-type SimpleClusterTokenService struct {
+func newMultiClusterTokenService(clusterTokenServices ...ClusterTokenService) *multiClusterTokenService {
+	return &multiClusterTokenService{
+		clusterTokenServices: clusterTokenServices,
+		logger:               logrus.WithField("subComponent", "newMultiClusterTokenService"),
+	}
+}
+
+type multiClusterTokenService struct {
+	logger               *logrus.Entry
+	clusterTokenServices []ClusterTokenService
+}
+
+func (m *multiClusterTokenService) Validate(token string) (bool, error) {
+	errs := make([]error, 0)
+
+	for _, cts := range m.clusterTokenServices {
+		isValid, err := cts.Validate(token)
+
+		if err != nil {
+			m.logger.WithField("host", cts.Host()).WithError(err).Error("Failed to validate token")
+			errs = append(errs, err)
+			continue
+		}
+
+		if isValid {
+			return true, nil
+		}
+	}
+
+	return false, aggerrs.NewAggregate(errs)
+}
+
+func (m *multiClusterTokenService) Host() string {
+	return ""
+}
+
+type simpleClusterTokenService struct {
 	ctx    context.Context
 	client ctrlruntimeclient.Client
+	host   string
 	logger *logrus.Entry
 }
 
-func newTokenService(ctx context.Context, client ctrlruntimeclient.Client) ClusterTokenService {
-	return &SimpleClusterTokenService{ctx: ctx, client: client, logger: logrus.WithField("subComponent", "simpleClusterTokenService")}
+func newTokenService(ctx context.Context, host string, client ctrlruntimeclient.Client) *simpleClusterTokenService {
+	return &simpleClusterTokenService{
+		ctx:    ctx,
+		client: client,
+		host:   host,
+		logger: logrus.WithField("subComponent", "simpleClusterTokenService").WithField("host", host),
+	}
 }
 
-func (s *SimpleClusterTokenService) Validate(token string) (bool, error) {
+func (s *simpleClusterTokenService) Validate(token string) (bool, error) {
 	t := time.Now()
 	var username string
 	var ret bool
@@ -434,6 +498,10 @@ func (s *SimpleClusterTokenService) Validate(token string) (bool, error) {
 	}
 	ret = sar.Status.Allowed
 	return ret, nil
+}
+
+func (s *simpleClusterTokenService) Host() string {
+	return s.host
 }
 
 type appHandler struct {

--- a/cmd/qci-appci/main_test.go
+++ b/cmd/qci-appci/main_test.go
@@ -16,13 +16,32 @@ import (
 )
 
 type fakeClusterTokenService struct {
+	validTokenPattern string
+	errTokenPattern   string
+	host              string
 }
 
 func (s *fakeClusterTokenService) Validate(token string) (bool, error) {
-	if token == "w" {
+	switch token {
+	case s.errTokenPattern:
+		return false, fmt.Errorf("host %s fails to validate %s", s.host, token)
+	case s.validTokenPattern:
+		return true, nil
+	default:
 		return false, nil
 	}
-	return true, nil
+}
+
+func (s *fakeClusterTokenService) Host() string {
+	return ""
+}
+
+func newFakeClusterTokenService(validTokenPattern, errTokenPattern, host string) *fakeClusterTokenService {
+	return &fakeClusterTokenService{
+		validTokenPattern: validTokenPattern,
+		errTokenPattern:   errTokenPattern,
+		host:              host,
+	}
 }
 
 type fakeQuayService struct {
@@ -249,7 +268,7 @@ func TestGetRouter(t *testing.T) {
 			for k, v := range tc.requestHeaders {
 				req.Header.Set(k, v)
 			}
-			handler := getRouter(fakeProxy, "host:12321", &fakeClusterTokenService{}, &fakeAppTokenService{}, func(s string) []byte { return []byte(s) }, "u", "p")
+			handler := getRouter(fakeProxy, "host:12321", newFakeClusterTokenService("p", "e", ""), &fakeAppTokenService{}, func(s string) []byte { return []byte(s) }, "u", "p")
 			rr := httptest.NewRecorder()
 			handler.ServeHTTP(rr, req)
 
@@ -310,6 +329,74 @@ func TestJWTTokenService(t *testing.T) {
 				if diff := cmp.Diff(actualValidateErr, actualValidateErr, testhelper.EquateErrorMessage); diff != "" {
 					t.Errorf("%s actualValidateErr differs from expected:\n%s", tc.name, diff)
 				}
+			}
+		})
+	}
+}
+
+func TestMultiClusterTokenService(t *testing.T) {
+	s := func(cts ...ClusterTokenService) []ClusterTokenService {
+		return cts
+	}
+
+	for _, tc := range []struct {
+		name                 string
+		token                string
+		clusterTokenServices []ClusterTokenService
+		wantIsValid          bool
+		wantErr              string
+	}{
+		{
+			name:                 "single: valid token",
+			token:                "v",
+			clusterTokenServices: s(newFakeClusterTokenService("v", "e", "appci")),
+			wantIsValid:          true,
+		},
+		{
+			name:                 "multi: first service validates token",
+			token:                "v",
+			clusterTokenServices: s(newFakeClusterTokenService("v", "e", "appci"), newFakeClusterTokenService("w", "e", "coreci")),
+			wantIsValid:          true,
+		},
+		{
+			name:                 "multi: second service validates token",
+			token:                "v",
+			clusterTokenServices: s(newFakeClusterTokenService("w", "e", "appci"), newFakeClusterTokenService("v", "e", "coreci")),
+			wantIsValid:          true,
+		},
+		{
+			name:                 "multi: invalid token",
+			token:                "w",
+			clusterTokenServices: s(newFakeClusterTokenService("v", "e", "appci"), newFakeClusterTokenService("v", "e", "coreci")),
+		},
+		{
+			name:                 "multi: first service in error but token is valid",
+			token:                "e",
+			clusterTokenServices: s(newFakeClusterTokenService("v", "e", "appci"), newFakeClusterTokenService("e", "E", "coreci")),
+			wantIsValid:          true,
+		},
+		{
+			name:                 "multi: all services in error",
+			token:                "e",
+			clusterTokenServices: s(newFakeClusterTokenService("v", "e", "appci"), newFakeClusterTokenService("v", "e", "coreci")),
+			wantErr:              "[host appci fails to validate e, host coreci fails to validate e]",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			multi := newMultiClusterTokenService(tc.clusterTokenServices...)
+			gotIsValid, err := multi.Validate(tc.token)
+
+			gotErr := ""
+			if err != nil {
+				gotErr = err.Error()
+			}
+
+			if tc.wantErr != gotErr {
+				t.Errorf("want error %s but got %s", tc.wantErr, gotErr)
+			}
+
+			if tc.wantIsValid != gotIsValid {
+				t.Errorf("want valid %t but got %t", tc.wantIsValid, gotIsValid)
 			}
 		})
 	}


### PR DESCRIPTION
Allow qci-appci to authenticate SA coming from a supplemental cluster other than the one it is deployed to.
This should ease the app.ci to core-ci transition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Multi-Cluster Token Validation Support

The qci-appci reverse proxy now supports validating service account tokens against multiple Kubernetes clusters. Previously, it could only authenticate tokens from the cluster it was deployed on. This change enables it to accept tokens from a supplemental cluster, easing the transition of CI infrastructure from app.ci to core-ci.

## Changes

**Token Service Architecture**
- Refactored token validation into a `ClusterTokenService` interface with `Validate(token string) (bool, error)` and `Host() string` methods
- Introduced a new `multiClusterTokenService` that attempts token validation across multiple clusters in sequence
- The per-cluster token service (`simpleClusterTokenService`) now tracks which cluster it's validating against via the `Host()` method

**Configuration**
- Added `--supplemental-kubeconfig` flag to optionally specify a secondary cluster's kubeconfig
- When provided, qci-appci creates token validators for both the in-cluster (primary) and supplemental clusters
- Token validation succeeds if any cluster validates the token; if all fail, an aggregate error containing validation failures from all clusters is returned

**Behavior Impact**
- Service accounts from the supplemental cluster can now authenticate against qci-appci without requiring a separate token service instance
- CI operators can gradually migrate workloads between clusters during infrastructure transitions without breaking authentication
- Error diagnostics now include per-cluster validation failures, making it easier to troubleshoot multi-cluster authentication issues

The changes maintain backward compatibility—when no supplemental kubeconfig is provided, qci-appci operates as a single-cluster validator as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->