### PR TITLE
pod-scaler: add authoritative dry-run flags

### DIFF
--- a/cmd/pod-scaler/admission.go
+++ b/cmd/pod-scaler/admission.go
@@ -37,9 +37,15 @@ import (
 	"github.com/openshift/ci-tools/pkg/steps"
 )
 
-func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Interface, kubeClient kubernetes.Interface, loaders map[string][]*cacheReloader, mutateResourceLimits bool, cpuCap int64, memoryCap string, cpuPriorityScheduling int64, percentageMeasured float64, measuredPodCPUIncrease float64, systemReservedCPU int64, authoritativeCPU, authoritativeMemory bool, reporter results.PodScalerReporter) {
+func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Interface, kubeClient kubernetes.Interface, loaders map[string][]*cacheReloader, mutateResourceLimits bool, cpuCap int64, memoryCap string, cpuPriorityScheduling int64, percentageMeasured float64, measuredPodCPUIncrease float64, systemReservedCPU int64, authoritativeCPU, authoritativeMemory, authoritativeCPUDryRun, authoritativeMemoryDryRun bool, reporter results.PodScalerReporter) {
 	logger := logrus.WithField("component", "pod-scaler admission")
 	logger.Infof("Initializing admission webhook server with %d loaders.", len(loaders))
+	if authoritativeCPUDryRun || authoritativeMemoryDryRun {
+		logger.WithFields(logrus.Fields{
+			"authoritative_cpu_dry_run":    authoritativeCPUDryRun,
+			"authoritative_memory_dry_run": authoritativeMemoryDryRun,
+		}).Info("authoritative decrease dry-run enabled")
+	}
 	health := pjutil.NewHealthOnPort(healthPort)
 	resources := newResourceServer(loaders, health)
 	decoder := admission.NewDecoder(scheme.Scheme)
@@ -51,7 +57,7 @@ func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Int
 		Port:    port,
 		CertDir: certDir,
 	})
-	server.Register("/pods", &webhook.Admission{Handler: &podMutator{logger: logger, client: client, decoder: decoder, resources: resources, mutateResourceLimits: mutateResourceLimits, cpuCap: cpuCap, memoryCap: memoryCap, cpuPriorityScheduling: cpuPriorityScheduling, percentageMeasured: percentageMeasured, measuredPodCPUIncrease: measuredPodCPUIncrease, nodeCache: nodeCache, authoritativeCPU: authoritativeCPU, authoritativeMemory: authoritativeMemory, reporter: reporter}})
+	server.Register("/pods", &webhook.Admission{Handler: &podMutator{logger: logger, client: client, decoder: decoder, resources: resources, mutateResourceLimits: mutateResourceLimits, cpuCap: cpuCap, memoryCap: memoryCap, cpuPriorityScheduling: cpuPriorityScheduling, percentageMeasured: percentageMeasured, measuredPodCPUIncrease: measuredPodCPUIncrease, nodeCache: nodeCache, authoritativeCPU: authoritativeCPU, authoritativeMemory: authoritativeMemory, authoritativeCPUDryRun: authoritativeCPUDryRun, authoritativeMemoryDryRun: authoritativeMemoryDryRun, reporter: reporter}})
 	logger.Info("Serving admission webhooks.")
 	if err := server.Start(interrupts.Context()); err != nil {
 		logrus.WithError(err).Fatal("Failed to serve webhooks.")
@@ -59,20 +65,22 @@ func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Int
 }
 
 type podMutator struct {
-	logger                 *logrus.Entry
-	client                 buildclientv1.BuildV1Interface
-	resources              *resourceServer
-	mutateResourceLimits   bool
-	decoder                admission.Decoder
-	cpuCap                 int64
-	memoryCap              string
-	cpuPriorityScheduling  int64
-	percentageMeasured     float64
-	measuredPodCPUIncrease float64
-	nodeCache              *nodeAllocatableCache
-	authoritativeCPU       bool
-	authoritativeMemory    bool
-	reporter               results.PodScalerReporter
+	logger                    *logrus.Entry
+	client                    buildclientv1.BuildV1Interface
+	resources                 *resourceServer
+	mutateResourceLimits      bool
+	decoder                   admission.Decoder
+	cpuCap                    int64
+	memoryCap                 string
+	cpuPriorityScheduling     int64
+	percentageMeasured        float64
+	measuredPodCPUIncrease    float64
+	nodeCache                 *nodeAllocatableCache
+	authoritativeCPU          bool
+	authoritativeMemory       bool
+	authoritativeCPUDryRun    bool
+	authoritativeMemoryDryRun bool
+	reporter                  results.PodScalerReporter
 }
 
 func (m *podMutator) Handle(ctx context.Context, req admission.Request) admission.Response {
@@ -121,7 +129,7 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 		m.setMeasuredLabel(pod, false, logger)
 	}
 
-	mutatePodResources(pod, m.resources, m.mutateResourceLimits, m.cpuCap, m.memoryCap, isMeasured, m.nodeCache, m.measuredPodCPUIncrease, m.authoritativeCPU, m.authoritativeMemory, m.reporter, logger)
+	mutatePodResources(pod, m.resources, m.mutateResourceLimits, m.cpuCap, m.memoryCap, isMeasured, m.nodeCache, m.measuredPodCPUIncrease, m.authoritativeCPU, m.authoritativeMemory, m.authoritativeCPUDryRun, m.authoritativeMemoryDryRun, m.reporter, logger)
 	m.addPriorityClass(pod)
 
 	marshaledPod, err := json.Marshal(pod)
@@ -223,7 +231,7 @@ func mutatePodLabels(pod *corev1.Pod, build *buildv1.Build) {
 const authoritativeMaxReductionPercent = 0.25
 
 // useOursIfLarger updates fields in theirs when ours are larger, or lowers them when authoritative mode allows.
-func useOursIfLarger(allOfOurs, allOfTheirs *corev1.ResourceRequirements, workloadName, workloadType string, isMeasured bool, workloadClass string, authoritativeCPU, authoritativeMemory bool, reporter results.PodScalerReporter, logger *logrus.Entry) {
+func useOursIfLarger(allOfOurs, allOfTheirs *corev1.ResourceRequirements, workloadName, workloadType string, isMeasured bool, workloadClass string, authoritativeCPU, authoritativeMemory, authoritativeCPUDryRun, authoritativeMemoryDryRun bool, reporter results.PodScalerReporter, logger *logrus.Entry) {
 	for _, item := range []*corev1.ResourceRequirements{allOfOurs, allOfTheirs} {
 		if item.Requests == nil {
 			item.Requests = corev1.ResourceList{}
@@ -271,14 +279,25 @@ func useOursIfLarger(allOfOurs, allOfTheirs *corev1.ResourceRequirements, worklo
 					continue
 				}
 				authoritative := authoritativeMemory
+				dryRun := authoritativeMemoryDryRun
 				if field == corev1.ResourceCPU {
 					authoritative = authoritativeCPU
+					dryRun = authoritativeCPUDryRun
 				}
-				if !authoritative {
+				if !authoritative && !dryRun {
 					continue
 				}
 				theirValue := their.AsApproximateFloat64()
 				if theirValue == 0 {
+					if dryRun {
+						fieldLogger.WithFields(logrus.Fields{
+							"event":         "authoritative_decrease_dry_run",
+							"workloadClass": workloadClass,
+							"would_set":     our.String(),
+							"authoritative": authoritative,
+						}).Info("authoritative decrease dry-run")
+						continue
+					}
 					(*pair.theirs)[field] = our
 					continue
 				}
@@ -286,8 +305,21 @@ func useOursIfLarger(allOfOurs, allOfTheirs *corev1.ResourceRequirements, worklo
 				if 1.0-(ourValue/theirValue) < 0.05 {
 					continue
 				}
+				capped := false
 				if 1.0-(ourValue/theirValue) > authoritativeMaxReductionPercent {
 					our.Set(int64(theirValue * (1.0 - authoritativeMaxReductionPercent)))
+					capped = true
+				}
+				if dryRun {
+					fieldLogger.WithFields(logrus.Fields{
+						"event":         "authoritative_decrease_dry_run",
+						"workloadClass": workloadClass,
+						"would_set":     our.String(),
+						"authoritative": authoritative,
+						"reduction_pct": (1.0 - our.AsApproximateFloat64()/theirValue) * 100,
+						"capped_25pct":  capped,
+					}).Info("authoritative decrease dry-run")
+					continue
 				}
 				(*pair.theirs)[field] = our
 			} else {
@@ -344,7 +376,7 @@ func preventUnschedulable(resources *corev1.ResourceRequirements, cpuCap int64, 
 	}
 }
 
-func mutatePodResources(pod *corev1.Pod, server *resourceServer, mutateResourceLimits bool, cpuCap int64, memoryCap string, isMeasured bool, nodeCache *nodeAllocatableCache, measuredPodCPUIncrease float64, authoritativeCPU, authoritativeMemory bool, reporter results.PodScalerReporter, logger *logrus.Entry) {
+func mutatePodResources(pod *corev1.Pod, server *resourceServer, mutateResourceLimits bool, cpuCap int64, memoryCap string, isMeasured bool, nodeCache *nodeAllocatableCache, measuredPodCPUIncrease float64, authoritativeCPU, authoritativeMemory, authoritativeCPUDryRun, authoritativeMemoryDryRun bool, reporter results.PodScalerReporter, logger *logrus.Entry) {
 	// Set measured and workload class in metadata
 	workloadClass := pod.Labels[ciWorkloadLabel]
 
@@ -398,7 +430,7 @@ func mutatePodResources(pod *corev1.Pod, server *resourceServer, mutateResourceL
 				logger.Debugf("recommendation exists for: %s (using max of measured and unmeasured)", containers[i].Name)
 				workloadType := determineWorkloadType(pod.Annotations, pod.Labels)
 				workloadName := determineWorkloadName(pod.Name, containers[i].Name, workloadType, pod.Labels)
-				useOursIfLarger(&resources, &containers[i].Resources, workloadName, workloadType, isMeasured, workloadClass, authoritativeCPU, authoritativeMemory, reporter, logger)
+				useOursIfLarger(&resources, &containers[i].Resources, workloadName, workloadType, isMeasured, workloadClass, authoritativeCPU, authoritativeMemory, authoritativeCPUDryRun, authoritativeMemoryDryRun, reporter, logger)
 				if mutateResourceLimits {
 					reconcileLimits(&containers[i].Resources)
 				}

--- a/cmd/pod-scaler/admission_test.go
+++ b/cmd/pod-scaler/admission_test.go
@@ -554,7 +554,7 @@ func TestMutatePodResources(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			original := testCase.pod.DeepCopy()
-			mutatePodResources(testCase.pod, testCase.server, testCase.mutateResourceLimits, 10, "20Gi", false, nil, 50.0, false, false, &defaultReporter, logrus.WithField("test", testCase.name))
+			mutatePodResources(testCase.pod, testCase.server, testCase.mutateResourceLimits, 10, "20Gi", false, nil, 50.0, false, false, false, false, &defaultReporter, logrus.WithField("test", testCase.name))
 			diff := cmp.Diff(original, testCase.pod)
 			// In some cases, cmp.Diff decides to use non-breaking spaces, and it's not
 			// particularly deterministic about this. We don't care.
@@ -729,7 +729,7 @@ func TestUseOursIfLarger(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			useOursIfLarger(&testCase.ours, &testCase.theirs, "test", "build", false, "", false, false, &defaultReporter, logrus.WithField("test", testCase.name))
+			useOursIfLarger(&testCase.ours, &testCase.theirs, "test", "build", false, "", false, false, false, false, &defaultReporter, logrus.WithField("test", testCase.name))
 			if diff := cmp.Diff(testCase.theirs, testCase.expected); diff != "" {
 				t.Errorf("%s: got incorrect resources after mutation: %v", testCase.name, diff)
 			}
@@ -814,11 +814,35 @@ func TestUseOursIfLarger_authoritative(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			useOursIfLarger(&tc.ours, &tc.theirs, "test", "build", tc.isMeasured, "", tc.authoritativeCPU, tc.authoritativeMemory, &defaultReporter, logrus.WithField("test", tc.name))
+			useOursIfLarger(&tc.ours, &tc.theirs, "test", "build", tc.isMeasured, "", tc.authoritativeCPU, tc.authoritativeMemory, false, false, &defaultReporter, logrus.WithField("test", tc.name))
 			if diff := cmp.Diff(tc.theirs, tc.expected); diff != "" {
 				t.Errorf("unexpected resources: %s", diff)
 			}
 		})
+	}
+}
+
+func TestUseOursIfLarger_authoritativeDryRun(t *testing.T) {
+	ours := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU: *resource.NewQuantity(10, resource.DecimalSI),
+		},
+	}
+	theirs := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU: *resource.NewQuantity(100, resource.DecimalSI),
+		},
+	}
+	expected := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU: *resource.NewQuantity(100, resource.DecimalSI),
+		},
+	}
+
+	useOursIfLarger(&ours, &theirs, "test", "build", false, "", true, false, true, false, &defaultReporter, logrus.WithField("test", t.Name()))
+	if diff := cmp.Diff(theirs, expected); diff != "" {
+		t.Errorf("dry-run should not mutate resources: %s", diff)
 	}
 }
 
@@ -899,7 +923,7 @@ func TestUseOursIsLarger_ReporterReports(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			useOursIfLarger(&tc.ours, &tc.theirs, "test", "build", false, "", false, false, &tc.reporter, logrus.WithField("test", tc.name))
+			useOursIfLarger(&tc.ours, &tc.theirs, "test", "build", false, "", false, false, false, false, &tc.reporter, logrus.WithField("test", tc.name))
 
 			if diff := cmp.Diff(tc.reporter.called, tc.expected); diff != "" {
 				t.Errorf("actual and expected reporter states don't match, : %v", diff)

--- a/cmd/pod-scaler/main.go
+++ b/cmd/pod-scaler/main.go
@@ -63,17 +63,19 @@ type consumerOptions struct {
 	port   int
 	uiPort int
 
-	dataDir                string
-	certDir                string
-	mutateResourceLimits   bool
-	cpuCap                 int64
-	memoryCap              string
-	cpuPriorityScheduling  int64
-	percentageMeasured     float64
-	measuredPodCPUIncrease float64
-	systemReservedCPU      int64
-	authoritativeCPU       bool
-	authoritativeMemory    bool
+	dataDir                   string
+	certDir                   string
+	mutateResourceLimits      bool
+	cpuCap                    int64
+	memoryCap                 string
+	cpuPriorityScheduling     int64
+	percentageMeasured        float64
+	measuredPodCPUIncrease    float64
+	systemReservedCPU         int64
+	authoritativeCPU          bool
+	authoritativeMemory       bool
+	authoritativeCPUDryRun    bool
+	authoritativeMemoryDryRun bool
 }
 
 func bindOptions(fs *flag.FlagSet) *options {
@@ -102,6 +104,8 @@ func bindOptions(fs *flag.FlagSet) *options {
 	fs.Int64Var(&o.systemReservedCPU, "system-reserved-cpu", 2, "CPU cores to reserve for system overhead when capping measured pod CPU.")
 	fs.BoolVar(&o.authoritativeCPU, "authoritative-cpu", false, "Allow admission to decrease CPU requests and limits based on measured usage.")
 	fs.BoolVar(&o.authoritativeMemory, "authoritative-memory", false, "Allow admission to decrease memory requests and limits based on measured usage.")
+	fs.BoolVar(&o.authoritativeCPUDryRun, "authoritative-cpu-dry-run", false, "Log CPU decreases that authoritative mode would apply without mutating pods.")
+	fs.BoolVar(&o.authoritativeMemoryDryRun, "authoritative-memory-dry-run", false, "Log memory decreases that authoritative mode would apply without mutating pods.")
 	o.resultsOptions.Bind(fs)
 	return &o
 }
@@ -291,7 +295,7 @@ func mainAdmission(opts *options, cache Cache) {
 		logrus.WithError(err).Fatal("Failed to create pod-scaler reporter.")
 	}
 
-	go admit(opts.port, opts.instrumentationOptions.HealthPort, opts.certDir, client, kubeClient, loaders(cache), opts.mutateResourceLimits, opts.cpuCap, opts.memoryCap, opts.cpuPriorityScheduling, opts.percentageMeasured, opts.measuredPodCPUIncrease, opts.systemReservedCPU, opts.authoritativeCPU, opts.authoritativeMemory, reporter)
+	go admit(opts.port, opts.instrumentationOptions.HealthPort, opts.certDir, client, kubeClient, loaders(cache), opts.mutateResourceLimits, opts.cpuCap, opts.memoryCap, opts.cpuPriorityScheduling, opts.percentageMeasured, opts.measuredPodCPUIncrease, opts.systemReservedCPU, opts.authoritativeCPU, opts.authoritativeMemory, opts.authoritativeCPUDryRun, opts.authoritativeMemoryDryRun, reporter)
 }
 
 func loaders(cache Cache) map[string][]*cacheReloader {

--- a/test/e2e/pod-scaler/e2e_test.go
+++ b/test/e2e/pod-scaler/e2e_test.go
@@ -20,9 +20,12 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/openhistogram/circonusllhist"
+	"github.com/prometheus/common/model"
+	jsonpatch "gopkg.in/evanphx/json-patch.v5"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/prow/pkg/interrupts"
@@ -346,5 +349,187 @@ func TestAdmission(t *testing.T) {
 			}
 			testhelper.CompareWithFixture(t, review.Response.Patch, testhelper.WithSuffix("-patch"))
 		})
+	}
+}
+
+func TestAdmissionAuthoritativeDryRun(t *testing.T) {
+	t.Parallel()
+	T := testhelper.NewT(interrupts.Context(), t)
+	prometheusAddr, _ := prometheus.Initialize(T, T.TempDir(), rand.New(rand.NewSource(4641280330504625122)), false)
+
+	kubeconfigFile := kubernetes.Fake(T, T.TempDir(), kubernetes.Prometheus(prometheusAddr), kubernetes.Builds(map[string]map[string]map[string]string{
+		"namespace": {
+			"withoutlabels": map[string]string{},
+		},
+	}))
+	dataDir := T.TempDir()
+	run.Producer(T, dataDir, kubeconfigFile, 0*time.Second)
+
+	podLabels := map[string]string{
+		"created-by-ci":                    "true",
+		"ci.openshift.io/metadata.org":     "org",
+		"ci.openshift.io/metadata.repo":    "repo",
+		"ci.openshift.io/metadata.branch":  "branch",
+		"ci.openshift.io/metadata.variant": "variant",
+		"ci.openshift.io/metadata.target":  "target",
+		"ci.openshift.io/metadata.step":    "step",
+	}
+	// Producer fixture histograms store counter-scale values; replace with low CPU rates so
+	// admission can exercise authoritative decrease (see TestAdmission for unmodified increase path).
+	seedLowCPURecommendationCache(T, dataDir, podscaler.MetadataFor(podLabels, "pod", "container"), 7)
+
+	// Same Prometheus fixture as TestAdmission "pod for which we have data" (~10 CPU recommendation).
+	const configuredMilli = 100_000                     // 100 CPU
+	wantMilli := int64(float64(configuredMilli) * 0.75) // 25% authoritative cap
+	cpuCap := int64(200)
+
+	highCPU := *resource.NewMilliQuantity(configuredMilli, resource.DecimalSI)
+	wantCPU := *resource.NewMilliQuantity(wantMilli, resource.DecimalSI)
+	basePod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "pod",
+			Labels: podLabels,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: "container",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU: highCPU,
+					},
+				},
+			}},
+		},
+	}
+
+	t.Run("dry-run does not decrease CPU", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(interrupts.Context())
+		defer cancel()
+		admissionHost, transport := run.Admission(T, dataDir, kubeconfigFile, ctx, false,
+			"--authoritative-cpu=true",
+			"--authoritative-cpu-dry-run=true",
+			fmt.Sprintf("--cpu-cap=%d", cpuCap),
+		)
+		got := cpuRequestAfterAdmission(t, &basePod, admissionHost, transport)
+		if got.Cmp(highCPU) != 0 {
+			t.Fatalf("dry-run changed CPU request from %s to %s", highCPU.String(), got.String())
+		}
+	})
+
+	t.Run("authoritative decreases CPU", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(interrupts.Context())
+		defer cancel()
+		admissionHost, transport := run.Admission(T, dataDir, kubeconfigFile, ctx, false, "--authoritative-cpu=true", fmt.Sprintf("--cpu-cap=%d", cpuCap))
+		got := cpuRequestAfterAdmission(t, &basePod, admissionHost, transport)
+		if got.Cmp(wantCPU) != 0 {
+			t.Fatalf("authoritative CPU request = %s, want %s", got.String(), wantCPU.String())
+		}
+	})
+}
+
+func cpuRequestAfterAdmission(t *testing.T, pod *corev1.Pod, admissionHost string, transport *http.Transport) resource.Quantity {
+	t.Helper()
+	pod = pod.DeepCopy()
+	pod.TypeMeta = metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"}
+	rawPod, err := json.Marshal(pod)
+	if err != nil {
+		t.Fatalf("marshal pod: %v", err)
+	}
+	request := admissionv1.AdmissionRequest{
+		UID:      "705ab4f5-6393-11e8-b7cc-42010a800003",
+		Kind:     metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+		Resource: metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+		Object:   runtime.RawExtension{Raw: rawPod},
+	}
+	rawReview, err := json.Marshal(admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{Kind: "AdmissionReview", APIVersion: "admission.k8s.io/v1"},
+		Request:  &request,
+	})
+	if err != nil {
+		t.Fatalf("marshal review: %v", err)
+	}
+	client := http.Client{Transport: transport}
+	response, err := client.Post(admissionHost+"/pods", "application/json", bytes.NewBuffer(rawReview))
+	if err != nil {
+		t.Fatalf("post admission: %v", err)
+	}
+	defer response.Body.Close()
+	rawResponse, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	var review admissionv1.AdmissionReview
+	if err := json.Unmarshal(rawResponse, &review); err != nil {
+		t.Fatalf("unmarshal review: %v", err)
+	}
+	if review.Response == nil || !review.Response.Allowed {
+		t.Fatalf("admission not allowed: %+v", review.Response)
+	}
+	patched, err := applyJSONPatchToPod(pod, review.Response.Patch)
+	if err != nil {
+		t.Fatalf("apply patch: %v", err)
+	}
+	cpu := patched.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+	if cpu.IsZero() {
+		t.Fatal("no CPU request on patched pod")
+	}
+	return cpu
+}
+
+func applyJSONPatchToPod(pod *corev1.Pod, patch []byte) (*corev1.Pod, error) {
+	raw, err := json.Marshal(pod)
+	if err != nil {
+		return nil, err
+	}
+	if len(patch) == 0 {
+		out := pod.DeepCopy()
+		return out, nil
+	}
+	decoded, err := jsonpatch.DecodePatch(patch)
+	if err != nil {
+		return nil, err
+	}
+	patched, err := decoded.Apply(raw)
+	if err != nil {
+		return nil, err
+	}
+	var out corev1.Pod
+	if err := json.Unmarshal(patched, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func seedLowCPURecommendationCache(t testhelper.TestingTInterface, dataDir string, meta podscaler.FullMetadata, coresAtQuantile float64) {
+	t.Helper()
+	hist := circonusllhist.New(circonusllhist.NoLookup())
+	for i := 0; i < 500; i++ {
+		if err := hist.RecordValue(coresAtQuantile); err != nil {
+			t.Fatalf("record histogram value: %v", err)
+		}
+	}
+	wrapped := circonusllhist.NewHistogramWithoutLookups(hist)
+	fp := model.Fingerprint(0xcafe)
+	for _, prefix := range []string{"steps", "pods", "prowjobs"} {
+		path := filepath.Join(dataDir, prefix, "container_cpu_usage_seconds_total.json")
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s CPU cache: %v", prefix, err)
+		}
+		var cache podscaler.CachedQuery
+		if err := json.Unmarshal(raw, &cache); err != nil {
+			t.Fatalf("unmarshal %s CPU cache: %v", prefix, err)
+		}
+		cache.Data = map[model.Fingerprint]*circonusllhist.HistogramWithoutLookups{fp: wrapped}
+		cache.DataByMetaData = map[podscaler.FullMetadata][]podscaler.FingerprintTime{
+			meta: {{Fingerprint: fp, Added: time.Now()}},
+		}
+		encoded, err := json.Marshal(&cache)
+		if err != nil {
+			t.Fatalf("marshal %s CPU cache: %v", prefix, err)
+		}
+		if err := os.WriteFile(path, encoded, 0o644); err != nil {
+			t.Fatalf("write %s CPU cache: %v", prefix, err)
+		}
 	}
 }

--- a/test/e2e/pod-scaler/run/consumer.go
+++ b/test/e2e/pod-scaler/run/consumer.go
@@ -20,8 +20,9 @@ import (
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
-// Admission sets up the pod-scaler admission server and returns a transport for talking to it
-func Admission(t testhelper.TestingTInterface, dataDir, kubeconfig string, parent context.Context, stream bool) (string, *http.Transport) {
+// Admission sets up the pod-scaler admission server and returns a transport for talking to it.
+// extraFlags are appended to the pod-scaler admission invocation (e.g. authoritative dry-run flags).
+func Admission(t testhelper.TestingTInterface, dataDir, kubeconfig string, parent context.Context, stream bool, extraFlags ...string) (string, *http.Transport) {
 	authDir := t.TempDir()
 	caCertFile := path.Join(authDir, "ca.crt")
 	caKeyFile := path.Join(authDir, "ca.key")
@@ -63,6 +64,7 @@ func Admission(t testhelper.TestingTInterface, dataDir, kubeconfig string, paren
 		"--metrics-port=9092",
 		"--report-credentials-file=" + credFile,
 	}
+	podScalerFlags = append(podScalerFlags, extraFlags...)
 	podScaler := testhelper.NewAccessory("pod-scaler", podScalerFlags, func(port, healthPort string) []string {
 		t.Logf("pod-scaler admission starting on port %s", port)
 		return []string{"--port", port, "--health-port", healthPort}


### PR DESCRIPTION
https://redhat-internal.slack.com/archives/GB7NB0CUC/p1779797039741619 
/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Pod-scaler: Add authoritative dry-run flags

This PR adds per-resource "authoritative dry-run" flags to the pod-scaler admission webhook so operators can see what authoritative decreases would do for CPU and memory without mutating pods.

### What changed (practical terms)
- New CLI flags:
  - --authoritative-cpu-dry-run — log CPU decreases that authoritative mode would apply but do not mutate pods
  - --authoritative-memory-dry-run — log memory decreases that authoritative mode would apply but do not mutate pods
- The admission server accepts and forwards these flags to the pod mutator so the webhook can operate in a non-mutating, observability-only mode for each resource independently.
- Authoritative decrease logic:
  - Still computes the same decreases as authoritative apply mode (including the existing small-reduction tolerance and the 25% max reduction cap).
  - When a resource's dry-run flag is enabled, the code logs the "would-be" authoritative_decrease and intentionally skips applying the update to the pod.
  - Dry-run logging can be enabled independently of the authoritative-apply flag; enabling dry-run will produce non-mutating logs of the would-be decrease even if authoritative apply is not enabled.
- Wiring and CLI:
  - consumer options and flag bindings expose the new flags and pass them through the admission startup path into the podMutator and mutation functions.
- Tests and e2e:
  - Unit tests updated to the new function signatures and a unit test (TestUseOursIfLarger_authoritativeDryRun) verifies dry-run produces the expected would-be result without mutating "theirs".
  - An e2e test (TestAdmissionAuthoritativeDryRun) seeds recommendation data, calls the admission endpoint with and without authoritative CPU dry-run, applies returned JSON patches, and asserts that dry-run leaves pod resources unchanged whereas authoritative apply reduces them according to the cap.
  - The e2e test helper that starts the pod-scaler admission accessory gained an extraFlags parameter so tests can pass the new flags into the running pod-scaler.

### Component affected
- cmd/pod-scaler (admission webhook consumer) — admission-time behavior for pod resource requests/limits.
- Tests: unit tests in cmd/pod-scaler and e2e tests under test/e2e/pod-scaler.

### Practical impact for CI operators
- Operators can preview and audit the exact CPU and/or memory reductions the pod-scaler would apply without changing pods, making rollouts of authoritative decreases safer.
- Per-resource dry-run gives fine-grained control (CPU-only, memory-only, or both) for validation and gradual rollout across CI fleets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->