### PR TITLE
api: register aws-rhdh-disconnected cluster profile

### DIFF
--- a/pkg/api/clusterprofile.go
+++ b/pkg/api/clusterprofile.go
@@ -51,6 +51,7 @@ const (
 	ClusterProfileAWSKonfluxQE            ClusterProfile = "aws-konflux-qe"
 	ClusterProfileAWSRHTAPPerformance     ClusterProfile = "aws-rhtap-performance"
 	ClusterProfileAWSRHDHPerf             ClusterProfile = "aws-rhdh-performance"
+	ClusterProfileAWSRHDHDisconnected     ClusterProfile = "aws-rhdh-disconnected"
 	ClusterProfileAWSServerless           ClusterProfile = "aws-serverless"
 	ClusterProfileAWSTelco                ClusterProfile = "aws-telco"
 	ClusterProfileAWSOpendatahub          ClusterProfile = "aws-opendatahub"
@@ -263,6 +264,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileAWSKonfluxQE,
 		ClusterProfileAWSRHTAPPerformance,
 		ClusterProfileAWSRHDHPerf,
+		ClusterProfileAWSRHDHDisconnected,
 		ClusterProfileAWSServerless,
 		ClusterProfileAWSStackrox,
 		ClusterProfileAWSTelco,
@@ -469,6 +471,7 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileAWSKonfluxQE,
 		ClusterProfileAWSRHTAPPerformance,
 		ClusterProfileAWSRHDHPerf,
+		ClusterProfileAWSRHDHDisconnected,
 		ClusterProfileAWSSustAutoRel412,
 		ClusterProfileAWSKubeVirt,
 		ClusterProfileAWSOVNPerfScale,
@@ -806,6 +809,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "aws-rhtap-performance-quota-slice"
 	case ClusterProfileAWSRHDHPerf:
 		return "aws-rhdh-performance-quota-slice"
+	case ClusterProfileAWSRHDHDisconnected:
+		return "aws-rhdh-disconnected-quota-slice"
 	case ClusterProfileAWSServerless:
 		return "aws-serverless-quota-slice"
 	case ClusterProfileAWSStackrox:


### PR DESCRIPTION
Add a dedicated AWS cluster profile for RHDH disconnected CI jobs.

This enables the RHDH team to use their own AWS account for disconnected (air-gapped) E2E tests.

Changes:
- New constant: `ClusterProfileAWSRHDHDisconnected` (`"aws-rhdh-disconnected"`)
- Cluster type: `aws` (reuses existing AWS type)
- Lease type: `aws-rhdh-disconnected-quota-slice`
- Region: `us-east-2`

Companion PR for `openshift/release` will add the Boskos quota slice configuration, secret bootstrap entry, and update RHDH CI jobs to use this profile.

Jira: https://redhat.atlassian.net/browse/RHIDP-13968

## Docs

- [Add a New Cluster Profile](https://docs.ci.openshift.org/docs/how-tos/adding-a-cluster-profile/) — step-by-step guide followed for this PR