### PR TITLE
fix: use go run gotestsum instead of calling gotestsum directly

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -8,4 +8,4 @@ if [[ -n ${ARTIFACT_DIR:-} ]]; then
 fi
 
 set -o xtrace
-gotestsum $JUNIT_ARG -- ${PACKAGES:-"./..."} -race ${TESTFLAGS:-}
+go run gotest.tools/gotestsum@latest $JUNIT_ARG -- ${PACKAGES:-"./..."} -race ${TESTFLAGS:-}


### PR DESCRIPTION
This ensures that the tool will be available in the environments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR modifies the test execution script (`hack/test-go.sh`) to dynamically fetch and run the `gotestsum` test runner via `go run gotest.tools/gotestsum@latest` instead of relying on a pre-installed binary.

### What Changed

The Go test runner invocation was updated from calling a pre-installed `gotestsum` binary to dynamically downloading and executing it using Go's `go run` mechanism. This change preserves all existing functionality including JUnit report generation, package selection, race condition detection, and custom test flags.

### Practical Impact for CI Operators

This change eliminates a build-time dependency requirement for test execution environments. Previously, CI jobs needed to ensure `gotestsum` was pre-installed in their container images or execution environments. Now, the tool is automatically fetched at runtime when the test script runs, similar to how developers might use `go run` locally for tools. This makes the testing infrastructure more self-contained and reduces environmental setup complexity.

The modification specifically impacts how the `ci-tools` project runs its own unit and integration tests, making the test workflow more reliable and less dependent on pre-provisioned tooling in CI containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->