### PR TITLE
prowgen: add disable_sparse_checkout option

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -53,6 +53,9 @@ type ProwgenOverrides struct {
 	// Expose declares that jobs should not be hidden from view in deck if they
 	// are private. This field has no effect if private is not set.
 	Expose bool `json:"expose,omitempty"`
+	// DisableSparseCheckout disables the sparse checkout optimization for the
+	// repository clone done by Prow's clonerefs.
+	DisableSparseCheckout bool `json:"disable_sparse_checkout,omitempty"`
 }
 
 // ReleaseBuildConfiguration describes how release

--- a/pkg/prowgen/jobbase.go
+++ b/pkg/prowgen/jobbase.go
@@ -97,7 +97,10 @@ func NewProwJobBaseBuilder(configSpec *cioperatorapi.ReleaseBuildConfiguration, 
 	if shouldSkipCloning {
 		b.base.UtilityConfig.DecorationConfig.SkipCloning = ptr.To(true)
 	} else {
-		b.base.UtilityConfig.DecorationConfig.SparseCheckoutFiles = sparseFiles
+		disableSparseCheckout := configSpec.Prowgen != nil && configSpec.Prowgen.DisableSparseCheckout
+		if !disableSparseCheckout {
+			b.base.UtilityConfig.DecorationConfig.SparseCheckoutFiles = sparseFiles
+		}
 		if private {
 			b.base.UtilityConfig.DecorationConfig.OauthTokenSecret = &prowv1.OauthTokenSecret{Key: cioperatorapi.OauthTokenSecretKey, Name: cioperatorapi.OauthTokenSecretName}
 		}

--- a/pkg/prowgen/jobbase_test.go
+++ b/pkg/prowgen/jobbase_test.go
@@ -122,6 +122,22 @@ func TestProwJobBaseBuilder(t *testing.T) {
 			podSpecBuilder: newFakePodSpecBuilder(),
 		},
 		{
+			name:             "job with images and sparse checkout disabled",
+			info:             defaultInfo,
+			images:           ciop.ImageConfiguration{Items: []ciop.ProjectDirectoryImageBuildStepConfiguration{{From: "base", To: "image"}}},
+			prowgenOverrides: &ciop.ProwgenOverrides{DisableSparseCheckout: true},
+			prefix:           "default",
+			podSpecBuilder:   newFakePodSpecBuilder(),
+		},
+		{
+			name:             "private job with images and sparse checkout disabled",
+			info:             &ciop.Metadata{Org: "vorg", Repo: "vrepo", Branch: "vbranch"},
+			images:           ciop.ImageConfiguration{Items: []ciop.ProjectDirectoryImageBuildStepConfiguration{{From: "base", To: "image"}}},
+			prowgenOverrides: &ciop.ProwgenOverrides{Private: true, DisableSparseCheckout: true},
+			prefix:           "default",
+			podSpecBuilder:   NewCiOperatorPodSpecGenerator(),
+		},
+		{
 			name:           "default job without further configuration, including podspec",
 			info:           defaultInfo,
 			prefix:         "default",

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_images_and_sparse_checkout_disabled.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_images_and_sparse_checkout_disabled.yaml
@@ -1,0 +1,4 @@
+agent: kubernetes
+decorate: true
+decoration_config: {}
+name: default-ci-org-repo-branch-

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_with_images_and_sparse_checkout_disabled.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_with_images_and_sparse_checkout_disabled.yaml
@@ -1,0 +1,50 @@
+agent: kubernetes
+decorate: true
+decoration_config:
+  oauth_token_secret:
+    key: oauth
+    name: github-credentials-openshift-ci-robot-private-git-cloner
+hidden: true
+name: default-ci-vorg-vrepo-vbranch-
+spec:
+  containers:
+  - args:
+    - --gcs-upload-secret=/secrets/gcs/service-account.json
+    - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+    - --oauth-token-path=/usr/local/github-credentials/oauth
+    - --report-credentials-file=/etc/report/credentials
+    command:
+    - ci-operator
+    image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+    imagePullPolicy: Always
+    name: ""
+    resources:
+      requests:
+        cpu: 10m
+    volumeMounts:
+    - mountPath: /secrets/gcs
+      name: gcs-credentials
+      readOnly: true
+    - mountPath: /usr/local/github-credentials
+      name: github-credentials-openshift-ci-robot-private-git-cloner
+      readOnly: true
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
+    - mountPath: /etc/pull-secret
+      name: pull-secret
+      readOnly: true
+    - mountPath: /etc/report
+      name: result-aggregator
+      readOnly: true
+  serviceAccountName: ci-operator
+  volumes:
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
+  - name: pull-secret
+    secret:
+      secretName: registry-pull-credentials
+  - name: result-aggregator
+    secret:
+      secretName: result-aggregator

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -351,6 +351,9 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"          tag_by_commit: true\n" +
 	"prowgen:\n" +
 	"    disable_rehearsals: true\n" +
+	"    # DisableSparseCheckout disables the sparse checkout optimization for the\n" +
+	"    # repository clone done by Prow's clonerefs.\n" +
+	"    disable_sparse_checkout: true\n" +
 	"    enable_secrets_store_csi_driver: true\n" +
 	"    # Expose declares that jobs should not be hidden from view in deck if they\n" +
 	"    # are private. This field has no effect if private is not set.\n" +


### PR DESCRIPTION
## Summary
- Adds `disable_sparse_checkout` field to `ProwgenOverrides` in ci-operator config
- When set, prowgen generates jobs that perform a full clone instead of sparse checkout
- This is needed for repositories that use git submodules, as sparse checkout with blobless fetches (`--filter=blob:none`) fails when submodule gitlink entries are modified but the submodule path is excluded from the sparse working tree

Repos that need this can add to their ci-operator config:
```yaml
prowgen:
  disable_sparse_checkout: true
```

This is intended as a workaround until kubernetes-sigs/prow#723 lands with a proper fallback in clonerefs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Adds disable_sparse_checkout option for repository cloning

This PR adds a new ci-operator prowgen configuration option to opt out of the sparse-checkout optimization used during Prow job repository cloning.

### Context
Prowgen previously generated jobs that use sparse checkout with blobless fetches (--filter=blob:none) to fetch only files required for CI (e.g., Dockerfiles, ci-operator configs). That optimization can fail for repositories that use git submodules when submodule gitlink entries are modified but the submodule path is excluded from the sparse working tree. This change is a workaround until clonerefs gains a proper fallback (kubernetes-sigs/prow#723).

### Changes (user-visible)
- New config field: prowgen: disable_sparse_checkout: true — added as `disable_sparse_checkout` on ProwgenOverrides (pkg/api/types.go). When set, prowgen will generate jobs that perform a full git clone instead of using sparse checkout / blobless fetches.
- Job generation: prowgen's job base builder now respects this flag and leaves SparseCheckoutFiles unset when disable_sparse_checkout is true, preserving existing SkipCloning and OAuth token behavior for private jobs (pkg/prowgen/jobbase.go).
- Tests and fixtures: Added unit tests and YAML fixtures exercising public and private image-build jobs with sparse checkout disabled (pkg/prowgen/jobbase_test.go and testdata fixtures).

### Impact for CI users/operators
Repository owners can opt out of sparse-checkout on a per-repo basis by setting prowgen.disable_sparse_checkout: true in ci-operator configuration. This forces full repository checkouts for generated Prow jobs, avoiding failures for repos that rely on submodules or other cases where sparse checkout breaks, while other repos retain the performance benefits of sparse checkout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->