### PR TITLE
DPTP-2938: floor authoritative CPU decreases at 10m and fix inflation

### DIFF
--- a/cmd/pod-scaler/admission.go
+++ b/cmd/pod-scaler/admission.go
@@ -230,6 +230,8 @@ func mutatePodLabels(pod *corev1.Pod, build *buildv1.Build) {
 
 const authoritativeMaxReductionPercent = 0.25
 
+var authoritativeMinCPURequest = resource.MustParse("10m")
+
 // useOursIfLarger updates fields in theirs when ours are larger, or lowers them when authoritative mode allows.
 func useOursIfLarger(allOfOurs, allOfTheirs *corev1.ResourceRequirements, workloadName, workloadType string, isMeasured bool, workloadClass string, authoritativeCPU, authoritativeMemory, authoritativeCPUDryRun, authoritativeMemoryDryRun bool, reporter results.PodScalerReporter, logger *logrus.Entry) {
 	for _, item := range []*corev1.ResourceRequirements{allOfOurs, allOfTheirs} {
@@ -254,8 +256,12 @@ func useOursIfLarger(allOfOurs, allOfTheirs *corev1.ResourceRequirements, worklo
 			}
 			//TODO(sgoeddel): this is a temporary experiment to see what effect setting values that are 120% of what has
 			// been determined has on the rate of OOMKilled and similar termination of workloads
-			increased := our.AsApproximateFloat64() * 1.2
-			our.Set(int64(increased))
+			if field == corev1.ResourceCPU {
+				our.SetMilli(int64(float64(our.MilliValue()) * 1.2))
+			} else {
+				increased := our.AsApproximateFloat64() * 1.2
+				our.Set(int64(increased))
+			}
 
 			their := (*pair.theirs)[field]
 			fieldLogger := logger.WithFields(logrus.Fields{
@@ -289,6 +295,14 @@ func useOursIfLarger(allOfOurs, allOfTheirs *corev1.ResourceRequirements, worklo
 				}
 				theirValue := their.AsApproximateFloat64()
 				if theirValue == 0 {
+					if field == corev1.ResourceCPU {
+						if our.Cmp(authoritativeMinCPURequest) < 0 {
+							our = authoritativeMinCPURequest
+						}
+						if our.Cmp(their) >= 0 {
+							continue
+						}
+					}
 					if dryRun {
 						fieldLogger.WithFields(logrus.Fields{
 							"event":         "authoritative_decrease_dry_run",
@@ -307,8 +321,20 @@ func useOursIfLarger(allOfOurs, allOfTheirs *corev1.ResourceRequirements, worklo
 				}
 				capped := false
 				if 1.0-(ourValue/theirValue) > authoritativeMaxReductionPercent {
-					our.Set(int64(theirValue * (1.0 - authoritativeMaxReductionPercent)))
+					if field == corev1.ResourceCPU {
+						our.SetMilli(int64(float64(their.MilliValue()) * (1.0 - authoritativeMaxReductionPercent)))
+					} else {
+						our.Set(int64(theirValue * (1.0 - authoritativeMaxReductionPercent)))
+					}
 					capped = true
+				}
+				if field == corev1.ResourceCPU {
+					if our.Cmp(authoritativeMinCPURequest) < 0 {
+						our = authoritativeMinCPURequest
+					}
+					if our.Cmp(their) >= 0 {
+						continue
+					}
 				}
 				if dryRun {
 					fieldLogger.WithFields(logrus.Fields{

--- a/cmd/pod-scaler/admission_test.go
+++ b/cmd/pod-scaler/admission_test.go
@@ -791,6 +791,26 @@ func TestUseOursIfLarger_authoritative(t *testing.T) {
 			},
 		},
 		{
+			name:             "cpu decrease never below 10m",
+			authoritativeCPU: true,
+			ours: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1m"),
+				},
+			},
+			theirs: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("12m"),
+				},
+			},
+			expected: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("10m"),
+				},
+			},
+		},
+		{
 			name:             "measured pod skips reduction",
 			authoritativeCPU: true,
 			isMeasured:       true,

--- a/cmd/pod-scaler/testdata/zz_fixture_TestMutatePodResources_resources_to_add.diff
+++ b/cmd/pod-scaler/testdata/zz_fixture_TestMutatePodResources_resources_to_add.diff
@@ -47,7 +47,7 @@
   					Limits: {},
   					Requests: v1.ResourceList{
 - 						s"cpu":    {i: resource.int64Amount{value: 2}, Format: "DecimalSI"},
-+ 						s"cpu":    {i: resource.int64Amount{value: 6}, s: "6", Format: "DecimalSI"},
++ 						s"cpu":    {i: resource.int64Amount{value: 6000, scale: -3}, s: "6", Format: "DecimalSI"},
 - 						s"memory": {i: resource.int64Amount{value: 100}, Format: "BinarySI"},
 + 						s"memory": {i: resource.int64Amount{value: 240000000}, s: "234375Ki", Format: "BinarySI"},
   					},

--- a/cmd/pod-scaler/testdata/zz_fixture_TestMutatePodResources_resources_to_add__limits_disabled.diff
+++ b/cmd/pod-scaler/testdata/zz_fixture_TestMutatePodResources_resources_to_add__limits_disabled.diff
@@ -47,7 +47,7 @@
   					Limits: {},
   					Requests: v1.ResourceList{
 - 						s"cpu":    {i: resource.int64Amount{value: 2}, Format: "DecimalSI"},
-+ 						s"cpu":    {i: resource.int64Amount{value: 6}, s: "6", Format: "DecimalSI"},
++ 						s"cpu":    {i: resource.int64Amount{value: 6000, scale: -3}, s: "6", Format: "DecimalSI"},
 - 						s"memory": {i: resource.int64Amount{value: 100}, Format: "BinarySI"},
 + 						s"memory": {i: resource.int64Amount{value: 21474836480}, s: "20Gi", Format: "BinarySI"},
   					},


### PR DESCRIPTION
/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Pod-scaler Admission Controller: CPU floor (10m) and more-precise CPU scaling math

This PR hardens the pod-scaler admission webhook's authoritative CPU decrease path and fixes CPU scaling precision so automatic reductions are safer and more consistent.

What changed (practical effect for CI users/operators)
- A 10 millicore floor (authoritativeMinCPURequest = 10m) is introduced so authoritative CPU decreases will never lower a container's CPU request below 10m.
  - When the configured ("theirs") CPU is zero, the computed ("ours") CPU request is clamped up to 10m before applying it.
  - After applying the maximum-authoritative-reduction cap, the final CPU value is clamped to 10m; if the clamp would not produce a value lower than the configured request, the decrease is skipped.
  - This prevents overly aggressive reductions that could render a container effectively CPU-starved.
- CPU scaling math now uses milli-based integer math for CPU quantities (MilliValue / SetMilli) rather than approximate floating-point scaling. Non-CPU resources continue to use approximate-float scaling.
  - The 120% experiment multiplier and the maximum-authoritative-reduction cap now compute CPU changes using milli-based math, improving accuracy and avoiding rounding/precision issues that could lead to incorrect request values.
- Test and fixture updates:
  - A new unit test verifies authoritative CPU reduction respects the 10m floor (example test: `ours` 1m, `theirs` 12m → result 10m).
  - Test fixtures were adjusted to reflect the revised/internal quantity representations (some CPU quantities now rendered/scaled differently and some memory limits/requests updated).

Component affected
- cmd/pod-scaler (admission webhook that mutates pod resource requests based on observed usage).

Operational impact
- More predictable and safer automatic CPU decreases in authoritative mode: reductions won't drop CPU below 10m and use precise milli arithmetic for CPU, reducing the risk of mis-calculated or excessively small requests while retaining the intended downsizing behavior when safe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->