### PR TITLE
Update AI bot name from ship-help to chai-bot

### DIFF
--- a/pkg/slack/events/helpdesk/helpdesk-message.go
+++ b/pkg/slack/events/helpdesk/helpdesk-message.go
@@ -123,7 +123,7 @@ func getContactedHelpdeskResponse(botId, reviewRequestWorkflowID, user string) [
 	} else {
 		sections = append(sections,
 			"In the meantime, check our <https://docs.ci.openshift.org/|documentation> or <https://docs.ci.openshift.org/getting-started/helpdesk-faq/|Helpdesk FAQ>.",
-			"You can also ask `(@)ship-help` - AI chatbot that can help answer your questions :ai-generated:.",
+			"You can also ask `(@)chai-bot` - AI chatbot that can help answer your questions :ai-generated:.",
 			"If this is an urgent CI outage, please ping `(@)dptp-triage`")
 	}
 

--- a/pkg/slack/events/helpdesk/testdata/zz_fixture_TestGetContactedHelpdeskResponse_empty_botId.yaml
+++ b/pkg/slack/events/helpdesk/testdata/zz_fixture_TestGetContactedHelpdeskResponse_empty_botId.yaml
@@ -9,7 +9,7 @@
     type: mrkdwn
   type: section
 - text:
-    text: You can also ask `(@)ship-help` - AI chatbot that can help answer your questions
+    text: You can also ask `(@)chai-bot` - AI chatbot that can help answer your questions
       :ai-generated:.
     type: mrkdwn
   type: section

--- a/pkg/slack/events/helpdesk/testdata/zz_fixture_TestGetContactedHelpdeskResponse_random_botId.yaml
+++ b/pkg/slack/events/helpdesk/testdata/zz_fixture_TestGetContactedHelpdeskResponse_random_botId.yaml
@@ -9,7 +9,7 @@
     type: mrkdwn
   type: section
 - text:
-    text: You can also ask `(@)ship-help` - AI chatbot that can help answer your questions
+    text: You can also ask `(@)chai-bot` - AI chatbot that can help answer your questions
       :ai-generated:.
     type: mrkdwn
   type: section


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates the AI bot name referenced in the helpdesk guidance messages within the CI infrastructure's Slack integration. The helpdesk message handler now directs users to `@chai-bot` instead of `@ship-help` when providing helpful resources or guidance through Slack.

## Changes

The helpdesk response message in the Slack events handler has been updated to reference the renamed bot. This affects:

- **helpdesk-message.go**: The message content that gets sent to users requesting helpdesk assistance now mentions `@chai-bot` as the resource to contact
- **Test fixtures**: Updated corresponding test fixtures to verify the new bot name is correctly included in helpdesk responses

## Impact

CI users interacting with the helpdesk guidance through Slack will now be directed to contact `@chai-bot` for additional assistance, replacing the previous `@ship-help` bot reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->