### PR TITLE
`sippy-config-generator`: add Synthetic field to ReleaseConfig

### DIFF
--- a/pkg/api/sippy/v1/types.go
+++ b/pkg/api/sippy/v1/types.go
@@ -22,4 +22,6 @@ type ReleaseConfig struct {
 
 	// InformingJobs is the list of informing payload jobs
 	InformingJobs []string `yaml:"informingJobs,omitempty"`
+
+	Synthetic bool `yaml:"synthetic,omitempty"`
 }


### PR DESCRIPTION
Adding a new field to the customizations file and need it present in the generated `openshift.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## sippy-config-generator: Add Synthetic field to ReleaseConfig

The `sippy-config-generator` tool, which generates Sippy configuration for tracking job health across OpenShift release branches, now supports a `Synthetic` flag for releases.

A new `Synthetic` boolean field has been added to the `ReleaseConfig` struct in `pkg/api/sippy/v1/types.go`. This allows users to mark releases as synthetic in the customization file—either for pseudo-releases of selected jobs or other special release configurations. When the generator processes the customization file and outputs the final `openshift.yaml` configuration consumed by Sippy, the `synthetic` field will be included if specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->