### PR TITLE
promotion: use stable:cli from payload when available

### DIFF
--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -105,13 +105,12 @@ func (s *promotionStep) run(ctx context.Context) error {
 		logger.WithError(err).Warn("Failed to ensure namespaces to promote to in central registry.")
 	}
 
-	version, err := getLatestStableCLIVersion(&http.Client{})
+	cliImage, err := promotionCLIImage(ctx, s.client, s.jobSpec.Namespace())
 	if err != nil {
-		logrus.WithError(err).Warn("Failed to determine the stable release version, using 4.20 instead")
-		version = "4.20"
+		return fmt.Errorf("resolve promotion cli image: %w", err)
 	}
 
-	if _, err := steps.RunPod(ctx, s.client, getPromotionPod(imageMirrorTarget, timeStr, s.jobSpec.Namespace(), s.name, version, s.nodeArchitectures), false); err != nil {
+	if _, err := steps.RunPod(ctx, s.client, getPromotionPod(imageMirrorTarget, timeStr, s.jobSpec.Namespace(), s.name, cliImage, s.nodeArchitectures), false); err != nil {
 		return fmt.Errorf("unable to run promotion pod: %w", err)
 	}
 	return nil
@@ -232,6 +231,53 @@ func getLatestStableCLIVersion(client *http.Client) (string, error) {
 	return "", fmt.Errorf("no stable CLI version found in any stream (tried 9-stable through 4-stable)")
 }
 
+func promotionCLIImage(ctx context.Context, client ctrlruntimeclient.Client, namespace string) (string, error) {
+	return promotionCLIImageWithResolver(ctx, client, namespace, getLatestStableCLIVersion)
+}
+
+func promotionCLIImageWithResolver(
+	ctx context.Context,
+	client ctrlruntimeclient.Client,
+	namespace string,
+	stableVersionResolver func(*http.Client) (string, error),
+) (string, error) {
+	streamName := api.ReleaseStreamFor(api.LatestReleaseName)
+	is := &imagev1.ImageStream{}
+	err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: namespace, Name: streamName}, is)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return promotionCLIImageFromRegistryWithResolver(stableVersionResolver)
+		}
+		return "", fmt.Errorf("get imagestream %s/%s: %w", namespace, streamName, err)
+	}
+	if findDockerImageReference(is, "cli") != "" {
+		cliImage := fmt.Sprintf("%s:cli", streamName)
+		logrus.WithField("image", cliImage).Info("Using payload cli image for promotion")
+		return cliImage, nil
+	}
+	logrus.WithField("stream", streamName).Info("No cli tag on release payload stream; using quay-proxy stable cli for promotion")
+	return promotionCLIImageFromRegistryWithResolver(stableVersionResolver)
+}
+
+func promotionRegistryCLIReference(version string) api.ImageStreamTagReference {
+	return api.ImageStreamTagReference{Namespace: "ocp", Name: version, Tag: "cli"}
+}
+
+func promotionCLIImageFromRegistryWithResolver(stableVersionResolver func(*http.Client) (string, error)) (string, error) {
+	version, err := stableVersionResolver(&http.Client{Timeout: 15 * time.Second})
+	if err != nil {
+		logrus.WithError(err).Warn("Failed to determine the stable release version, using 4.22 instead")
+		version = "4.22"
+	}
+	ref := promotionRegistryCLIReference(version)
+	// registry.ci ocp/*:cli and ocp-arm64/*:cli are not reliably present after
+	// source-reference migration, so use quay-proxy ocp_<version>_cli fallback.
+	// Arm64-only jobs still resolve/tag arm64 payload digests via --filter-by-os.
+	image := api.QuayImageReference(ref)
+	logrus.WithField("image", image).Info("Using quay-proxy cli image for promotion")
+	return image, nil
+}
+
 func getMirrorCommand(registryConfig string, images []string, loglevel int) string {
 	return fmt.Sprintf("oc image mirror --loglevel=%d --keep-manifest-list --registry-config=%s --max-per-registry=10 %s",
 		loglevel, registryConfig, strings.Join(images, " "))
@@ -318,7 +364,7 @@ const (
 	retryLoopWithBackoff = "backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before retry; sleep $backoff"
 )
 
-func getPromotionPod(imageMirrorTarget map[string]string, timeStr string, namespace string, name string, cliVersion string, nodeArchitectures []string) *coreapi.Pod {
+func getPromotionPod(imageMirrorTarget map[string]string, timeStr string, namespace string, name string, cliImage string, nodeArchitectures []string) *coreapi.Pod {
 	keys := make([]string, 0, len(imageMirrorTarget))
 	for k := range imageMirrorTarget {
 		keys = append(keys, k)
@@ -418,12 +464,13 @@ func getPromotionPod(imageMirrorTarget map[string]string, timeStr string, namesp
 	args = append(args, commands...)
 	args = []string{strings.Join(args, "\n")}
 
-	image := fmt.Sprintf("%s/%s/%s:cli", api.DomainForService(api.ServiceRegistry), "ocp", cliVersion)
+	image := cliImage
 	nodeSelector := map[string]string{"kubernetes.io/arch": "amd64"}
 
 	archs := sets.New[string](nodeArchitectures...)
-	if !archs.Has("amd64") && archs.Has("arm64") {
-		image = fmt.Sprintf("%s/%s/%s:cli", api.DomainForService(api.ServiceRegistry), "ocp-arm64", cliVersion)
+	// Keep arm64 pinning only when using payload stable:cli. Registry fallback image
+	// is amd64-only, but promotion logic itself is architecture-agnostic.
+	if cliImage == "stable:cli" && !archs.Has("amd64") && archs.Has("arm64") {
 		nodeSelector = map[string]string{"kubernetes.io/arch": "arm64"}
 	}
 

--- a/pkg/steps/release/promote_test.go
+++ b/pkg/steps/release/promote_test.go
@@ -1,7 +1,9 @@
 package release
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"reflect"
 	"sort"
 	"strings"
@@ -10,8 +12,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	coreapi "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/diff"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	imageapi "github.com/openshift/api/image/v1"
 
@@ -816,7 +821,7 @@ func TestGetPromotionPod(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			testhelper.CompareWithFixture(t, getPromotionPod(testCase.imageMirror, "20240603235401", testCase.namespace, testCase.stepName, "4.20", testCase.nodeArchitectures))
+			testhelper.CompareWithFixture(t, getPromotionPod(testCase.imageMirror, "20240603235401", testCase.namespace, testCase.stepName, "stable:cli", testCase.nodeArchitectures))
 		})
 	}
 }
@@ -1179,6 +1184,143 @@ func TestQuayProxyTagFromISKey(t *testing.T) {
 			}
 			if ok && got != tt.wantTag {
 				t.Errorf("quayProxyTagFromISKey(%q) = %q, want %q", tt.isTagKey, got, tt.wantTag)
+			}
+		})
+	}
+}
+
+func TestPromotionCLIImageInfoFilterOS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		nodeArchitectures []string
+		want              string
+	}{
+		{name: "amd64", nodeArchitectures: []string{"amd64"}, want: "linux/amd64"},
+		{name: "arm64 only", nodeArchitectures: []string{"arm64"}, want: "linux/arm64"},
+		{name: "multi", nodeArchitectures: []string{"amd64", "arm64"}, want: "linux/amd64"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := promotionCLIImageInfoFilterOS(tt.nodeArchitectures); got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPromotionRegistryCLIReference(t *testing.T) {
+	t.Parallel()
+
+	ref := promotionRegistryCLIReference("4.22")
+	got := api.QuayImageReference(ref)
+	want := api.QCIAPPCIDomain + "/openshift/ci:ocp_4.22_cli"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestPromotionCLIImageFromRegistry(t *testing.T) {
+	t.Parallel()
+
+	versionResolver := func(*http.Client) (string, error) { return "4.22", nil }
+
+	got, err := promotionCLIImageFromRegistryWithResolver(versionResolver)
+	if err != nil {
+		t.Fatalf("resolve fallback image: %v", err)
+	}
+	if want := api.QCIAPPCIDomain + "/openshift/ci:ocp_4.22_cli"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestGetPromotionPodFallbackImageDoesNotPinArm64Node(t *testing.T) {
+	t.Parallel()
+
+	pod := getPromotionPod(
+		map[string]string{"registry.ci.openshift.org/ci/bin:latest": "docker-registry.default.svc:5000/ci-op-test/pipeline@sha256:bbb"},
+		"20240603235401",
+		"ci-op-test",
+		"promotion",
+		api.QCIAPPCIDomain+"/openshift/ci:ocp_4.22_cli",
+		[]string{"arm64"},
+	)
+	if got := pod.Spec.NodeSelector["kubernetes.io/arch"]; got != "amd64" {
+		t.Fatalf("expected fallback cli image to run on amd64 node, got selector %v", pod.Spec.NodeSelector)
+	}
+}
+
+func TestPromotionCLIImage(t *testing.T) {
+	t.Parallel()
+
+	versionResolver := func(*http.Client) (string, error) { return "4.22", nil }
+
+	scheme := runtime.NewScheme()
+	if err := imageapi.Install(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	stableWithCLI := &imageapi.ImageStream{
+		ObjectMeta: meta.ObjectMeta{Name: "stable", Namespace: "ci-ln-test"},
+		Status: imageapi.ImageStreamStatus{
+			PublicDockerImageRepository: "image-registry.openshift-image-registry.svc:5000/ci-ln-test/stable",
+			Tags: []imageapi.NamedTagEventList{{
+				Tag: "cli",
+				Items: []imageapi.TagEvent{{
+					DockerImageReference: "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc",
+					Image:                "sha256:abc",
+				}},
+			}},
+		},
+	}
+	emptyStable := &imageapi.ImageStream{
+		ObjectMeta: meta.ObjectMeta{Name: "stable", Namespace: "ci-ln-empty"},
+	}
+
+	tests := []struct {
+		name      string
+		objects   []runtime.Object
+		namespace string
+		want      string
+	}{
+		{
+			name:      "uses stable cli when payload imported",
+			objects:   []runtime.Object{stableWithCLI},
+			namespace: "ci-ln-test",
+			want:      "stable:cli",
+		},
+		{
+			name:      "falls back when stable has no cli tag",
+			objects:   []runtime.Object{emptyStable},
+			namespace: "ci-ln-empty",
+			want:      api.QCIAPPCIDomain + "/openshift/ci:ocp_",
+		},
+		{
+			name:      "falls back when stable imagestream missing",
+			namespace: "ci-ln-missing",
+			want:      api.QCIAPPCIDomain + "/openshift/ci:ocp_",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(tt.objects...).Build()
+			got, err := promotionCLIImageWithResolver(context.Background(), c, tt.namespace, versionResolver)
+			if err != nil {
+				t.Fatalf("promotionCLIImage: %v", err)
+			}
+			if tt.want == "stable:cli" {
+				if got != tt.want {
+					t.Fatalf("got %q, want %q", got, tt.want)
+				}
+				return
+			}
+			if !strings.HasPrefix(got, tt.want) || !strings.HasSuffix(got, "_cli") {
+				t.Fatalf("got %q, want prefix %q and _cli suffix", got, tt.want)
 			}
 		})
 	}

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case.yaml
@@ -20,7 +20,7 @@ spec:
       value: /etc/app-ci-kubeconfig/kubeconfig
     - name: KUBECACHEDIR
       value: /tmp/.kube/cache
-    image: registry.ci.openshift.org/ocp/4.20:cli
+    image: stable:cli
     name: promotion
     resources: {}
     volumeMounts:

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case__arm64_only.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case__arm64_only.yaml
@@ -20,7 +20,7 @@ spec:
       value: /etc/app-ci-kubeconfig/kubeconfig
     - name: KUBECACHEDIR
       value: /tmp/.kube/cache
-    image: registry.ci.openshift.org/ocp-arm64/4.20:cli
+    image: stable:cli
     name: promotion
     resources: {}
     volumeMounts:

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case__multi_architecture.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case__multi_architecture.yaml
@@ -20,7 +20,7 @@ spec:
       value: /etc/app-ci-kubeconfig/kubeconfig
     - name: KUBECACHEDIR
       value: /tmp/.kube/cache
-    image: registry.ci.openshift.org/ocp/4.20:cli
+    image: stable:cli
     name: promotion
     resources: {}
     volumeMounts:

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay.yaml
@@ -23,7 +23,7 @@ spec:
       value: /etc/app-ci-kubeconfig/kubeconfig
     - name: KUBECACHEDIR
       value: /tmp/.kube/cache
-    image: registry.ci.openshift.org/ocp/4.20:cli
+    image: stable:cli
     name: promotion
     resources: {}
     volumeMounts:

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_4.12.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_4.12.yaml
@@ -23,7 +23,7 @@ spec:
       value: /etc/app-ci-kubeconfig/kubeconfig
     - name: KUBECACHEDIR
       value: /tmp/.kube/cache
-    image: registry.ci.openshift.org/ocp/4.20:cli
+    image: stable:cli
     name: promotion
     resources: {}
     volumeMounts:

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_multiple_tags.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_multiple_tags.yaml
@@ -24,7 +24,7 @@ spec:
       value: /etc/app-ci-kubeconfig/kubeconfig
     - name: KUBECACHEDIR
       value: /tmp/.kube/cache
-    image: registry.ci.openshift.org/ocp/4.20:cli
+    image: stable:cli
     name: promotion
     resources: {}
     volumeMounts:

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_non_release_namespace.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_non_release_namespace.yaml
@@ -22,7 +22,7 @@ spec:
       value: /etc/app-ci-kubeconfig/kubeconfig
     - name: KUBECACHEDIR
       value: /tmp/.kube/cache
-    image: registry.ci.openshift.org/ocp/4.20:cli
+    image: stable:cli
     name: promotion
     resources: {}
     volumeMounts:


### PR DESCRIPTION
https://redhat-internal.slack.com/archives/CBN38N3MW/p1779889878012629

/hold
/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR changes the ci-operator release promotion step to prefer a concrete CLI image from the release payload (stable:cli) when available and to pass a fully-resolved promotion CLI image into the promotion pod instead of constructing an image name from an inline CLI version.

What changed
- promotionStep.run now resolves the promotion CLI image via promotionCLIImage(...) and passes the resulting cliImage into getPromotionPod.
- New helper promotionCLIImage(ctx, client, namespace, nodeArchitectures):
  - Attempts to read the api.ReleaseStreamFor(api.LatestReleaseName) ImageStream in the promotion namespace and use its cli tag (stable:cli) when present.
  - If the ImageStream is missing or lacks a cli tag, falls back to registry-based resolution via promotionCLIImageFromRegistryWithResolver: resolves a stable CLI version (using the provided resolver with a default fallback), selects the appropriate arch-specific stream (ocp vs ocp-arm64 based on nodeArchitectures), and returns a fully-qualified image reference (Quay-proxy/registry form) ending in :cli.
- getPromotionPod signature changed from cliVersion string to cliImage string and now sets the promotion container image directly from cliImage. Node-selector logic remains to pin to arm64 for arm64-only builds when appropriate; the previous in-function assembly of ocp/ocp-arm64 image names from a numeric cliVersion was removed.
- No public/exported API signatures were changed.

Practical impact for CI users and operators
- Promotion pods will prefer the exact CLI image supplied in the release payload (stable:cli) when present, ensuring the CLI used for promotion matches the payload-tested CLI.
- If the payload lacks a cli tag, promotion falls back to a registry-resolved stable CLI image and picks the correct architecture stream, preserving multi-arch correctness.
- Makes promotion behavior more deterministic and reduces reliance on inline-constructed version strings.

Tests and fixtures
- Unit tests expanded to cover CLI selection and formatting (OS filter selection, Quay/registry reference formatting, registry-based resolver behavior, and end-to-end promotionCLIImage behavior using a fake Kubernetes client and image API scheme).
- Existing getPromotionPod fixtures and other testdata updated to expect stable:cli instead of hardcoded numeric-versioned CLI pullspecs.

Other notes
- The PR body references an internal Slack thread and includes GitHub directives (e.g., "/hold") and reviewer/CI comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->