### PR TITLE
fix: dockerfile registry.ci input detection with baseImages

### DIFF
--- a/cmd/registry-replacer/main.go
+++ b/cmd/registry-replacer/main.go
@@ -383,7 +383,7 @@ func replacer(
 }
 
 func ensureReplacement(image *api.ProjectDirectoryImageBuildStepConfiguration, dockerfile []byte) ([]cidockerfile.OrgRepoTag, error) {
-	toReplace := cidockerfile.ExtractRegistryReferences(dockerfile, "")
+	toReplace := cidockerfile.ExtractRegistryReferences(dockerfile)
 	var result []cidockerfile.OrgRepoTag
 	for _, toReplace := range toReplace {
 		orgRepoTag, err := cidockerfile.OrgRepoTagFromPullString(toReplace)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -980,7 +980,7 @@ func readDockerfileForImage(image api.ProjectDirectoryImageBuildStepConfiguratio
 // required InputImageTagStepConfiguration steps to import them, as well as an updated
 // image configuration with the detected inputs added
 func processDetectedBaseImages(baseImages map[string]api.ImageStreamTagReference, image api.ProjectDirectoryImageBuildStepConfiguration, details dockerfileDetails) ([]api.StepConfiguration, api.ProjectDirectoryImageBuildStepConfiguration) {
-	detectedBaseImages := dockerfile.DetectInputsFromDockerfile(details.content, image.Inputs, image.From)
+	detectedBaseImages := dockerfile.DetectInputsFromDockerfile(details.content, image.Inputs, image.From, baseImages)
 	if len(detectedBaseImages) == 0 {
 		return nil, image
 	}

--- a/pkg/dockerfile/extract.go
+++ b/pkg/dockerfile/extract.go
@@ -24,10 +24,9 @@ func (ort OrgRepoTag) String() string {
 }
 
 // ExtractRegistryReferences finds all registry.ci.openshift.org and quay-proxy.ci.openshift.org references in the Dockerfile
-func ExtractRegistryReferences(dockerfile []byte, from api.PipelineImageStreamTagReference) []string {
+func ExtractRegistryReferences(dockerfile []byte) []string {
 	var refs []string
 	seen := sets.Set[string]{}
-	lastFromRef := ""
 
 	for _, line := range bytes.Split(dockerfile, []byte("\n")) {
 		upper := bytes.ToUpper(line)
@@ -40,24 +39,10 @@ func ExtractRegistryReferences(dockerfile []byte, from api.PipelineImageStreamTa
 			continue
 		}
 		ref := string(match)
-		if bytes.HasPrefix(upper, []byte("FROM")) {
-			lastFromRef = ref
-		}
-
 		if !seen.Has(ref) {
 			refs = append(refs, ref)
 			seen.Insert(ref)
 		}
-	}
-	if from != "" {
-		// If from is specified, remove the last detected FROM ref, it will be replaced
-		var newRefs []string
-		for _, ref := range refs {
-			if ref != lastFromRef {
-				newRefs = append(newRefs, ref)
-			}
-		}
-		refs = newRefs
 	}
 	return refs
 }

--- a/pkg/dockerfile/inputs.go
+++ b/pkg/dockerfile/inputs.go
@@ -9,11 +9,15 @@ import (
 // DetectInputsFromDockerfile parses a Dockerfile and detects registry references that need to be added as base images
 // Returns a map of base image names to ImageStreamTagReferences
 // The ImageStreamTagReference.As field contains the original registry reference from the Dockerfile
-func DetectInputsFromDockerfile(dockerfile []byte, existingInputs map[string]api.ImageBuildInputs, from api.PipelineImageStreamTagReference) map[string]api.ImageStreamTagReference {
-	registryRefs := ExtractRegistryReferences(dockerfile, from)
-	baseImages := make(map[string]api.ImageStreamTagReference)
+func DetectInputsFromDockerfile(dockerfile []byte, existingInputs map[string]api.ImageBuildInputs, from api.PipelineImageStreamTagReference, baseImages map[string]api.ImageStreamTagReference) map[string]api.ImageStreamTagReference {
+	registryRefs := ExtractRegistryReferences(dockerfile)
+	detected := make(map[string]api.ImageStreamTagReference)
 
 	for _, ref := range registryRefs {
+		if from != "" && matchesFromBaseImage(ref, from, baseImages) {
+			logrus.WithField("reference", ref).WithField("from", from).Debug("Skipping Dockerfile input already provided by image from")
+			continue
+		}
 		if HasManualReplacementFor(existingInputs, ref) {
 			logrus.WithField("reference", ref).Debug("Skipping Dockerfile inputs detection: manual replacement exists")
 			continue
@@ -24,7 +28,7 @@ func DetectInputsFromDockerfile(dockerfile []byte, existingInputs map[string]api
 			continue
 		}
 		baseImageKey := orgRepoTag.String()
-		baseImages[baseImageKey] = api.ImageStreamTagReference{
+		detected[baseImageKey] = api.ImageStreamTagReference{
 			Namespace: orgRepoTag.Org,
 			Name:      orgRepoTag.Repo,
 			Tag:       orgRepoTag.Tag,
@@ -32,5 +36,20 @@ func DetectInputsFromDockerfile(dockerfile []byte, existingInputs map[string]api
 		}
 	}
 
-	return baseImages
+	return detected
+}
+
+func matchesFromBaseImage(ref string, from api.PipelineImageStreamTagReference, baseImages map[string]api.ImageStreamTagReference) bool {
+	if from == "" || baseImages == nil {
+		return false
+	}
+	base, ok := baseImages[string(from)]
+	if !ok {
+		return false
+	}
+	orgRepoTag, err := OrgRepoTagFromPullString(ref)
+	if err != nil {
+		return false
+	}
+	return orgRepoTag.Org == base.Namespace && orgRepoTag.Repo == base.Name && orgRepoTag.Tag == base.Tag
 }

--- a/pkg/dockerfile/inputs_test.go
+++ b/pkg/dockerfile/inputs_test.go
@@ -13,6 +13,7 @@ func TestDetectInputsFromDockerfile(t *testing.T) {
 		name           string
 		dockerfile     string
 		existingInputs map[string]api.ImageBuildInputs
+		baseImages     map[string]api.ImageStreamTagReference
 		expected       map[string]api.ImageStreamTagReference
 		from           api.PipelineImageStreamTagReference
 	}{
@@ -142,20 +143,26 @@ FROM registry.ci.openshift.org/ocp/4.19:base AS runtime
 			},
 		},
 		{
-			name: "from: is specified - should exclude the last and only detected FROM ref",
+			name: "from matches base image - skip duplicate",
 			dockerfile: `FROM registry.ci.openshift.org/ocp/4.19:base
 RUN echo "hello"
 `,
-			from:     "src",
+			from: "src",
+			baseImages: map[string]api.ImageStreamTagReference{
+				"src": {Namespace: "ocp", Name: "4.19", Tag: "base"},
+			},
 			expected: map[string]api.ImageStreamTagReference{},
 		},
 		{
-			name: "from: is specified - should exclude the last detected FROM ref",
+			name: "from matches only its base image in multi-stage",
 			dockerfile: `FROM registry.ci.openshift.org/ocp/4.18:base AS builder
 FROM registry.ci.openshift.org/ocp/4.19:base
 RUN echo "hello"
 `,
 			from: "src",
+			baseImages: map[string]api.ImageStreamTagReference{
+				"src": {Namespace: "ocp", Name: "4.19", Tag: "base"},
+			},
 			expected: map[string]api.ImageStreamTagReference{
 				"ocp_4.18_base": {
 					Namespace: "ocp",
@@ -166,13 +173,35 @@ RUN echo "hello"
 			},
 		},
 		{
-			name: "from: is specified - should exclude the last detected FROM ref with COPY",
+			name: "multi-stage cli with unrelated from",
+			dockerfile: `FROM registry.ci.openshift.org/ocp/4.14:cli AS cli
+FROM quay.io/centos/centos:stream9
+COPY --from=cli /usr/bin/oc /usr/bin/
+`,
+			from: "stream9",
+			baseImages: map[string]api.ImageStreamTagReference{
+				"stream9": {Namespace: "openshift", Name: "centos", Tag: "stream9"},
+			},
+			expected: map[string]api.ImageStreamTagReference{
+				"ocp_4.14_cli": {
+					Namespace: "ocp",
+					Name:      "4.14",
+					Tag:       "cli",
+					As:        "registry.ci.openshift.org/ocp/4.14:cli",
+				},
+			},
+		},
+		{
+			name: "from matches only its base image with COPY",
 			dockerfile: `FROM registry.ci.openshift.org/ocp/4.18:base AS builder
 FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.21
 COPY --from=registry.ci.openshift.org/ocp/4.19:base /something /somewhere
 RUN echo "hello"
 `,
 			from: "src",
+			baseImages: map[string]api.ImageStreamTagReference{
+				"src": {Namespace: "ocp", Name: "4.19", Tag: "base"},
+			},
 			expected: map[string]api.ImageStreamTagReference{
 				"ocp_4.18_base": {
 					Namespace: "ocp",
@@ -180,11 +209,11 @@ RUN echo "hello"
 					Tag:       "base",
 					As:        "registry.ci.openshift.org/ocp/4.18:base",
 				},
-				"ocp_4.19_base": {
-					Namespace: "ocp",
-					Name:      "4.19",
-					Tag:       "base",
-					As:        "registry.ci.openshift.org/ocp/4.19:base",
+				"openshift_release_rhel-9-release-golang-1.24-openshift-4.21": {
+					Namespace: "openshift",
+					Name:      "release",
+					Tag:       "rhel-9-release-golang-1.24-openshift-4.21",
+					As:        "registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.21",
 				},
 			},
 		},
@@ -192,7 +221,7 @@ RUN echo "hello"
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := DetectInputsFromDockerfile([]byte(tc.dockerfile), tc.existingInputs, tc.from)
+			result := DetectInputsFromDockerfile([]byte(tc.dockerfile), tc.existingInputs, tc.from, tc.baseImages)
 
 			if diff := cmp.Diff(tc.expected, result); diff != "" {
 				t.Errorf("result differs from expected:\n%s", diff)


### PR DESCRIPTION
Skip Dockerfile registry.ci inputs already covered by `from` + `baseImages`; stop dropping the last unrelated `FROM` when `from` names a different base.

https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_continuous-release-jobs/1797/pull-ci-openshift-continuous-release-jobs-master-images/2060040001508347904

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes Dockerfile registry reference detection in OpenShift CI's pipeline configuration processing, addressing issues with duplicate input detection when base images are explicitly specified.

### Problem Fixed

The CI infrastructure was incorrectly detecting and processing Docker registry references from Dockerfile `FROM` instructions that were already declared through the `baseImages` configuration. This caused:
- Duplicate input detection when a base image was both explicitly configured and referenced in the Dockerfile
- Loss of the last `FROM` instruction in multi-stage builds when the primary `from` configuration pointed to a different base image
- Overly aggressive removal of `FROM` directives that were unrelated to the primary build stage

### Changes

**Core Detection Logic (`pkg/dockerfile/inputs.go`)**:
- Extended `DetectInputsFromDockerfile()` with a new `baseImages` parameter to enable skipping of Dockerfile registry references that are already covered by explicitly configured base images
- Added `matchesFromBaseImage()` helper function that compares Dockerfile references against the base images map by namespace, repository, and tag to determine if a reference should be skipped

**Simplified Registry Extraction (`pkg/dockerfile/extract.go`)**:
- Removed the `from` parameter from `ExtractRegistryReferences()` 
- The function now unconditionally extracts all registry references without special handling for dropping references based on the `from` configuration

**Updated Callers**:
- `pkg/defaults/defaults.go`: Now passes the `baseImages` map when detecting inputs during pipeline configuration processing
- `cmd/registry-replacer/main.go`: Simplified to use the new signature of `ExtractRegistryReferences()`

### Impact

CI operators and users defining multi-stage container builds will see more accurate image input detection. The fix ensures that:
- Base images explicitly declared in configuration are not redundantly detected from Dockerfile instructions
- All `FROM` instructions in multi-stage builds are properly preserved, regardless of which stages are used as the primary build base
- Registry reference detection correctly handles scenarios where the primary build base differs from secondary image references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->