### PR TITLE
fix: quay promotion digest resolve for ocp/4.x

### DIFF
--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -288,14 +288,9 @@ func getTagCommand(tagSpecs []string, loglevel int) string {
 		loglevel, strings.Join(tagSpecs, " "))
 }
 
-// quayProxyTagFromISKey derives the quay-proxy image tag from an IS tag key of the form
-// "namespace/streamname-quay:tag", which is the format produced by getQuayProxyTarget when
-// ImageStreamTagReference.Name is non-empty (the standard ocp promotion case).
-// Example: "ocp/4.21-quay:ovn-kubernetes" → "quay-proxy.ci.openshift.org/openshift/ci:ocp_4.21_ovn-kubernetes".
-//
-// The stream segment must end with "-quay"; we split namespace/stream from tag using the last ":" in
-// the segment after "/". Using strings.Index(rest, "-quay:") is wrong when the promotion Name (stream
-// base before "-quay") itself contains "-quay", e.g. "something-quay-operator-quay:component".
+// quayProxyTagFromISKey derives the quay-proxy floating tag from an IS tag key.
+// Handles "namespace/stream-quay:tag" (4.23+) and consolidated "ocp/4.13:tag" (4.11–4.22).
+// Example: "ocp/4.13:cli" → "quay-proxy.ci.openshift.org/openshift/ci:ocp_4.13_cli".
 func quayProxyTagFromISKey(isTagKey string) (string, bool) {
 	slashIdx := strings.Index(isTagKey, "/")
 	if slashIdx == -1 {
@@ -313,10 +308,14 @@ func quayProxyTagFromISKey(isTagKey string) (string, bool) {
 		return "", false
 	}
 	const quayStreamSuffix = "-quay"
-	if !strings.HasSuffix(streamPart, quayStreamSuffix) {
+	var streamName string
+	if strings.HasSuffix(streamPart, quayStreamSuffix) {
+		streamName = strings.TrimSuffix(streamPart, quayStreamSuffix)
+	} else if api.ConsolidatedQuayPromotionVersion(streamPart) {
+		streamName = streamPart
+	} else {
 		return "", false
 	}
-	streamName := strings.TrimSuffix(streamPart, quayStreamSuffix)
 	if streamName == "" {
 		return "", false
 	}
@@ -333,7 +332,26 @@ func promotionCLIImageInfoFilterOS(nodeArchitectures []string) string {
 	return "linux/amd64"
 }
 
-const quayPromotionDigestTagAttempts = 5
+const (
+	quayPromotionDigestTagAttempts = 5
+	quayPromotionMirrorAttempts    = 5
+)
+
+// getMirrorRetryShell mirrors images with retries and fails the promotion pod if all attempts fail.
+func getMirrorRetryShell(registryConfig string, images []string, loglevel int) string {
+	mirrorCmd := getMirrorCommand(registryConfig, images, loglevel)
+	n := quayPromotionMirrorAttempts
+	return fmt.Sprintf(`for r in {1..%d}; do
+  echo Mirror attempt $r
+  if %s; then break; fi
+  if [ "${r}" -eq %d ]; then
+    exit 1
+  fi
+  backoff=$(($RANDOM %% 120))s
+  echo Sleeping randomized $backoff before retry
+  sleep $backoff
+done`, n, mirrorCmd, n)
+}
 
 // getResolveAndTagRetryShell resolves quay-proxy digest via oc image info and oc tags the IST; retries when QCI moves after mirror.
 func getResolveAndTagRetryShell(registryConfig, quayProxyTag, isTag string, loglevel int, filterByOS string) string {
@@ -374,10 +392,8 @@ func getPromotionPod(imageMirrorTarget map[string]string, timeStr string, namesp
 	var images []string
 	var pruneImages []string
 	var tags []string
-	// resolveAndTagPairs holds [quayProxyTag, isTag] for concrete *-quay IS targets in a
-	// quay promotion step. These are handled post-mirror via oc image info + oc tag so
-	// that spec.from always carries the exact QCI manifest digest rather than a floating tag.
-	// Non-release namespaces use oc tag directly.
+	// resolveAndTagPairs holds [quayProxyTag, isTag] for official ocp IS targets (consolidated
+	// ocp/4.x:tag and legacy *-quay). Resolved post-mirror via oc image info + oc tag.
 	var resolveAndTagPairs [][2]string
 
 	isQuayStep := name == api.PromotionQuayStepName
@@ -419,29 +435,25 @@ func getPromotionPod(imageMirrorTarget map[string]string, timeStr string, namesp
 
 	// Generate mirror commands if there are images to mirror
 	if len(images) > 0 {
-		mirrorCommand := fmt.Sprintf("for r in {1..5}; do echo Mirror attempt $r; %s && break; backoff=$(($RANDOM %% 120))s; echo Sleeping randomized $backoff before retry; sleep $backoff; done", getMirrorCommand(registryConfig, images, 2))
-		commands = append(commands, mirrorCommand)
+		commands = append(commands, getMirrorRetryShell(registryConfig, images, 2))
 	}
 
-	// Generate tag/resolve-and-tag commands.
-	if isQuayStep && (len(tags) > 0 || len(resolveAndTagPairs) > 0) {
-		// Quay promotion: run under set +e so one failure does not block the rest.
-		tagCommands := []string{"set +e"}
-
-		// Template-based IS tags (contain ${component}): batch-then-individual retry, unchanged.
-		if len(tags) > 0 {
-			singleCmd := fmt.Sprintf(retryLoopTemplate, 2, `"Tag attempt $r (all together)"`, getTagCommand(tags, 2), ":")
-			tagCommands = append(tagCommands, singleCmd)
-			for _, tagPair := range tags {
-				individualCmd := fmt.Sprintf(retryLoopTemplate, 3, `"Tag attempt $r (individual)"`, getTagCommand([]string{tagPair}, 2), retryLoopWithBackoff)
-				tagCommands = append(tagCommands, individualCmd)
-			}
-		}
-
-		// Concrete *-quay IS targets: resolve QCI digest post-mirror, then tag.
+	if isQuayStep {
 		for _, pair := range resolveAndTagPairs {
 			quayProxyTag, isTag := pair[0], pair[1]
-			tagCommands = append(tagCommands, getResolveAndTagRetryShell(registryConfig, quayProxyTag, isTag, 2, promotionCLIImageInfoFilterOS(nodeArchitectures)))
+			commands = append(commands, getResolveAndTagRetryShell(registryConfig, quayProxyTag, isTag, 2, promotionCLIImageInfoFilterOS(nodeArchitectures)))
+		}
+	}
+
+	// Non-official IS tags (ci/ci-quay, ${component} templates) keep best-effort batch tagging.
+	if isQuayStep && len(tags) > 0 {
+		tagCommands := []string{"set +e"}
+
+		singleCmd := fmt.Sprintf(retryLoopTemplate, 2, `"Tag attempt $r (all together)"`, getTagCommand(tags, 2), ":")
+		tagCommands = append(tagCommands, singleCmd)
+		for _, tagPair := range tags {
+			individualCmd := fmt.Sprintf(retryLoopTemplate, 3, `"Tag attempt $r (individual)"`, getTagCommand([]string{tagPair}, 2), retryLoopWithBackoff)
+			tagCommands = append(tagCommands, individualCmd)
 		}
 
 		tagCommands = append(tagCommands, "set -e")

--- a/pkg/steps/release/promote_test.go
+++ b/pkg/steps/release/promote_test.go
@@ -1110,6 +1110,22 @@ func TestGetPublicImageReference(t *testing.T) {
 	}
 }
 
+func TestGetMirrorRetryShell(t *testing.T) {
+	regcfg := "/etc/push-secret/.dockerconfigjson"
+	got := getMirrorRetryShell(regcfg, []string{"src=dst"}, 2)
+	for _, sub := range []string{
+		"for r in {1..5}",
+		"Mirror attempt $r",
+		"oc image mirror",
+		`[ "${r}" -eq 5 ]`,
+		"exit 1",
+	} {
+		if !strings.Contains(got, sub) {
+			t.Fatalf("missing substring %q in:\n%s", sub, got)
+		}
+	}
+}
+
 func TestGetResolveAndTagRetryShell(t *testing.T) {
 	regcfg := "/etc/push-secret/.dockerconfigjson"
 	proxyTag := "quay-proxy.ci.openshift.org/openshift/ci:ocp_4.21_ovn-kubernetes"
@@ -1170,8 +1186,20 @@ func TestQuayProxyTagFromISKey(t *testing.T) {
 			wantOK:   false,
 		},
 		{
-			name:     "no -quay: suffix",
+			name:     "consolidated ocp stream",
+			isTagKey: "ocp/4.13:secondary-scheduler-operator",
+			wantTag:  "quay-proxy.ci.openshift.org/openshift/ci:ocp_4.13_secondary-scheduler-operator",
+			wantOK:   true,
+		},
+		{
+			name:     "consolidated 4.21 stream",
 			isTagKey: "ocp/4.21:ovn-kubernetes",
+			wantTag:  "quay-proxy.ci.openshift.org/openshift/ci:ocp_4.21_ovn-kubernetes",
+			wantOK:   true,
+		},
+		{
+			name:     "non-consolidated stream without -quay",
+			isTagKey: "ocp/4.23:ovn-kubernetes",
 			wantOK:   false,
 		},
 	}

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case.yaml
@@ -7,11 +7,17 @@ metadata:
 spec:
   containers:
   - args:
-    - for r in {1..5}; do echo Mirror attempt $r; oc image mirror --loglevel=2 --keep-manifest-list
-      --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:afd71aa3cbbf7d2e00cd8696747b2abf164700147723c657919c20b13d13ec62=registry.ci.openshift.org/ci/applyconfig:latest
-      docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb=registry.ci.openshift.org/ci/bin:latest
-      && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before
-      retry; sleep $backoff; done
+    - |-
+      for r in {1..5}; do
+        echo Mirror attempt $r
+        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:afd71aa3cbbf7d2e00cd8696747b2abf164700147723c657919c20b13d13ec62=registry.ci.openshift.org/ci/applyconfig:latest docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb=registry.ci.openshift.org/ci/bin:latest; then break; fi
+        if [ "${r}" -eq 5 ]; then
+          exit 1
+        fi
+        backoff=$(($RANDOM % 120))s
+        echo Sleeping randomized $backoff before retry
+        sleep $backoff
+      done
     command:
     - /bin/sh
     - -c

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case__arm64_only.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case__arm64_only.yaml
@@ -7,11 +7,17 @@ metadata:
 spec:
   containers:
   - args:
-    - for r in {1..5}; do echo Mirror attempt $r; oc image mirror --loglevel=2 --keep-manifest-list
-      --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:afd71aa3cbbf7d2e00cd8696747b2abf164700147723c657919c20b13d13ec62=registry.ci.openshift.org/ci/applyconfig:latest
-      docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb=registry.ci.openshift.org/ci/bin:latest
-      && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before
-      retry; sleep $backoff; done
+    - |-
+      for r in {1..5}; do
+        echo Mirror attempt $r
+        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:afd71aa3cbbf7d2e00cd8696747b2abf164700147723c657919c20b13d13ec62=registry.ci.openshift.org/ci/applyconfig:latest docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb=registry.ci.openshift.org/ci/bin:latest; then break; fi
+        if [ "${r}" -eq 5 ]; then
+          exit 1
+        fi
+        backoff=$(($RANDOM % 120))s
+        echo Sleeping randomized $backoff before retry
+        sleep $backoff
+      done
     command:
     - /bin/sh
     - -c

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case__multi_architecture.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case__multi_architecture.yaml
@@ -7,11 +7,17 @@ metadata:
 spec:
   containers:
   - args:
-    - for r in {1..5}; do echo Mirror attempt $r; oc image mirror --loglevel=2 --keep-manifest-list
-      --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:afd71aa3cbbf7d2e00cd8696747b2abf164700147723c657919c20b13d13ec62=registry.ci.openshift.org/ci/applyconfig:latest
-      docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb=registry.ci.openshift.org/ci/bin:latest
-      && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before
-      retry; sleep $backoff; done
+    - |-
+      for r in {1..5}; do
+        echo Mirror attempt $r
+        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:afd71aa3cbbf7d2e00cd8696747b2abf164700147723c657919c20b13d13ec62=registry.ci.openshift.org/ci/applyconfig:latest docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb=registry.ci.openshift.org/ci/bin:latest; then break; fi
+        if [ "${r}" -eq 5 ]; then
+          exit 1
+        fi
+        backoff=$(($RANDOM % 120))s
+        echo Sleeping randomized $backoff before retry
+        sleep $backoff
+      done
     command:
     - /bin/sh
     - -c

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay.yaml
@@ -9,7 +9,16 @@ spec:
   - args:
     - |-
       oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ci_a_latest=quay.io/openshift/ci:20240603235401_prune_ci_a_latest quay.io/openshift/ci:ci_c_latest=quay.io/openshift/ci:20240603235401_prune_ci_c_latest || true
-      for r in {1..5}; do echo Mirror attempt $r; oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb=quay.io/openshift/ci:ci_a_latest registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:ddd=quay.io/openshift/ci:ci_c_latest && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before retry; sleep $backoff; done
+      for r in {1..5}; do
+        echo Mirror attempt $r
+        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb=quay.io/openshift/ci:ci_a_latest registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:ddd=quay.io/openshift/ci:ci_c_latest; then break; fi
+        if [ "${r}" -eq 5 ]; then
+          exit 1
+        fi
+        backoff=$(($RANDOM % 120))s
+        echo Sleeping randomized $backoff before retry
+        sleep $backoff
+      done
       set +e
       for r in {1..2}; do echo "Tag attempt $r (all together)"; oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@sha256:ddd ci/${component}-quay:c quay-proxy.ci.openshift.org/openshift/ci@sha256:bbb ci/ci-quay:${component} && break; :; done
       for r in {1..3}; do echo "Tag attempt $r (individual)"; oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@sha256:ddd ci/${component}-quay:c && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before retry; sleep $backoff; done

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_4.12.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_4.12.yaml
@@ -7,14 +7,45 @@ metadata:
 spec:
   containers:
   - args:
-    - |-
+    - |
       oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes-base || true
-      for r in {1..5}; do echo Mirror attempt $r; oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:aaa=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before retry; sleep $backoff; done
-      set +e
-      for r in {1..2}; do echo "Tag attempt $r (all together)"; oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@sha256:aaa ocp/4.12:ovn-kubernetes quay-proxy.ci.openshift.org/openshift/ci@sha256:bbb ocp/4.12:ovn-kubernetes-base && break; :; done
-      for r in {1..3}; do echo "Tag attempt $r (individual)"; oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@sha256:aaa ocp/4.12:ovn-kubernetes && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before retry; sleep $backoff; done
-      for r in {1..3}; do echo "Tag attempt $r (individual)"; oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@sha256:bbb ocp/4.12:ovn-kubernetes-base && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before retry; sleep $backoff; done
-      set -e
+      for r in {1..5}; do
+        echo Mirror attempt $r
+        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:aaa=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base; then break; fi
+        if [ "${r}" -eq 5 ]; then
+          exit 1
+        fi
+        backoff=$(($RANDOM % 120))s
+        echo Sleeping randomized $backoff before retry
+        sleep $backoff
+      done
+      for r in {1..5}; do
+        _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay-proxy.ci.openshift.org/openshift/ci:ocp_4.12_ovn-kubernetes | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+        if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.12:ovn-kubernetes; then
+          break
+        fi
+        echo "promotion-quay: digest-tag failed for ocp/4.12:ovn-kubernetes attempt ${r}/5 (QCI digest may have moved after mirror)" >&2
+        if [ "${r}" -eq 5 ]; then
+          exit 1
+        fi
+        echo "promotion-quay: retrying digest-tag for ocp/4.12:ovn-kubernetes (attempt $((r+1))/5 after randomized backoff)" >&2
+        backoff=$(($RANDOM % 120))s
+        sleep "${backoff}"
+      done
+
+      for r in {1..5}; do
+        _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay-proxy.ci.openshift.org/openshift/ci:ocp_4.12_ovn-kubernetes-base | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+        if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.12:ovn-kubernetes-base; then
+          break
+        fi
+        echo "promotion-quay: digest-tag failed for ocp/4.12:ovn-kubernetes-base attempt ${r}/5 (QCI digest may have moved after mirror)" >&2
+        if [ "${r}" -eq 5 ]; then
+          exit 1
+        fi
+        echo "promotion-quay: retrying digest-tag for ocp/4.12:ovn-kubernetes-base (attempt $((r+1))/5 after randomized backoff)" >&2
+        backoff=$(($RANDOM % 120))s
+        sleep "${backoff}"
+      done
     command:
     - /bin/sh
     - -c

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_multiple_tags.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_multiple_tags.yaml
@@ -7,15 +7,59 @@ metadata:
 spec:
   containers:
   - args:
-    - |-
+    - |
       oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes-base quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes-microshift || true
-      for r in {1..5}; do echo Mirror attempt $r; oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:aaa=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:ccc=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before retry; sleep $backoff; done
-      set +e
-      for r in {1..2}; do echo "Tag attempt $r (all together)"; oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@sha256:aaa ocp/4.21:ovn-kubernetes quay-proxy.ci.openshift.org/openshift/ci@sha256:bbb ocp/4.21:ovn-kubernetes-base quay-proxy.ci.openshift.org/openshift/ci@sha256:ccc ocp/4.21:ovn-kubernetes-microshift && break; :; done
-      for r in {1..3}; do echo "Tag attempt $r (individual)"; oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@sha256:aaa ocp/4.21:ovn-kubernetes && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before retry; sleep $backoff; done
-      for r in {1..3}; do echo "Tag attempt $r (individual)"; oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@sha256:bbb ocp/4.21:ovn-kubernetes-base && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before retry; sleep $backoff; done
-      for r in {1..3}; do echo "Tag attempt $r (individual)"; oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@sha256:ccc ocp/4.21:ovn-kubernetes-microshift && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before retry; sleep $backoff; done
-      set -e
+      for r in {1..5}; do
+        echo Mirror attempt $r
+        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:aaa=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:ccc=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift; then break; fi
+        if [ "${r}" -eq 5 ]; then
+          exit 1
+        fi
+        backoff=$(($RANDOM % 120))s
+        echo Sleeping randomized $backoff before retry
+        sleep $backoff
+      done
+      for r in {1..5}; do
+        _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay-proxy.ci.openshift.org/openshift/ci:ocp_4.21_ovn-kubernetes | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+        if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.21:ovn-kubernetes; then
+          break
+        fi
+        echo "promotion-quay: digest-tag failed for ocp/4.21:ovn-kubernetes attempt ${r}/5 (QCI digest may have moved after mirror)" >&2
+        if [ "${r}" -eq 5 ]; then
+          exit 1
+        fi
+        echo "promotion-quay: retrying digest-tag for ocp/4.21:ovn-kubernetes (attempt $((r+1))/5 after randomized backoff)" >&2
+        backoff=$(($RANDOM % 120))s
+        sleep "${backoff}"
+      done
+
+      for r in {1..5}; do
+        _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay-proxy.ci.openshift.org/openshift/ci:ocp_4.21_ovn-kubernetes-base | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+        if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.21:ovn-kubernetes-base; then
+          break
+        fi
+        echo "promotion-quay: digest-tag failed for ocp/4.21:ovn-kubernetes-base attempt ${r}/5 (QCI digest may have moved after mirror)" >&2
+        if [ "${r}" -eq 5 ]; then
+          exit 1
+        fi
+        echo "promotion-quay: retrying digest-tag for ocp/4.21:ovn-kubernetes-base (attempt $((r+1))/5 after randomized backoff)" >&2
+        backoff=$(($RANDOM % 120))s
+        sleep "${backoff}"
+      done
+
+      for r in {1..5}; do
+        _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay-proxy.ci.openshift.org/openshift/ci:ocp_4.21_ovn-kubernetes-microshift | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+        if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.21:ovn-kubernetes-microshift; then
+          break
+        fi
+        echo "promotion-quay: digest-tag failed for ocp/4.21:ovn-kubernetes-microshift attempt ${r}/5 (QCI digest may have moved after mirror)" >&2
+        if [ "${r}" -eq 5 ]; then
+          exit 1
+        fi
+        echo "promotion-quay: retrying digest-tag for ocp/4.21:ovn-kubernetes-microshift (attempt $((r+1))/5 after randomized backoff)" >&2
+        backoff=$(($RANDOM % 120))s
+        sleep "${backoff}"
+      done
     command:
     - /bin/sh
     - -c

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_non_release_namespace.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_non_release_namespace.yaml
@@ -8,11 +8,33 @@ spec:
   containers:
   - args:
     - |-
-      for r in {1..5}; do echo Mirror attempt $r; oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb=quay.io/openshift/ci:ci_ci_sanitize-prow-jobs registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:aaa=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before retry; sleep $backoff; done
+      for r in {1..5}; do
+        echo Mirror attempt $r
+        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb=quay.io/openshift/ci:ci_ci_sanitize-prow-jobs registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:aaa=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes; then break; fi
+        if [ "${r}" -eq 5 ]; then
+          exit 1
+        fi
+        backoff=$(($RANDOM % 120))s
+        echo Sleeping randomized $backoff before retry
+        sleep $backoff
+      done
+      for r in {1..5}; do
+        _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay-proxy.ci.openshift.org/openshift/ci:ocp_4.21_ovn-kubernetes | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+        if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.21:ovn-kubernetes; then
+          break
+        fi
+        echo "promotion-quay: digest-tag failed for ocp/4.21:ovn-kubernetes attempt ${r}/5 (QCI digest may have moved after mirror)" >&2
+        if [ "${r}" -eq 5 ]; then
+          exit 1
+        fi
+        echo "promotion-quay: retrying digest-tag for ocp/4.21:ovn-kubernetes (attempt $((r+1))/5 after randomized backoff)" >&2
+        backoff=$(($RANDOM % 120))s
+        sleep "${backoff}"
+      done
+
       set +e
-      for r in {1..2}; do echo "Tag attempt $r (all together)"; oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@sha256:bbb ci/ci-quay:sanitize-prow-jobs quay-proxy.ci.openshift.org/openshift/ci@sha256:aaa ocp/4.21:ovn-kubernetes && break; :; done
+      for r in {1..2}; do echo "Tag attempt $r (all together)"; oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@sha256:bbb ci/ci-quay:sanitize-prow-jobs && break; :; done
       for r in {1..3}; do echo "Tag attempt $r (individual)"; oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@sha256:bbb ci/ci-quay:sanitize-prow-jobs && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before retry; sleep $backoff; done
-      for r in {1..3}; do echo "Tag attempt $r (individual)"; oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@sha256:aaa ocp/4.21:ovn-kubernetes && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before retry; sleep $backoff; done
       set -e
     command:
     - /bin/sh


### PR DESCRIPTION
Consolidated `ocp/4.11–4.22` promotion targets now resolve quay-proxy digests post-mirror via `oc image info` + `oc tag`. Mirror retries fail the pod after 5 attempts; official digest-tag runs outside `set +e`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes image promotion for OpenShift's consolidated OCP/4.x release streams in the CI operator. Previously, promotion of container images to Quay had issues with properly resolving digest references after mirroring images between registries.

## What Changed

**Core Issue**: The promotion logic for quay-proxy didn't correctly handle digest resolution when pushing images to consolidated `ocp/4.x` streams (e.g., `ocp/4.13`, `ocp/4.21`). After mirroring an image to quay-proxy, the system couldn't reliably determine the resulting image digest to tag it into release streams.

**Solution**:
- **Dynamic digest resolution**: After mirroring images to quay-proxy, the system now runs `oc image info` to dynamically fetch the actual image digest, then uses `oc tag` to apply the correct tags. This replaces the previous approach of using fixed/hardcoded digests.
- **Improved retry logic**: Mirror operations now have explicit retry handling that fails the pod after 5 attempts (instead of proceeding with stale data). Each retry includes randomized backoff (0-120 second sleep) to avoid thundering-herd effects.
- **Consolidated stream support**: The quay-proxy tag parser now handles both the newer namespaced format (`namespace/stream-quay:tag`) and the consolidated format (`ocp/4.x:tag`).
- **Separate handling for official vs. non-official targets**: Official digest-tag runs now execute outside `set +e` error suppression (ensuring proper failure detection), while template/non-digest tags use best-effort tagging with error suppression.

## Practical Impact

For CI operators: Image promotions to consolidated OCP release streams should now complete more reliably, with proper error handling when mirrors fail and accurate digest tracking after cross-registry operations. Failed mirroring will now properly fail the promotion pod instead of continuing with stale state.

For test fixtures: The shell scripts that execute within promotion pods now contain more structured retry logic with clearer exit/failure semantics, making promotion jobs easier to debug when issues occur.

## Files Modified

- `pkg/steps/release/promote.go` - Added mirror retry helpers, split quay-step flow for official vs. non-official targets, dynamic digest resolution
- `pkg/steps/release/promote_test.go` - New test for mirror retry logic, expanded quay-proxy tag mapping tests
- Multiple test fixtures - Updated shell scripts to use structured retry loops with `oc image info` for dynamic digest resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->