### PR TITLE
fix: spec-first official ocp input import for 4.11–4.22

### DIFF
--- a/pkg/steps/input_image_tag.go
+++ b/pkg/steps/input_image_tag.go
@@ -61,9 +61,9 @@ func (s *inputImageTagStep) Inputs() (api.InputDefinition, error) {
 		}
 		s.imageName = from.Image.Name
 	} else {
-		imageName := api.QuayImageReference(s.config.BaseImage)
-		logrus.Debugf("Resolved %s to %s.", s.config.BaseImage.ISTagName(), imageName)
-		s.imageName = imageName
+		// resolveInputs runs before the job namespace exists; spec-first import runs in run().
+		s.imageName = api.QuayImageReference(s.config.BaseImage)
+		logrus.Debugf("Resolved %s to %s.", s.config.BaseImage.ISTagName(), s.imageName)
 	}
 
 	return api.InputDefinition{s.imageName}, nil
@@ -80,24 +80,30 @@ func (s *inputImageTagStep) run(ctx context.Context) error {
 		return fmt.Errorf("could not resolve inputs for image tag step: %w", err)
 	}
 
-	var objectReferenceName string
+	var from *coreapi.ObjectReference
+	var refPolicy imagev1.TagReferencePolicyType
+	var sourcePullSpec string
+
 	if s.config.ExternalImage != nil {
-		externalPullSpec := externalImageReference(s.config)
-		logrus.Infof("Tagging %s into %s:%s.", externalPullSpec, api.PipelineImageStream, s.config.To)
-		objectReferenceName = externalPullSpec
-	} else {
+		sourcePullSpec = externalImageReference(s.config)
+		logrus.Infof("Tagging %s into %s:%s.", sourcePullSpec, api.PipelineImageStream, s.config.To)
+		from = &coreapi.ObjectReference{Kind: "DockerImage", Name: sourcePullSpec}
+		refPolicy = imagev1.SourceTagReferencePolicy
+	} else if api.IsCreatedForClusterBotJob(s.config.BaseImage.Namespace) {
 		logrus.Infof("Tagging %s into %s:%s.", s.config.BaseImage.ISTagName(), api.PipelineImageStream, s.config.To)
-		objectReferenceName = api.QuayImageReference(s.config.BaseImage)
-	}
-	from := &coreapi.ObjectReference{
-		Kind: "DockerImage",
-		Name: objectReferenceName,
-	}
-	if api.IsCreatedForClusterBotJob(s.config.BaseImage.Namespace) {
 		from = &coreapi.ObjectReference{
 			Kind:      "ImageStreamImage",
 			Name:      fmt.Sprintf("%s@%s", s.config.BaseImage.Name, s.imageName),
 			Namespace: s.config.BaseImage.Namespace,
+		}
+		sourcePullSpec = s.imageName
+		refPolicy = imagev1.SourceTagReferencePolicy
+	} else {
+		logrus.Infof("Tagging %s into %s:%s.", s.config.BaseImage.ISTagName(), api.PipelineImageStream, s.config.To)
+		var err error
+		from, refPolicy, sourcePullSpec, err = s.resolveOfficialImport(ctx)
+		if err != nil {
+			return fmt.Errorf("could not resolve official import for %s: %w", s.config.BaseImage.ISTagName(), err)
 		}
 	}
 
@@ -107,10 +113,8 @@ func (s *inputImageTagStep) run(ctx context.Context) error {
 			Namespace: s.jobSpec.Namespace(),
 		},
 		Tag: &imagev1.TagReference{
-			ReferencePolicy: imagev1.TagReferencePolicy{
-				Type: imagev1.SourceTagReferencePolicy,
-			},
-			From: from,
+			ReferencePolicy: imagev1.TagReferencePolicy{Type: refPolicy},
+			From:            from,
 			ImportPolicy: imagev1.TagImportPolicy{
 				ImportMode: imagev1.ImportModePreserveOriginal,
 			},
@@ -137,7 +141,7 @@ func (s *inputImageTagStep) run(ctx context.Context) error {
 		ImageStreamName: api.PipelineImageStream,
 		TagName:         string(s.config.To),
 		FullTagName:     s.jobSpec.Namespace() + "/" + api.PipelineImageStream + ":" + string(s.config.To),
-		SourceImage:     objectReferenceName,
+		SourceImage:     sourcePullSpec,
 		SourceImageKind: from.Kind,
 		StartTime:       startTime,
 		CompletionTime:  time.Now(),
@@ -145,6 +149,22 @@ func (s *inputImageTagStep) run(ctx context.Context) error {
 	})
 
 	return nil
+}
+
+func (s *inputImageTagStep) resolveOfficialImport(ctx context.Context) (*coreapi.ObjectReference, imagev1.TagReferencePolicyType, string, error) {
+	from, ok, err := utils.ResolveOfficialInputFrom(ctx, s.client, s.jobSpec.Namespace(), s.config.BaseImage)
+	if err != nil {
+		return nil, imagev1.SourceTagReferencePolicy, "", err
+	}
+	if !ok {
+		pullSpec := api.QuayImageReference(s.config.BaseImage)
+		return &coreapi.ObjectReference{Kind: "DockerImage", Name: pullSpec}, imagev1.SourceTagReferencePolicy, pullSpec, nil
+	}
+	pullSpec := from.Name
+	if from.Kind != "DockerImage" && from.Namespace != "" {
+		pullSpec = fmt.Sprintf("%s/%s", from.Namespace, from.Name)
+	}
+	return from, imagev1.LocalTagReferencePolicy, pullSpec, nil
 }
 
 // waitForTagInSpec waits for the tag on the image stream are to show in spec

--- a/pkg/steps/input_image_tag_test.go
+++ b/pkg/steps/input_image_tag_test.go
@@ -136,6 +136,179 @@ func TestInputImageTagStep(t *testing.T) {
 	}
 }
 
+func TestInputImageTagStepOfficialSpec(t *testing.T) {
+	specPullSpec := "quay-proxy.ci.openshift.org/openshift/ci@sha256:deadbeef"
+	baseImage := api.ImageStreamTagReference{
+		Namespace: "ocp",
+		Name:      "4.22",
+		Tag:       "hyperkube",
+	}
+	quayRef := api.QuayImageReference(baseImage)
+	config := api.InputImageTagStepConfiguration{
+		InputImage: api.InputImage{
+			To:        "ocp_4_22_hyperkube",
+			BaseImage: baseImage,
+		},
+	}
+	client := loggingclient.New(fakectrlruntimeclient.NewClientBuilder().WithRuntimeObjects(
+		&imagev1.ImageStream{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ocp", Name: "4.22"},
+			Spec: imagev1.ImageStreamSpec{Tags: []imagev1.TagReference{{
+				Name: "hyperkube",
+				From: &corev1.ObjectReference{Kind: "DockerImage", Name: specPullSpec},
+			}}},
+		},
+		&imagev1.ImageStream{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "target-namespace", Name: api.PipelineImageStream},
+			Spec: imagev1.ImageStreamSpec{
+				LookupPolicy: imagev1.ImageLookupPolicy{Local: true},
+				Tags:         []imagev1.TagReference{{Name: "ocp_4_22_hyperkube"}},
+			},
+			Status: imagev1.ImageStreamStatus{
+				PublicDockerImageRepository: "some-reg/target-namespace/pipeline",
+				Tags: []imagev1.NamedTagEventList{{
+					Tag:   "ocp_4_22_hyperkube",
+					Items: []imagev1.TagEvent{{Image: "sha256:47e2f82dbede8ff990e6e240f82d78830e7558f7b30df7bd8c0693992018b1e3"}},
+				}},
+			},
+		}).Build(), nil)
+	jobspec := &api.JobSpec{}
+	jobspec.SetNamespace("target-namespace")
+	iits := InputImageTagStep(&config, client, jobspec)
+	specification := stepExpectation{
+		name:     "[input:ocp_4_22_hyperkube]",
+		requires: nil,
+		creates:  []api.StepLink{api.InternalImageLink("ocp_4_22_hyperkube")},
+		inputs:   inputsExpectation{values: api.InputDefinition{quayRef}, err: false},
+	}
+	examineStep(t, iits, specification)
+	executeStep(t, iits, executionExpectation{
+		prerun:   doneExpectation{value: false, err: false},
+		runError: false,
+		postrun:  doneExpectation{value: true, err: false},
+	})
+	expectedImageStreamTag := &imagev1.ImageStreamTag{
+		ObjectMeta: metav1.ObjectMeta{Name: "pipeline:ocp_4_22_hyperkube", Namespace: jobspec.Namespace(), ResourceVersion: "1"},
+		Tag: &imagev1.TagReference{
+			From:            &corev1.ObjectReference{Kind: "DockerImage", Name: specPullSpec},
+			ImportPolicy:    imagev1.TagImportPolicy{ImportMode: imagev1.ImportModePreserveOriginal},
+			ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.LocalTagReferencePolicy},
+		},
+	}
+	targetImageStreamTag := &imagev1.ImageStreamTag{}
+	if err := client.Get(context.Background(), ctrlruntimeclient.ObjectKey{Namespace: jobspec.Namespace(), Name: "pipeline:ocp_4_22_hyperkube"}, targetImageStreamTag); err != nil {
+		t.Fatalf("failed to get pipeline tag: %v", err)
+	}
+	if !equality.Semantic.DeepEqual(expectedImageStreamTag, targetImageStreamTag) {
+		t.Errorf("unexpected pipeline tag:\n%s", diff.ObjectReflectDiff(expectedImageStreamTag, targetImageStreamTag))
+	}
+}
+
+func TestInputImageTagStepLegacyStream(t *testing.T) {
+	baseImage := api.ImageStreamTagReference{Namespace: "ocp", Name: "5.0", Tag: "cli"}
+	config := api.InputImageTagStepConfiguration{
+		InputImage: api.InputImage{To: "cli", BaseImage: baseImage},
+	}
+	quayRef := api.QuayImageReference(baseImage)
+	client := loggingclient.New(fakectrlruntimeclient.NewClientBuilder().WithRuntimeObjects(
+		&imagev1.ImageStream{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "target-namespace", Name: api.PipelineImageStream},
+			Spec: imagev1.ImageStreamSpec{
+				LookupPolicy: imagev1.ImageLookupPolicy{Local: true},
+				Tags:         []imagev1.TagReference{{Name: "cli"}},
+			},
+			Status: imagev1.ImageStreamStatus{
+				PublicDockerImageRepository: "some-reg/target-namespace/pipeline",
+				Tags: []imagev1.NamedTagEventList{{
+					Tag:   "cli",
+					Items: []imagev1.TagEvent{{Image: "sha256:47e2f82dbede8ff990e6e240f82d78830e7558f7b30df7bd8c0693992018b1e3"}},
+				}},
+			},
+		}).Build(), nil)
+	jobspec := &api.JobSpec{}
+	jobspec.SetNamespace("target-namespace")
+	iits := InputImageTagStep(&config, client, jobspec)
+	examineStep(t, iits, stepExpectation{
+		name:    "[input:cli]",
+		creates: []api.StepLink{api.InternalImageLink("cli")},
+		inputs:  inputsExpectation{values: api.InputDefinition{quayRef}, err: false},
+	})
+	executeStep(t, iits, executionExpectation{
+		prerun: doneExpectation{value: false, err: false}, runError: false, postrun: doneExpectation{value: true, err: false},
+	})
+	expected := &imagev1.ImageStreamTag{
+		ObjectMeta: metav1.ObjectMeta{Name: "pipeline:cli", Namespace: jobspec.Namespace(), ResourceVersion: "1"},
+		Tag: &imagev1.TagReference{
+			From:            &corev1.ObjectReference{Kind: "DockerImage", Name: quayRef},
+			ImportPolicy:    imagev1.TagImportPolicy{ImportMode: imagev1.ImportModePreserveOriginal},
+			ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.SourceTagReferencePolicy},
+		},
+	}
+	got := &imagev1.ImageStreamTag{}
+	if err := client.Get(context.Background(), ctrlruntimeclient.ObjectKey{Namespace: jobspec.Namespace(), Name: "pipeline:cli"}, got); err != nil {
+		t.Fatalf("get pipeline tag: %v", err)
+	}
+	if !equality.Semantic.DeepEqual(expected, got) {
+		t.Errorf("unexpected tag:\n%s", diff.ObjectReflectDiff(expected, got))
+	}
+}
+
+func TestInputImageTagStepStableFirst(t *testing.T) {
+	baseImage := api.ImageStreamTagReference{Namespace: "ocp", Name: "4.22", Tag: "cli"}
+	config := api.InputImageTagStepConfiguration{
+		InputImage: api.InputImage{To: "ocp_4_22_cli", BaseImage: baseImage},
+	}
+	client := loggingclient.New(fakectrlruntimeclient.NewClientBuilder().WithRuntimeObjects(
+		&imagev1.ImageStream{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "target-namespace", Name: api.StableImageStream},
+			Spec:       imagev1.ImageStreamSpec{Tags: []imagev1.TagReference{{Name: "cli"}}},
+			Status: imagev1.ImageStreamStatus{
+				PublicDockerImageRepository: "registry/target-namespace/stable",
+				Tags: []imagev1.NamedTagEventList{{
+					Tag:   "cli",
+					Items: []imagev1.TagEvent{{Image: "sha256:1111"}},
+				}},
+			},
+		},
+		&imagev1.ImageStream{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "target-namespace", Name: api.PipelineImageStream},
+			Spec: imagev1.ImageStreamSpec{
+				LookupPolicy: imagev1.ImageLookupPolicy{Local: true},
+				Tags:         []imagev1.TagReference{{Name: "ocp_4_22_cli"}},
+			},
+			Status: imagev1.ImageStreamStatus{
+				PublicDockerImageRepository: "registry/target-namespace/pipeline",
+				Tags: []imagev1.NamedTagEventList{{
+					Tag:   "ocp_4_22_cli",
+					Items: []imagev1.TagEvent{{Image: "sha256:2222"}},
+				}},
+			},
+		}).Build(), nil)
+	jobspec := &api.JobSpec{}
+	jobspec.SetNamespace("target-namespace")
+	iits := InputImageTagStep(&config, client, jobspec)
+	executeStep(t, iits, executionExpectation{
+		prerun: doneExpectation{value: false, err: false}, runError: false, postrun: doneExpectation{value: true, err: false},
+	})
+	expected := &imagev1.ImageStreamTag{
+		ObjectMeta: metav1.ObjectMeta{Name: "pipeline:ocp_4_22_cli", Namespace: jobspec.Namespace(), ResourceVersion: "1"},
+		Tag: &imagev1.TagReference{
+			From: &corev1.ObjectReference{
+				Kind: "ImageStreamTag", Name: "stable:cli", Namespace: jobspec.Namespace(),
+			},
+			ImportPolicy:    imagev1.TagImportPolicy{ImportMode: imagev1.ImportModePreserveOriginal},
+			ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.LocalTagReferencePolicy},
+		},
+	}
+	got := &imagev1.ImageStreamTag{}
+	if err := client.Get(context.Background(), ctrlruntimeclient.ObjectKey{Namespace: jobspec.Namespace(), Name: "pipeline:ocp_4_22_cli"}, got); err != nil {
+		t.Fatalf("get pipeline tag: %v", err)
+	}
+	if !equality.Semantic.DeepEqual(expected, got) {
+		t.Errorf("unexpected tag:\n%s", diff.ObjectReflectDiff(expected, got))
+	}
+}
+
 func TestInputImageTagStepExternal(t *testing.T) {
 	config := api.InputImageTagStepConfiguration{
 		InputImage: api.InputImage{

--- a/pkg/steps/release/snapshot.go
+++ b/pkg/steps/release/snapshot.go
@@ -82,22 +82,23 @@ func snapshotStream(ctx context.Context, client loggingclient.LoggingClient, sou
 		}
 		snapshot.ObjectMeta.Annotations[api.ReleaseConfigAnnotation] = value
 	}
-	for _, tag := range integratedStream.Tags {
-		from := &coreapi.ObjectReference{
-			Kind: "DockerImage",
-			Name: api.QuayImageReference(api.ImageStreamTagReference{Namespace: sourceNamespace, Name: sourceName, Tag: tag}),
+	var source *imagev1.ImageStream
+	if !api.IsCreatedForClusterBotJob(sourceNamespace) {
+		source = &imagev1.ImageStream{}
+		if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: sourceNamespace, Name: sourceName}, source); err != nil {
+			return nil, fmt.Errorf("could not resolve source imagestream %s/%s for release %s: %w", sourceNamespace, sourceName, targetRelease, err)
 		}
-		// a special case for cluster-bot
-		if api.IsCreatedForClusterBotJob(sourceNamespace) {
-			source := &imagev1.ImageStream{}
+	}
+	for _, tag := range integratedStream.Tags {
+		if api.IsCreatedForClusterBotJob(sourceNamespace) && source == nil {
+			source = &imagev1.ImageStream{}
 			if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: sourceNamespace, Name: sourceName}, source); err != nil {
 				return nil, fmt.Errorf("could not resolve source imagestream %s/%s for release %s: %w", sourceNamespace, sourceName, targetRelease, err)
 			}
-			if valid, _ := utils.FindStatusTag(source, tag); valid != nil {
-				from = valid
-			} else {
-				continue
-			}
+		}
+		from, ok := snapshotImportSource(sourceNamespace, sourceName, tag, source)
+		if !ok {
+			continue
 		}
 		if refPolicy == nil {
 			sourcePolicy := imagev1.SourceTagReferencePolicy
@@ -122,6 +123,27 @@ func snapshotStream(ctx context.Context, client loggingclient.LoggingClient, sou
 	}
 	logrus.Infof("Imported tags on imagestream (after taking snapshot) %s/%s", created.Namespace, created.Name)
 	return snapshot, nil
+}
+
+func snapshotImportSource(sourceNamespace, sourceName, tag string, source *imagev1.ImageStream) (*coreapi.ObjectReference, bool) {
+	base := api.ImageStreamTagReference{Namespace: sourceNamespace, Name: sourceName, Tag: tag}
+	from := &coreapi.ObjectReference{
+		Kind: "DockerImage",
+		Name: api.QuayImageReference(base),
+	}
+	if api.IsCreatedForClusterBotJob(sourceNamespace) {
+		if valid, _ := utils.FindStatusTag(source, tag); valid != nil {
+			return valid, true
+		}
+		return nil, false
+	}
+	if api.ConsolidatedQuayPromotionVersion(sourceName) && source != nil {
+		return utils.OfficialImageTagFrom(source, base), true
+	}
+	if ref := utils.FindSpecTag(source, tag); ref != nil && ref.Kind == "DockerImage" && ref.Name != "" {
+		from.Name = ref.Name
+	}
+	return from, true
 }
 
 func (r *releaseSnapshotStep) Name() string {

--- a/pkg/steps/release/snapshot_test.go
+++ b/pkg/steps/release/snapshot_test.go
@@ -1,0 +1,89 @@
+package release
+
+import (
+	"testing"
+
+	coreapi "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	imagev1 "github.com/openshift/api/image/v1"
+
+	"github.com/openshift/ci-tools/pkg/api"
+)
+
+func TestSnapshotImportSource(t *testing.T) {
+	specPull := "quay-proxy.ci.openshift.org/openshift/ci@sha256:abc"
+	base := api.ImageStreamTagReference{Namespace: "ocp", Name: "4.18", Tag: "cluster-version-operator"}
+	tests := []struct {
+		name      string
+		namespace string
+		stream    string
+		tag       string
+		source    *imagev1.ImageStream
+		wantOK    bool
+		wantFrom  *coreapi.ObjectReference
+	}{
+		{
+			name:   "consolidated spec first",
+			stream: "4.18",
+			tag:    base.Tag,
+			source: &imagev1.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ocp", Name: "4.18"},
+				Spec: imagev1.ImageStreamSpec{Tags: []imagev1.TagReference{{
+					Name: base.Tag,
+					From: &coreapi.ObjectReference{Kind: "DockerImage", Name: specPull},
+				}}},
+			},
+			wantOK:   true,
+			wantFrom: &coreapi.ObjectReference{Kind: "DockerImage", Name: specPull},
+		},
+		{
+			name:     "consolidated quay fallback",
+			stream:   "4.18",
+			tag:      base.Tag,
+			source:   &imagev1.ImageStream{ObjectMeta: metav1.ObjectMeta{Namespace: "ocp", Name: "4.18"}},
+			wantOK:   true,
+			wantFrom: &coreapi.ObjectReference{Kind: "DockerImage", Name: api.QuayImageReference(base)},
+		},
+		{
+			name:   "non-consolidated spec docker",
+			stream: "4.23",
+			tag:    "cli",
+			source: &imagev1.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ocp", Name: "4.23"},
+				Spec: imagev1.ImageStreamSpec{Tags: []imagev1.TagReference{{
+					Name: "cli",
+					From: &coreapi.ObjectReference{Kind: "DockerImage", Name: specPull},
+				}}},
+			},
+			wantOK:   true,
+			wantFrom: &coreapi.ObjectReference{Kind: "DockerImage", Name: specPull},
+		},
+		{
+			name:     "default quay float",
+			stream:   "4.23",
+			tag:      "cli",
+			source:   &imagev1.ImageStream{ObjectMeta: metav1.ObjectMeta{Namespace: "ocp", Name: "4.23"}},
+			wantOK:   true,
+			wantFrom: &coreapi.ObjectReference{Kind: "DockerImage", Name: api.QuayImageReference(api.ImageStreamTagReference{Namespace: "ocp", Name: "4.23", Tag: "cli"})},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			namespace := tt.namespace
+			if namespace == "" {
+				namespace = "ocp"
+			}
+			from, ok := snapshotImportSource(namespace, tt.stream, tt.tag, tt.source)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if from.Kind != tt.wantFrom.Kind || from.Name != tt.wantFrom.Name {
+				t.Fatalf("from = %+v, want %+v", from, tt.wantFrom)
+			}
+		})
+	}
+}

--- a/pkg/steps/utils/image.go
+++ b/pkg/steps/utils/image.go
@@ -43,14 +43,24 @@ func ImageDigestFor(client ctrlruntimeclient.Client, namespace func() string, na
 		if len(image) > 0 {
 			return fmt.Sprintf("%s@%s", registry, image), nil
 		}
-		if ref == nil && findSpecTag(is, tag) == nil {
+		if ref == nil && !hasSpecTag(is, tag) {
 			return "", fmt.Errorf("image stream %q has no tag %q in spec or status", name, tag)
 		}
 		return fmt.Sprintf("%s:%s", registry, tag), nil
 	}
 }
 
-func findSpecTag(is *imagev1.ImageStream, tag string) *coreapi.ObjectReference {
+func hasSpecTag(is *imagev1.ImageStream, tag string) bool {
+	for _, t := range is.Spec.Tags {
+		if t.Name == tag {
+			return true
+		}
+	}
+	return false
+}
+
+// FindSpecTag returns the spec tag's From reference when present.
+func FindSpecTag(is *imagev1.ImageStream, tag string) *coreapi.ObjectReference {
 	for _, t := range is.Spec.Tags {
 		if t.Name != tag {
 			continue
@@ -58,6 +68,44 @@ func findSpecTag(is *imagev1.ImageStream, tag string) *coreapi.ObjectReference {
 		return t.From
 	}
 	return nil
+}
+
+// OfficialImageTagFrom returns an import source from spec, then status, then quay-proxy.
+func OfficialImageTagFrom(source *imagev1.ImageStream, base api.ImageStreamTagReference) *coreapi.ObjectReference {
+	if source != nil {
+		if ref := FindSpecTag(source, base.Tag); ref != nil && ref.Name != "" {
+			return ref
+		}
+		if ref, _ := FindStatusTag(source, base.Tag); ref != nil && ref.Name != "" {
+			return ref
+		}
+	}
+	return &coreapi.ObjectReference{Kind: "DockerImage", Name: api.QuayImageReference(base)}
+}
+
+// ResolveOfficialInputFrom resolves consolidated ocp inputs: stable in job ns, then spec/status/quay on source IS.
+// When ok is false, callers use QuayImageReference with Source policy (e.g. 4.23, 5.0).
+func ResolveOfficialInputFrom(ctx context.Context, client ctrlruntimeclient.Client, jobNamespace string, base api.ImageStreamTagReference) (*coreapi.ObjectReference, bool, error) {
+	if !api.ConsolidatedQuayPromotionVersion(base.Name) || !api.RefersToOfficialImage(base.Namespace, api.WithoutOKD) {
+		return nil, false, nil
+	}
+	stable := &imagev1.ImageStream{}
+	if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: jobNamespace, Name: api.StableImageStream}, stable); err == nil {
+		if _, exists, _ := util.ResolvePullSpec(stable, base.Tag, true); exists {
+			return &coreapi.ObjectReference{
+				Kind:      "ImageStreamTag",
+				Namespace: jobNamespace,
+				Name:      fmt.Sprintf("%s:%s", api.StableImageStream, base.Tag),
+			}, true, nil
+		}
+	} else if !kerrors.IsNotFound(err) {
+		return nil, false, fmt.Errorf("get stable imagestream in %s: %w", jobNamespace, err)
+	}
+	source := &imagev1.ImageStream{}
+	if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: base.Namespace, Name: base.Name}, source); err != nil && !kerrors.IsNotFound(err) {
+		return nil, false, fmt.Errorf("get source imagestream %s: %w", base.ISTagName(), err)
+	}
+	return OfficialImageTagFrom(source, base), true, nil
 }
 
 // FindStatusTag returns an object reference to a tag if

--- a/pkg/steps/utils/image_test.go
+++ b/pkg/steps/utils/image_test.go
@@ -11,6 +11,7 @@ import (
 
 	coreapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -18,12 +19,91 @@ import (
 
 	imagev1 "github.com/openshift/api/image/v1"
 
+	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
 func init() {
 	if err := imagev1.AddToScheme(scheme.Scheme); err != nil {
 		panic(fmt.Sprintf("failed to register imagev1 scheme: %v", err))
+	}
+}
+
+func TestResolveOfficialInputFrom(t *testing.T) {
+	specPull := "quay-proxy.ci.openshift.org/openshift/ci@sha256:abc"
+	base := api.ImageStreamTagReference{Namespace: "ocp", Name: "4.22", Tag: "hyperkube"}
+	tests := []struct {
+		name     string
+		base     api.ImageStreamTagReference
+		objects  []runtime.Object
+		wantOK   bool
+		wantFrom *coreapi.ObjectReference
+	}{
+		{name: "non-consolidated", base: api.ImageStreamTagReference{Namespace: "ocp", Name: "5.0", Tag: "cli"}, wantOK: false},
+		{
+			name: "spec docker",
+			base: base,
+			objects: []runtime.Object{&imagev1.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ocp", Name: "4.22"},
+				Spec: imagev1.ImageStreamSpec{Tags: []imagev1.TagReference{{
+					Name: "hyperkube",
+					From: &coreapi.ObjectReference{Kind: "DockerImage", Name: specPull},
+				}}},
+			}},
+			wantOK:   true,
+			wantFrom: &coreapi.ObjectReference{Kind: "DockerImage", Name: specPull},
+		},
+		{
+			name: "spec image stream image",
+			base: api.ImageStreamTagReference{Namespace: "ocp", Name: "4.22", Tag: "cli"},
+			objects: []runtime.Object{&imagev1.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ocp", Name: "4.22"},
+				Spec: imagev1.ImageStreamSpec{Tags: []imagev1.TagReference{{
+					Name: "cli",
+					From: &coreapi.ObjectReference{Kind: "ImageStreamImage", Name: "4.22@sha256:deadbeef", Namespace: "ocp"},
+				}}},
+			}},
+			wantOK:   true,
+			wantFrom: &coreapi.ObjectReference{Kind: "ImageStreamImage", Name: "4.22@sha256:deadbeef", Namespace: "ocp"},
+		},
+		{
+			name:     "quay fallback",
+			base:     base,
+			wantOK:   true,
+			wantFrom: &coreapi.ObjectReference{Kind: "DockerImage", Name: api.QuayImageReference(base)},
+		},
+		{
+			name: "stable first",
+			base: api.ImageStreamTagReference{Namespace: "ocp", Name: "4.22", Tag: "cli"},
+			objects: []runtime.Object{&imagev1.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "job-ns", Name: api.StableImageStream},
+				Spec:       imagev1.ImageStreamSpec{Tags: []imagev1.TagReference{{Name: "cli"}}},
+				Status: imagev1.ImageStreamStatus{
+					PublicDockerImageRepository: "registry/job-ns/stable",
+					Tags:                        []imagev1.NamedTagEventList{{Tag: "cli", Items: []imagev1.TagEvent{{Image: "sha256:1111"}}}},
+				},
+			}},
+			wantOK:   true,
+			wantFrom: &coreapi.ObjectReference{Kind: "ImageStreamTag", Name: "stable:cli", Namespace: "job-ns"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := fakectrlruntimeclient.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(tt.objects...).Build()
+			from, ok, err := ResolveOfficialInputFrom(context.Background(), client, "job-ns", tt.base)
+			if err != nil {
+				t.Fatalf("ResolveOfficialInputFrom() error = %v", err)
+			}
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if from.Kind != tt.wantFrom.Kind || from.Name != tt.wantFrom.Name || from.Namespace != tt.wantFrom.Namespace {
+				t.Fatalf("from = %+v, want %+v", from, tt.wantFrom)
+			}
+		})
 	}
 }
 
@@ -458,5 +538,39 @@ func TestGetEvaluator(t *testing.T) {
 				t.Errorf("%s: actual does not match expected, diff: %s", testCase.name, diff)
 			}
 		}
+	}
+}
+
+func TestImageDigestForSpecTagWithoutFrom(t *testing.T) {
+	is := &imagev1.ImageStream{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "pipeline"},
+		Spec: imagev1.ImageStreamSpec{
+			Tags: []imagev1.TagReference{{Name: "pending"}},
+		},
+		Status: imagev1.ImageStreamStatus{
+			PublicDockerImageRepository: "registry/ns/pipeline",
+		},
+	}
+	client := fakectrlruntimeclient.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(is).Build()
+	got, err := ImageDigestFor(client, func() string { return "ns" }, "pipeline", "pending")()
+	if err != nil {
+		t.Fatalf("ImageDigestFor() error = %v", err)
+	}
+	if got != "registry/ns/pipeline:pending" {
+		t.Fatalf("ImageDigestFor() = %q, want %q", got, "registry/ns/pipeline:pending")
+	}
+}
+
+func TestImageDigestForMissingTag(t *testing.T) {
+	is := &imagev1.ImageStream{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "pipeline"},
+		Status: imagev1.ImageStreamStatus{
+			PublicDockerImageRepository: "registry/ns/pipeline",
+		},
+	}
+	client := fakectrlruntimeclient.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(is).Build()
+	_, err := ImageDigestFor(client, func() string { return "ns" }, "pipeline", "missing")()
+	if err == nil {
+		t.Fatal("ImageDigestFor() expected error for missing tag")
 	}
 }

--- a/test/e2e/multi-stage/integration-releases.yaml
+++ b/test/e2e/multi-stage/integration-releases.yaml
@@ -36,14 +36,14 @@ tests:
               cpu: 10m
               memory: 10Mi
         - as: latest
-          commands: grep -q 'v1.0.0' <<<"$( cluster-version-operator version )"
+          commands: grep -q '4.18' <<<"$( cluster-version-operator version )"
           from: "release:latest"
           resources:
             requests:
               cpu: 10m
               memory: 10Mi
         - as: latest-cli
-          commands: grep -q 'v4.2.0-alpha' <<<"$( oc version )" # oc has a broken version in integration streams
+          commands: grep -q '4.18' <<<"$( oc version )"
           from: "stable:cli"
           resources:
             requests:


### PR DESCRIPTION
Official `ocp/4.11–4.22` inputs resolve from `stable:` in the job ns, then spec/status `@sha256` on the source IS, with `LocalTagReferencePolicy` for pipeline tags. Legacy streams (4.23, 5.0) keep quay-proxy + Source policy.

https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-api-2854-openshift-installer-10566-openshift-origin-31211-openshift-machine-config-operator-6076-ci-5.0-e2e-aws-ovn-techpreview-serial-3of3/2060029597415641088#1:build-log.txt%3A150-157


dependent on https://github.com/openshift/ci-tools/pull/5216 
/hold

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR changes how ci-operator resolves and imports official OpenShift Container Platform (OCP) base images for versions 4.11–4.22 to a spec-first flow: prefer a job-namespace stable:<tag> ImageStream, otherwise prefer the source ImageStream spec/status digest (`@sha256`), and create pipeline ImageStreamTags that reference the digest (LocalTagReferencePolicy). Legacy streams (4.23 and 5.0) remain on the existing quay-proxy SourceTagReferencePolicy. The change depends on PR `#5216`.

## Affected component and runtime behavior

- Component: ci-operator (image resolution / input import).
- Behavior changes:
  - For OCP 4.11–4.22:
    - Look for stable:<tag> in the job namespace first.
    - If not found, read the source ImageStream spec/status and import by digest (`@sha256`) when available.
    - Create pipeline ImageStreamTag entries with LocalTagReferencePolicy so pipeline tags point at the resolved digest (improves determinism).
    - Avoid fallback to quay-proxy pull-through when official-input semantics apply.
  - For legacy streams (4.23 and 5.0): unchanged — continue using quay-proxy with SourceTagReferencePolicy.

## Key implementation notes

- input_image_tag.go
  - Refactors run() to compute the ImageStreamTag From, ReferencePolicy, and source pull spec across three cases (external, cluster-bot, official).
  - Adds resolveOfficialImport that delegates to utils.ResolveOfficialInputFrom and chooses LocalTagReferencePolicy for resolved official inputs.
  - metrics.TagImportEvent now records the computed source pull spec.
- utils/image.go
  - Introduces exported helpers: ResolveOfficialInputFrom, OfficialImageTagFrom, and FindSpecTag.
  - ImageDigestFor now validates spec presence and surfaces errors when a tag is absent; spec-tag lookups are exposed via FindSpecTag.
  - ResolveOfficialInputFrom implements the "stable first" job-namespace lookup, source ImageStream loading when needed, and Quay fallback.
- release/snapshot.go
  - Consolidates and reuses source ImageStream resolution for snapshot creation and centralizes per-tag import-source selection into snapshotImportSource.
- Tests and CI
  - Adds unit tests covering spec-first resolution, stable-first behavior, legacy fallback, ImageDigestFor edge cases, and snapshotImportSource.
  - Updates an e2e multi-stage test to assert "latest" (4.18) in integration-releases.yaml.
  - Author ran e2e; PR references CI logs demonstrating behavior.

## Practical impact for CI users and operators

- Jobs targeting OCP 4.11–4.22 will prefer importing inputs by digest (via job-namespace stable:<tag> or source ImageStream spec/status), improving reproducibility and reducing reliance on quay-proxy.
- Existing behavior for legacy streams is preserved.
- Operators should merge PR `#5216` alongside this change to ensure the new resolution path functions as intended.

## Meta / workflow notes

- The PR was held pending a dependent PR (`#5216`) and later unheld.
- Reviewed and approved (/lgtm) by danilo-gemoli and hector-vido; author triggered end-to-end tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->