### PR TITLE
ROSAENG-6811: Allow Gangway pod_spec_options.envs to override step parameters

### DIFF
--- a/pkg/steps/multi_stage/gen.go
+++ b/pkg/steps/multi_stage/gen.go
@@ -2,6 +2,7 @@ package multi_stage
 
 import (
 	"fmt"
+	"os"
 	"path"
 	"strings"
 
@@ -408,6 +409,9 @@ func (s *multiStageTestStep) generateParams(env []api.StepParameter) []coreapi.E
 			value = *env.Default
 		}
 		if v, ok := s.env[env.Name]; ok {
+			value = v
+		}
+		if v := os.Getenv(env.Name); v != "" {
 			value = v
 		}
 		ret = append(ret, coreapi.EnvVar{Name: env.Name, Value: value})

--- a/pkg/steps/multi_stage/gen_test.go
+++ b/pkg/steps/multi_stage/gen_test.go
@@ -785,3 +785,33 @@ func TestSetSecurityContexts(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateParamsEnvOverride(t *testing.T) {
+	defaultVal := "from-default"
+	params := []api.StepParameter{
+		{Name: "WITH_DEFAULT", Default: &defaultVal},
+		{Name: "NO_DEFAULT"},
+		{Name: "ENV_OVERRIDE", Default: &defaultVal},
+		{Name: "EMPTY_ENV_NO_OVERRIDE", Default: &defaultVal},
+	}
+	s := &multiStageTestStep{
+		env: api.TestEnvironment{
+			"NO_DEFAULT":   "from-config",
+			"ENV_OVERRIDE": "from-config",
+		},
+	}
+	t.Setenv("ENV_OVERRIDE", "from-pod-env")
+	// Empty env var should not override
+	t.Setenv("EMPTY_ENV_NO_OVERRIDE", "")
+
+	got := s.generateParams(params)
+	expected := []coreapi.EnvVar{
+		{Name: "WITH_DEFAULT", Value: "from-default"},
+		{Name: "NO_DEFAULT", Value: "from-config"},
+		{Name: "ENV_OVERRIDE", Value: "from-pod-env"},
+		{Name: "EMPTY_ENV_NO_OVERRIDE", Value: "from-default"},
+	}
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("generateParams env override precedence mismatch:\n%s", diff.ObjectReflectDiff(expected, got))
+	}
+}


### PR DESCRIPTION
## Summary

When Gangway triggers a periodic job with pod_spec_options.envs, those env vars are appended to the ci-operator pod. However, ci-operator builds step container envs from its YAML config (TestEnvironment map), not from os.Getenv(). Runtime env overrides from Gangway never reach step containers.

This PR adds a check to generateParams in pkg/steps/multi_stage/gen.go: after checking the config env value, check os.Getenv for the same parameter name. If set, the pod-level env var takes precedence.

**Safety**: Only env vars matching declared step parameter names (from the step ref env list) are considered. Arbitrary pod env vars cannot leak into steps.

**Use case**: SAPM promotion pipelines trigger Prow periodic jobs via Gangway to run operator e2e tests. Different OCM environments need different OCM_LOGIN_ENV values. Without this change, each combination needs a separate periodic job. With it, one periodic per operator is sufficient.

## Test plan

- Existing tests pass (go test ./pkg/steps/multi_stage/...)
- Verify with a Gangway-triggered periodic that passes OCM_LOGIN_ENV=integration via pod_spec_options.envs

Jira: https://redhat.atlassian.net/browse/ROSAENG-6811

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR changes ci-operator's multi-stage step parameter resolution so pod-level environment variables (e.g., those injected via Gangway's pod_spec_options.envs) can override step parameter values when the env var name matches a declared step parameter.

## What Changed

- generateParams in pkg/steps/multi_stage/gen.go now checks os.Getenv for each step parameter name after computing the parameter value from defaults and step-configured envs. If a non-empty pod env var exists for that parameter name, its value is used instead.
- A unit test (TestGenerateParamsEnvOverride) in pkg/steps/multi_stage/gen_test.go verifies that:
  - a pod env var overrides both the step config env and the parameter default,
  - step config env is used when the pod env var is absent,
  - an empty pod env var does not override a parameter default.

## Practical Impact for CI Users / Operators

ci-operator jobs triggered via Gangway can now pass runtime environment overrides (for example OCM_LOGIN_ENV) through pod_spec_options.envs and have those values reach step containers without changing ci-operator YAML. This enables scenarios like SAPM promotion pipelines that use Gangway to trigger periodic jobs across multiple environments without creating separate periodic jobs for each environment.

## Component Affected

- Component: ci-operator (multi-stage step parameter generation)
- Behavioral change: step parameter value precedence now includes process/pod environment variables (but only for names declared as step parameters).

## Safety & Scope

- Only env vars whose names match declared step parameter names are considered; arbitrary pod envs are not propagated.
- Change surface is minimal (small code addition in generateParams) and includes a focused unit test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->