### PR TITLE
DPTP-3787: fix tolerate missing ocp source IS in release snapshot

### DIFF
--- a/pkg/steps/release/snapshot.go
+++ b/pkg/steps/release/snapshot.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	coreapi "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -86,7 +87,10 @@ func snapshotStream(ctx context.Context, client loggingclient.LoggingClient, sou
 	if !api.IsCreatedForClusterBotJob(sourceNamespace) {
 		source = &imagev1.ImageStream{}
 		if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: sourceNamespace, Name: sourceName}, source); err != nil {
-			return nil, fmt.Errorf("could not resolve source imagestream %s/%s for release %s: %w", sourceNamespace, sourceName, targetRelease, err)
+			if !kerrors.IsNotFound(err) {
+				return nil, fmt.Errorf("could not resolve source imagestream %s/%s for release %s: %w", sourceNamespace, sourceName, targetRelease, err)
+			}
+			source = nil
 		}
 	}
 	for _, tag := range integratedStream.Tags {
@@ -137,11 +141,13 @@ func snapshotImportSource(sourceNamespace, sourceName, tag string, source *image
 		}
 		return nil, false
 	}
-	if api.ConsolidatedQuayPromotionVersion(sourceName) && source != nil {
+	if api.ConsolidatedQuayPromotionVersion(sourceName) {
 		return utils.OfficialImageTagFrom(source, base), true
 	}
-	if ref := utils.FindSpecTag(source, tag); ref != nil && ref.Kind == "DockerImage" && ref.Name != "" {
-		from.Name = ref.Name
+	if source != nil {
+		if ref := utils.FindSpecTag(source, tag); ref != nil && ref.Kind == "DockerImage" && ref.Name != "" {
+			from.Name = ref.Name
+		}
 	}
 	return from, true
 }

--- a/pkg/steps/release/snapshot_test.go
+++ b/pkg/steps/release/snapshot_test.go
@@ -46,6 +46,13 @@ func TestSnapshotImportSource(t *testing.T) {
 			wantFrom: &coreapi.ObjectReference{Kind: "DockerImage", Name: api.QuayImageReference(base)},
 		},
 		{
+			name:     "consolidated missing source imagestream",
+			stream:   "4.22",
+			tag:      base.Tag,
+			wantOK:   true,
+			wantFrom: &coreapi.ObjectReference{Kind: "DockerImage", Name: api.QuayImageReference(api.ImageStreamTagReference{Namespace: "ocp", Name: "4.22", Tag: base.Tag})},
+		},
+		{
 			name:   "non-consolidated spec docker",
 			stream: "4.23",
 			tag:    "cli",


### PR DESCRIPTION
https://search.dptools.openshift.org/?search=Reporting+job+state.*with+reason.*executing_graph:step_failed:creating_release_images&maxAge=6h&context=1&type=build-log&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

Fixes issue introduced by #5217 on Saturday

/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Fix for Release Snapshot Source ImageStream Recovery

This PR restores tolerant behavior in the release snapshot step so CI jobs no longer hard-fail when the official OCP source ImageStream (e.g., ocp/4.22) is missing from build clusters.

What changed (practical effect)
- Component affected: release snapshot logic used by the release-inputs step in ci-operator (pkg/steps/release).
- When the source ImageStream cannot be GETted and the error is a Kubernetes NotFound, snapshotStream now treats the source as absent (source = nil) and continues instead of failing the step. Other error types still fail.
- snapshotImportSource was reorganized so consolidated Quay promotion paths are evaluated independently of the presence of the source ImageStream and the spec tag lookup is only performed when a source exists. As a result, when the source ImageStream is absent, tag resolution falls back to a Quay-derived DockerImage reference (api.QuayImageReference).
- A unit test was added to verify behavior for consolidated streams when the source ImageStream is missing, asserting fallback to the Quay proxy reference.

Impact for CI users/operators
- Jobs that rely on official OCP ImageStreams that only exist on app.ci (and are not mirrored to build clusters) will now proceed: the [release-inputs:initial] step will gracefully fall back to Quay proxy references instead of hard-failing. This restores prior behavior for tag resolution and allows periodic and PR jobs that depend on unpinned float tags and Quay promotion fallbacks to run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->