### PR TITLE
private-org-sync: add --exclude-branch-pattern flag

### DIFF
--- a/cmd/private-org-sync/main.go
+++ b/cmd/private-org-sync/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -44,6 +45,9 @@ type options struct {
 	confirm              bool
 	failOnNonexistentDst bool
 	debug                bool
+
+	excludeBranchPatterns   privateorg.ArrayFlags
+	compiledExcludePatterns []*regexp.Regexp
 }
 
 const defaultPrefix = "https://github.com"
@@ -95,11 +99,29 @@ func (o *options) validate() []error {
 		errs = append(errs, fmt.Errorf("--git-email is not specified"))
 	}
 
+	for _, pattern := range o.excludeBranchPatterns {
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("--exclude-branch-pattern %q is not a valid regex: %w", pattern, err))
+			continue
+		}
+		o.compiledExcludePatterns = append(o.compiledExcludePatterns, re)
+	}
+
 	if err := o.WhitelistOptions.Validate(); err != nil {
 		errs = append(errs, err)
 
 	}
 	return errs
+}
+
+func (o *options) isBranchExcluded(branch string) bool {
+	for _, re := range o.compiledExcludePatterns {
+		if re.MatchString(branch) {
+			return true
+		}
+	}
+	return false
 }
 
 func gatherOptions() options {
@@ -114,6 +136,7 @@ func gatherOptions() options {
 	fs.StringVar(&o.org, "only-org", "", "Mirror only repos that belong to this org")
 	fs.StringVar(&o.repo, "only-repo", "", "Mirror only a single repo")
 	fs.Var(&o.flattenOrgs, "flatten-org", "Organizations whose repos should not have org prefix (can be specified multiple times)")
+	fs.Var(&o.excludeBranchPatterns, "exclude-branch-pattern", "Regex pattern for branches to exclude from sync (can be specified multiple times)")
 	fs.StringVar(&o.gitDir, "git-dir", "", "Path to directory in which to perform Git operations")
 
 	fs.StringVar(&o.gitName, "git-name", "", "The name to use on the git merge command.")
@@ -632,7 +655,7 @@ func main() {
 
 	var errs []error
 
-	locations, whitelistErrors := getWhitelistedLocations(o.WhitelistOptions.WhitelistConfig.Whitelist, syncer.git, o.prefix, token)
+	locations, whitelistErrors := getWhitelistedLocations(o.WhitelistOptions.WhitelistConfig.Whitelist, syncer.git, o.prefix, token, o.isBranchExcluded)
 	errs = append(errs, whitelistErrors...)
 
 	callback := func(_ *api.ReleaseBuildConfiguration, repoInfo *config.Info) error {
@@ -707,7 +730,7 @@ func main() {
 	}
 }
 
-func getWhitelistedLocations(whitelist map[string][]string, git gitFunc, prefix, token string) (map[location]struct{}, []error) {
+func getWhitelistedLocations(whitelist map[string][]string, git gitFunc, prefix, token string, isBranchExcluded func(string) bool) (map[location]struct{}, []error) {
 	var errs []error
 	locations := make(map[location]struct{})
 
@@ -731,6 +754,10 @@ func getWhitelistedLocations(whitelist map[string][]string, git gitFunc, prefix,
 			}
 
 			for branch := range branches {
+				if isBranchExcluded(branch) {
+					logrus.WithFields(logrus.Fields{"org": org, "repo": repo, "branch": branch}).Debug("Skipping excluded branch")
+					continue
+				}
 				locations[location{org: org, repo: repo, branch: branch}] = struct{}{}
 			}
 		}

--- a/cmd/private-org-sync/main_test.go
+++ b/cmd/private-org-sync/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -881,4 +882,71 @@ func TestDestinationNaming(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsBranchExcluded(t *testing.T) {
+	o := &options{
+		compiledExcludePatterns: []*regexp.Regexp{
+			regexp.MustCompile(`^konflux/`),
+			regexp.MustCompile(`^dependabot/`),
+		},
+	}
+
+	testCases := []struct {
+		branch   string
+		excluded bool
+	}{
+		{branch: "main", excluded: false},
+		{branch: "release-4.18", excluded: false},
+		{branch: "konflux/mintmaker/release-1.6/eslint-plugin-react-7.x", excluded: true},
+		{branch: "dependabot/npm/lodash-4.17.21", excluded: true},
+		{branch: "feature/konflux-support", excluded: false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.branch, func(t *testing.T) {
+			if got := o.isBranchExcluded(tc.branch); got != tc.excluded {
+				t.Errorf("isBranchExcluded(%q) = %v, want %v", tc.branch, got, tc.excluded)
+			}
+		})
+	}
+}
+
+func TestGetWhitelistedLocationsExcludesBranches(t *testing.T) {
+	git := func(_ *logrus.Entry, _ string, command ...string) (string, int, error) {
+		if command[0] == "ls-remote" {
+			return "sha1 refs/heads/main\nsha2 refs/heads/release-4.18\nsha3 refs/heads/konflux/mintmaker/dep-update\n", 0, nil
+		}
+		return "", 0, nil
+	}
+
+	excludeKonflux := func(branch string) bool {
+		return regexp.MustCompile(`^konflux/`).MatchString(branch)
+	}
+	noExclusions := func(string) bool { return false }
+
+	whitelist := map[string][]string{"org": {"repo"}}
+
+	t.Run("with exclusion pattern", func(t *testing.T) {
+		locations, errs := getWhitelistedLocations(whitelist, git, defaultPrefix, "", excludeKonflux)
+		if len(errs) > 0 {
+			t.Fatalf("unexpected errors: %v", errs)
+		}
+		if len(locations) != 2 {
+			t.Errorf("expected 2 locations, got %d: %v", len(locations), locations)
+		}
+		excluded := location{org: "org", repo: "repo", branch: "konflux/mintmaker/dep-update"}
+		if _, ok := locations[excluded]; ok {
+			t.Error("konflux branch should have been excluded")
+		}
+	})
+
+	t.Run("without exclusion pattern", func(t *testing.T) {
+		locations, errs := getWhitelistedLocations(whitelist, git, defaultPrefix, "", noExclusions)
+		if len(errs) > 0 {
+			t.Fatalf("unexpected errors: %v", errs)
+		}
+		if len(locations) != 3 {
+			t.Errorf("expected 3 locations, got %d: %v", len(locations), locations)
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- Adds a repeatable `--exclude-branch-pattern` flag that takes a regex and filters out matching branches discovered via `ls-remote` in the whitelist path
- Repos like `stolostron/glo-grafana` have hundreds of transient `konflux/mintmaker/*` branches that exhaust the pod's process limits during sync, causing "Resource temporarily unavailable" errors ([job log](https://deck-internal-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/test-platform-results/logs/periodic-openshift-release-private-org-sync/2061333020945682432))
- The job can be configured with `--exclude-branch-pattern=^konflux/` to skip these branches without future code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
The private-org-sync CLI now adds a repeatable --exclude-branch-pattern flag to exclude matching branches discovered via git ls-remote from synchronization.

Practical change for CI operators
- You can now skip problematic or transient branches at runtime by supplying one or more regex patterns (e.g. --exclude-branch-pattern='^konflux/'). This prevents the tool from enumerating and syncing branches that would otherwise inflate the number of git operations and can trigger "Resource temporarily unavailable" or other process-limit failures during sync jobs.

Affected component and behavior
- Component: cmd/private-org-sync (the private-org synchronization CLI).
- Behavior: During discovery of whitelisted locations, branch names returned by ls-remote are tested against compiled exclusion regexes via a new isBranchExcluded predicate. Matched branches are logged at debug level and are omitted from the set of locations to mirror/sync.

Implementation notes
- New CLI flag: --exclude-branch-pattern (repeatable); backed by the existing ArrayFlags helper.
- Patterns are compiled to []*regexp.Regexp during options validation with clear errors for invalid regexes.
- getWhitelistedLocations now accepts an isBranchExcluded callback so branch filtering happens during location construction.
- Unit tests added to validate regex compilation, options.isBranchExcluded, and that getWhitelistedLocations filters excluded branches.

Operational impact
- No code redeploy is required to change branch filtering—operators can adjust exclusion patterns per run to avoid syncing large numbers of transient branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->