### PR TITLE
fix: skip stale registry.ci ocp spec in OfficialImageTagFrom

### DIFF
--- a/pkg/steps/utils/image.go
+++ b/pkg/steps/utils/image.go
@@ -73,10 +73,10 @@ func FindSpecTag(is *imagev1.ImageStream, tag string) *coreapi.ObjectReference {
 // OfficialImageTagFrom returns an import source from spec, then status, then quay-proxy.
 func OfficialImageTagFrom(source *imagev1.ImageStream, base api.ImageStreamTagReference) *coreapi.ObjectReference {
 	if source != nil {
-		if ref := FindSpecTag(source, base.Tag); ref != nil && ref.Name != "" {
+		if ref := FindSpecTag(source, base.Tag); ref != nil && ref.Name != "" && (ref.Kind != "DockerImage" || !strings.HasPrefix(ref.Name, api.ServiceDomainAPPCIRegistry+"/ocp/")) {
 			return ref
 		}
-		if ref, _ := FindStatusTag(source, base.Tag); ref != nil && ref.Name != "" {
+		if ref, _ := FindStatusTag(source, base.Tag); ref != nil && ref.Name != "" && (ref.Kind != "DockerImage" || !strings.HasPrefix(ref.Name, api.ServiceDomainAPPCIRegistry+"/ocp/")) {
 			return ref
 		}
 	}

--- a/pkg/steps/utils/image_test.go
+++ b/pkg/steps/utils/image_test.go
@@ -73,6 +73,19 @@ func TestResolveOfficialInputFrom(t *testing.T) {
 			wantFrom: &coreapi.ObjectReference{Kind: "DockerImage", Name: api.QuayImageReference(base)},
 		},
 		{
+			name: "skip stale registry.ci ocp spec",
+			base: api.ImageStreamTagReference{Namespace: "ocp", Name: "4.16", Tag: "base-rhel9"},
+			objects: []runtime.Object{&imagev1.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ocp", Name: "4.16"},
+				Spec: imagev1.ImageStreamSpec{Tags: []imagev1.TagReference{{
+					Name: "base-rhel9",
+					From: &coreapi.ObjectReference{Kind: "DockerImage", Name: "registry.ci.openshift.org/ocp/4.16@sha256:dead"},
+				}}},
+			}},
+			wantOK:   true,
+			wantFrom: &coreapi.ObjectReference{Kind: "DockerImage", Name: api.QuayImageReference(api.ImageStreamTagReference{Namespace: "ocp", Name: "4.16", Tag: "base-rhel9"})},
+		},
+		{
 			name: "stable first",
 			base: api.ImageStreamTagReference{Namespace: "ocp", Name: "4.22", Tag: "cli"},
 			objects: []runtime.Object{&imagev1.ImageStream{


### PR DESCRIPTION
https://redhat-internal.slack.com/archives/CBN38N3MW/p1780243383859199

/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix: Skip Stale Registry.CI OCP Spec in OfficialImageTagFrom

**Component affected:** Image resolution utility in ci-operator (`pkg/steps/utils/`)

**What changed:** The `OfficialImageTagFrom` function now skips stale OCP image references from the internal registry.ci registry (registry.ci.openshift.org/ocp/*) when resolving official image tag sources. The function checks both the spec and status image stream tags, but only returns them if they are either non-DockerImage types OR DockerImage references that don't point to the internal OCP registry. When a spec or status tag references a stale internal registry.ci OCP image, the function falls back to using a Quay-based image reference instead.

**Why it matters:** ci-operator uses `OfficialImageTagFrom` to resolve image sources for official OCP images during CI test setup. The internal registry.ci is temporary and images there can become outdated or unavailable. By filtering out these stale internal references, the system automatically falls back to Quay, which hosts the canonical, actively-maintained OCP images. This prevents CI job failures caused by attempting to pull from obsolete or deprecated internal registries and ensures jobs use current, reliable image sources.

**Testing:** Added test case "skip stale registry.ci ocp spec" that verifies when an image stream tag's spec contains a DockerImage reference to registry.ci.openshift.org/ocp/*, that reference is correctly skipped and the function returns a Quay-based reference instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->