### PR TITLE
DPTP-2938: restore pod-scaler GCS cache lookup broken by WorkloadClass on meta

### DIFF
--- a/cmd/pod-scaler/admission.go
+++ b/cmd/pod-scaler/admission.go
@@ -403,13 +403,11 @@ func preventUnschedulable(resources *corev1.ResourceRequirements, cpuCap int64, 
 }
 
 func mutatePodResources(pod *corev1.Pod, server *resourceServer, mutateResourceLimits bool, cpuCap int64, memoryCap string, isMeasured bool, nodeCache *nodeAllocatableCache, measuredPodCPUIncrease float64, authoritativeCPU, authoritativeMemory, authoritativeCPUDryRun, authoritativeMemoryDryRun bool, reporter results.PodScalerReporter, logger *logrus.Entry) {
-	// Set measured and workload class in metadata
 	workloadClass := pod.Labels[ciWorkloadLabel]
 
 	mutateResources := func(containers []corev1.Container) {
 		for i := range containers {
 			meta := podscaler.MetadataFor(pod.ObjectMeta.Labels, pod.ObjectMeta.Name, containers[i].Name)
-			meta.WorkloadClass = workloadClass
 
 			// Get recommendations from both measured and unmeasured runs, use maximum
 			var resources corev1.ResourceRequirements

--- a/cmd/pod-scaler/admission_test.go
+++ b/cmd/pod-scaler/admission_test.go
@@ -569,6 +569,65 @@ func TestMutatePodResources(t *testing.T) {
 	}
 }
 
+func TestMutatePodResources_ciWorkloadLabelDoesNotBreakCacheLookup(t *testing.T) {
+	logger := logrus.WithField("test", t.Name())
+	cacheMeta := podscaler.FullMetadata{
+		Metadata: api.Metadata{
+			Org:     "org",
+			Repo:    "repo",
+			Branch:  "branch",
+			Variant: "variant",
+		},
+		Target:    "target",
+		Step:      "step",
+		Pod:       "tomutate",
+		Container: "test",
+	}
+	server := &resourceServer{
+		logger: logger,
+		lock:   sync.RWMutex{},
+		byMetaData: map[podscaler.FullMetadata]corev1.ResourceRequirements{
+			cacheMeta: {
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: *resource.NewMilliQuantity(5000, resource.DecimalSI),
+				},
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "tomutate",
+			Labels: map[string]string{
+				"ci.openshift.io/metadata.org":     "org",
+				"ci.openshift.io/metadata.repo":    "repo",
+				"ci.openshift.io/metadata.branch":  "branch",
+				"ci.openshift.io/metadata.variant": "variant",
+				"ci.openshift.io/metadata.target":  "target",
+				"ci.openshift.io/metadata.step":    "step",
+				"ci-workload":                      "prowjobs",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: "test",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU: *resource.NewMilliQuantity(100, resource.DecimalSI),
+					},
+				},
+			}},
+		},
+	}
+
+	mutatePodResources(pod, server, false, 10, "20Gi", false, nil, 50.0, false, false, false, false, &defaultReporter, logger)
+
+	got := pod.Spec.Containers[0].Resources.Requests.Cpu().MilliValue()
+	const want = 6000 // 5000m recommendation inflated by 1.2 in useOursIfLarger
+	if got != want {
+		t.Fatalf("CPU request = %dm, want %dm", got, want)
+	}
+}
+
 func TestUseOursIfLarger(t *testing.T) {
 	var testCases = []struct {
 		name                   string


### PR DESCRIPTION
Found why authoritative CPU dry-run showed zero events fleet-wide. Jan measured-pods change set WorkloadClass on GCS cache lookup keys, but cached data has no workload_class — every lookup missed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Pod-Scaler GCS Cache Lookup Fix

This PR restores the pod-scaler's GCS cache lookup functionality that was broken by a recent change that added `WorkloadClass` to cache metadata keys.

### Problem
A previous change added `WorkloadClass` to the pod-scaler's GCS cache lookup keys, but all existing cached data lacks the `workload_class` field. This mismatch caused all cache lookups to fail, forcing the pod-scaler to miss cached resource recommendations and fall back to default behavior.

### Solution
The fix removes the `WorkloadClass` assignment from the metadata object used for cache lookups in `mutatePodResources`. While the code still reads and passes `workloadClass` from pod labels to downstream resource reconciliation logic, the GCS cache lookup now uses metadata keys matching the existing cache structure without the `WorkloadClass` field. This restores cache hit rates and allows pods to retrieve their appropriate resource recommendations from the cache.

### Testing
A new test (`TestMutatePodResources_ciWorkloadLabelDoesNotBreakCacheLookup`) verifies that cache lookups work correctly even when pods carry the `ci-workload` label, ensuring the pod-scaler doesn't regress on this behavior in the future.

### Impact
This restores the pod-scaler's ability to efficiently look up resource recommendations from cached data, improving CI infrastructure efficiency by using pre-computed resource allocations rather than falling back to defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->