### PR TITLE
Modifying build client to handle different build logics

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -57,6 +57,10 @@ func (config *ReleaseBuildConfiguration) Default() {
 	for i := range config.Tests {
 		defTest(&config.Tests[i])
 	}
+
+	if config.BuildType == "" {
+		config.BuildType = BuildTypeOpenshift
+	}
 }
 
 // ImageStreamFor guesses at the ImageStream that will hold a tag.

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -75,6 +75,7 @@ type ReleaseBuildConfiguration struct {
 
 	InputConfiguration `json:",inline"`
 
+	BuildType string `json:"build_type,omitempty"`
 	// BinaryBuildCommands will create a "bin" image based on "src" that
 	// contains the output of this command. This allows reuse of binary artifacts
 	// across other steps. If empty, no "bin" image will be created.
@@ -1821,4 +1822,9 @@ type ClusterClaimOwnerDetails struct {
 
 const (
 	EphemeralClusterTestDoneSignalSecretName = "test-done-signal"
+)
+
+const (
+	// BuildTypeOpenshift indicates the Openshift Build
+	BuildTypeOpenshift = "openshift"
 )

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -60,7 +60,7 @@ func FromConfig(ctx context.Context, cfg *Config) ([]api.Step, []api.Step, error
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not get build client for cluster config: %w", err)
 	}
-	buildClient := steps.NewBuildClient(client, buildGetter.RESTClient(), cfg.NodeArchitectures, cfg.ManifestToolDockerCfg, cfg.LocalRegistryDNS, cfg.MetricsAgent)
+	buildClient := steps.NewBuildClient(client, api.BuildTypeOpenshift, buildGetter.RESTClient(), cfg.NodeArchitectures, cfg.ManifestToolDockerCfg, cfg.LocalRegistryDNS, cfg.MetricsAgent)
 
 	coreGetter, err := coreclientset.NewForConfig(cfg.ClusterConfig)
 	if err != nil {

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -1284,7 +1284,7 @@ func TestFromConfig(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	buildClient := steps.NewBuildClient(client, nil, nil, "", "", nil)
+	buildClient := steps.NewBuildClient(client, api.BuildTypeOpenshift, nil, nil, "", "", nil)
 	podClient := kubernetes.NewPodClient(client, nil, nil, 0, nil)
 
 	clusterPool := hivev1.ClusterPool{

--- a/pkg/steps/build_client.go
+++ b/pkg/steps/build_client.go
@@ -21,6 +21,7 @@ type BuildClient interface {
 	ManifestToolDockerCfg() string
 	LocalRegistryDNS() string
 	MetricsAgent() *metrics.MetricsAgent
+	BuildType() string
 }
 
 type buildClient struct {
@@ -30,9 +31,10 @@ type buildClient struct {
 	manifestToolDockerCfg string
 	localRegistryDNS      string
 	metricsAgent          *metrics.MetricsAgent
+	buildType             string
 }
 
-func NewBuildClient(client loggingclient.LoggingClient, restClient rest.Interface, nodeArchitectures []string, manifestToolDockerCfg, localRegistryDNS string, metricsAgent *metrics.MetricsAgent) BuildClient {
+func NewBuildClient(client loggingclient.LoggingClient, buildType string, restClient rest.Interface, nodeArchitectures []string, manifestToolDockerCfg, localRegistryDNS string, metricsAgent *metrics.MetricsAgent) BuildClient {
 	return &buildClient{
 		LoggingClient:         client,
 		client:                restClient,
@@ -40,6 +42,7 @@ func NewBuildClient(client loggingclient.LoggingClient, restClient rest.Interfac
 		manifestToolDockerCfg: manifestToolDockerCfg,
 		localRegistryDNS:      localRegistryDNS,
 		metricsAgent:          metricsAgent,
+		buildType:             buildType,
 	}
 }
 
@@ -71,4 +74,8 @@ func (c *buildClient) MetricsAgent() *metrics.MetricsAgent {
 
 func (c *buildClient) Client() loggingclient.LoggingClient {
 	return c.LoggingClient
+}
+
+func (c *buildClient) BuildType() string {
+	return c.buildType
 }

--- a/pkg/steps/index_generator_test.go
+++ b/pkg/steps/index_generator_test.go
@@ -231,7 +231,7 @@ func TestDatabaseIndex(t *testing.T) {
 			if err := yaml.Unmarshal(rawImageStreamTag, ist); err != nil {
 				t.Fatalf("failed to unmarshal imagestreamTag: %v", err)
 			}
-			actual, actualErr := databaseIndex(NewBuildClient(loggingclient.New(fakectrlruntimeclient.NewClientBuilder().WithObjects(ist, image).Build(), nil), nil, nil, "", "", nil),
+			actual, actualErr := databaseIndex(NewBuildClient(loggingclient.New(fakectrlruntimeclient.NewClientBuilder().WithObjects(ist, image).Build(), nil), api.BuildTypeOpenshift, nil, nil, "", "", nil),
 				testCase.isTagName, "ns")
 			if diff := cmp.Diff(testCase.expectedErr, actualErr, testhelper.EquateErrorMessage); diff != "" {
 				t.Fatalf("actual did not match expected, diff: %s", diff)

--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -492,9 +492,15 @@ func handleBuilds(ctx context.Context, buildClient BuildClient, podClient kubern
 	wg.Add(len(builds))
 	for _, build := range builds {
 		go func(b buildapi.Build) {
+			var err error
 			defer wg.Done()
 			metricsAgent.AddNodeWorkload(ctx, b.Namespace, fmt.Sprintf("%s-build", b.Name), b.Name, podClient)
-			if err := handleBuild(ctx, buildClient, podClient, b); err != nil {
+			if buildClient.BuildType() == api.BuildTypeOpenshift {
+				err = handleOpenshiftBuild(ctx, buildClient, podClient, b)
+			} else {
+				err = fmt.Errorf("undefined build type %s", buildClient.BuildType())
+			}
+			if err != nil {
 				errChan <- fmt.Errorf("error occurred handling build %s: %w", b.Name, err)
 			}
 			metricsAgent.RemoveNodeWorkload(b.Name)
@@ -552,7 +558,7 @@ func constructMultiArchBuilds(build buildapi.Build, stepArchitectures []string) 
 	return ret
 }
 
-func handleBuild(ctx context.Context, client BuildClient, podClient kubernetes.PodClient, build buildapi.Build) error {
+func handleOpenshiftBuild(ctx context.Context, buildClient BuildClient, podClient kubernetes.PodClient, build buildapi.Build) error {
 	const attempts = 5
 	ns, name := build.Namespace, build.Name
 	var errs []error
@@ -560,7 +566,7 @@ func handleBuild(ctx context.Context, client BuildClient, podClient kubernetes.P
 		var attempt buildapi.Build
 
 		build.DeepCopyInto(&attempt)
-		if err := client.Create(ctx, &attempt); err == nil {
+		if err := buildClient.Create(ctx, &attempt); err == nil {
 			logrus.Infof("Created build %q", name)
 		} else if kerrors.IsAlreadyExists(err) {
 			logrus.Infof("Found existing build %q", name)
@@ -568,19 +574,19 @@ func handleBuild(ctx context.Context, client BuildClient, podClient kubernetes.P
 			return false, fmt.Errorf("could not create build %s: %w", name, err)
 		}
 
-		client.MetricsAgent().AddNodeWorkload(ctx, ns, fmt.Sprintf("%s-build", name), name, podClient)
-		client.MetricsAgent().StoreMachinesSnapshotForBuildPod(ctx, ns, fmt.Sprintf("%s-build", name), podClient)
-		if err := waitForBuildOrTimeout(ctx, client, podClient, ns, name); err != nil {
+		buildClient.MetricsAgent().AddNodeWorkload(ctx, ns, fmt.Sprintf("%s-build", name), name, podClient)
+		buildClient.MetricsAgent().StoreMachinesSnapshotForBuildPod(ctx, ns, fmt.Sprintf("%s-build", name), podClient)
+		if err := waitForBuildOrTimeout(ctx, buildClient, podClient, ns, name); err != nil {
 			errs = append(errs, err)
-			return false, handleFailedBuild(ctx, client, ns, name, err)
+			return false, handleFailedBuild(ctx, buildClient, ns, name, err)
 		}
-		if err := gatherSuccessfulBuildLog(client, ns, name); err != nil {
+		if err := gatherSuccessfulBuildLog(buildClient, ns, name); err != nil {
 			// log error but do not fail successful build
 			logrus.WithError(err).Warnf("Failed gathering successful build %s logs into artifacts.", name)
 		}
 		return true, nil
 	}); err != nil {
-		if err == wait.ErrWaitTimeout {
+		if wait.Interrupted(err) {
 			return fmt.Errorf("build not successful after %d attempts: %w", attempts, utilerrors.NewAggregate(errs))
 		}
 		return err

--- a/pkg/steps/source_test.go
+++ b/pkg/steps/source_test.go
@@ -401,7 +401,7 @@ func TestWaitForBuild(t *testing.T) {
 							CompletionTimestamp: &end,
 						},
 					},
-				).Build(), nil), nil, nil, "", "", nil),
+				).Build(), nil), api.BuildTypeOpenshift, nil, nil, "", "", nil),
 			expected: fmt.Errorf("build didn't start running within 0s (phase: Pending)"),
 		},
 		{
@@ -430,7 +430,7 @@ func TestWaitForBuild(t *testing.T) {
 							Namespace: ns,
 						},
 					},
-				).Build(), nil), nil, nil, "", "", nil),
+				).Build(), nil), api.BuildTypeOpenshift, nil, nil, "", "", nil),
 			expected: fmt.Errorf("build didn't start running within 0s (phase: Pending):\nFound 0 events for Pod some-build-build:"),
 		},
 		{
@@ -471,7 +471,7 @@ func TestWaitForBuild(t *testing.T) {
 							}},
 						},
 					},
-				).Build(), nil), nil, nil, "", "", nil),
+				).Build(), nil), api.BuildTypeOpenshift, nil, nil, "", "", nil),
 			expected: fmt.Errorf(`build didn't start running within 0s (phase: Pending):
 * Container the-container is not ready with reason the_reason and message the_message
 Found 0 events for Pod some-build-build:`),
@@ -490,7 +490,7 @@ Found 0 events for Pod some-build-build:`),
 						StartTimestamp:      &start,
 						CompletionTimestamp: &end,
 					},
-				}).Build(), nil), nil, nil, "", "", nil),
+				}).Build(), nil), api.BuildTypeOpenshift, nil, nil, "", "", nil),
 			timeout: 30 * time.Minute,
 		},
 		{
@@ -534,7 +534,7 @@ Found 0 events for Pod some-build-build:`),
 							Time: now.Add(-59 * time.Minute),
 						},
 					},
-				}).Build(), nil), nil, nil, "", "", nil),
+				}).Build(), nil), api.BuildTypeOpenshift, nil, nil, "", "", nil),
 			timeout: 30 * time.Minute,
 		},
 		{
@@ -719,6 +719,10 @@ func (c *fakeBuildClient) MetricsAgent() *metrics.MetricsAgent { return nil }
 
 func (c *fakeBuildClient) Client() loggingclient.LoggingClient {
 	return c.LoggingClient
+}
+
+func (c *fakeBuildClient) BuildType() string {
+	return api.BuildTypeOpenshift
 }
 
 func Test_constructMultiArchBuilds(t *testing.T) {


### PR DESCRIPTION
This is the first step to isolate image build logic inside `buildClient` , so it can handle different builds on different platforms like AWS, Shipwright, etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR introduces a build-type abstraction into ci-operator’s build client so the system can host multiple build-platform implementations. It isolates image build logic inside buildClient and wires configuration through to the client so ci-operator can choose platform-specific build behavior (current default: OpenShift).

## What changed (practical effect)

- Build client API: The BuildClient interface gained BuildType() and NewBuildClient now requires an explicit buildType argument; the concrete buildClient stores and returns that type.
- Configuration: ReleaseBuildConfiguration accepts an optional build_type field (json:"build_type,omitempty"). Defaulting sets build_type to "openshift" when unspecified, so existing configs continue to behave the same.
- Build execution: source.go’s build orchestration now dispatches by buildClient.BuildType(). OpenShift builds follow a new handleOpenshiftBuild path that encapsulates creation, exponential-retry handling for "already exists", metrics registration and machine snapshot capture, waiting with timeout semantics, failure handling, and best-effort log collection. Unknown build types return an error.
- Tests/defaults: Call sites and tests were updated to pass api.BuildTypeOpenshift; the fakeBuildClient test helper implements BuildType() to satisfy the interface.

## Component impact

- Affects ci-operator build step implementation (pkg/steps), API types (pkg/api), and defaults (pkg/defaults). For CI operators and job/config authors: you can now declare build_type in ReleaseBuildConfiguration. Until additional implementations are added, behavior remains OpenShift by default, but the codebase is prepared to add alternate build backends (e.g., AWS, Shipwright) with minimal invasive changes.

## Backwards compatibility and next steps

- Backwards compatible: unspecified build_type defaults to "openshift", preserving existing behavior.
- Next work: implement and wire additional platform-specific BuildClient behaviors and add dispatch paths for them.

## Notes for reviewers

- API/signature changes: new config field and NewBuildClient signature requires updating all callers.
- Behavior: review the refactored handleBuild/handleOpenshiftBuild retry, timeout and error-aggregation semantics and the best-effort log-gathering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->