### PR TITLE
Register libvirt-s390x-vpn-oz cluster profile

### DIFF
--- a/pkg/api/clusterprofile.go
+++ b/pkg/api/clusterprofile.go
@@ -124,6 +124,7 @@ const (
 	ClusterProfileLibvirtS390x2           ClusterProfile = "libvirt-s390x-2"
 	ClusterProfileLibvirtS390xAmd64       ClusterProfile = "libvirt-s390x-amd64"
 	ClusterProfileLibvirtS390xVPN         ClusterProfile = "libvirt-s390x-vpn"
+	ClusterProfileLibvirtS390xVPNOZ       ClusterProfile = "libvirt-s390x-vpn-oz"
 	ClusterProfileMetalPerfscaleBMCPT     ClusterProfile = "metal-perfscale-cpt"
 	ClusterProfileMetalPerfscaleJetlag    ClusterProfile = "metal-perfscale-jetlag"
 	ClusterProfileMetalPerfscaleOSP       ClusterProfile = "metal-perfscale-osp"
@@ -343,6 +344,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileLibvirtS390x2,
 		ClusterProfileLibvirtS390xAmd64,
 		ClusterProfileLibvirtS390xVPN,
+		ClusterProfileLibvirtS390xVPNOZ,
 		ClusterProfileMetalPerfscaleBMCPT,
 		ClusterProfileMetalPerfscaleJetlag,
 		ClusterProfileMetalPerfscaleOSP,
@@ -618,6 +620,8 @@ func (p ClusterProfile) ClusterType() string {
 		return "libvirt-s390x-amd64"
 	case ClusterProfileLibvirtS390xVPN:
 		return "libvirt-s390x-vpn"
+	case ClusterProfileLibvirtS390xVPNOZ:
+		return "libvirt-s390x-vpn-oz"
 	case ClusterProfileMetalRHgs:
 		return "metal-redhat-gs"
 	case ClusterProfileMetalPerfscaleBMCPT:
@@ -960,6 +964,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "libvirt-s390x-amd64-quota-slice"
 	case ClusterProfileLibvirtS390xVPN:
 		return "libvirt-s390x-vpn-quota-slice"
+	case ClusterProfileLibvirtS390xVPNOZ:
+		return "libvirt-s390x-vpn-oz-quota-slice"
 	case ClusterProfileMetalPerfscaleBMCPT:
 		return "metal-perfscale-cpt-quota-slice"
 	case ClusterProfileMetalPerfscaleJetlag:
@@ -1176,7 +1182,7 @@ func LeaseTypeFromClusterType(t string) (string, error) {
 		"aws", "aws-us-east-1", "aws-c2s", "aws-china", "aws-usgov", "aws-sc2s", "aws-eusc", "aws-osd-msp", "aws-opendatahub",
 		"alibaba", "azure-2", "azure4", "azure-arm64", "azurestack", "azuremag", "equinix-ocp-metal",
 		"gcp", "gcp-arm64", "gcp-opendatahub", "libvirt-ppc64le", "libvirt-ppc64le-s2s", "libvirt-s390x",
-		"libvirt-s390x-1", "libvirt-s390x-2", "libvirt-s390x-amd64", "libvirt-s390x-vpn", "ibmcloud-multi-ppc64le",
+		"libvirt-s390x-1", "libvirt-s390x-2", "libvirt-s390x-amd64", "libvirt-s390x-vpn", "libvirt-s390x-vpn-oz", "ibmcloud-multi-ppc64le",
 		"ibmcloud-multi-s390x", "nutanix", "nutanix-qe", "nutanix-qe-dis", "nutanix-qe-zone", "nutanix-qe-gpu",
 		"nutanix-qe-flow", "openstack", "openstack-osuosl", "openstack-vexxhost", "openstack-ppc64le",
 		"openstack-nerc-dev", "vsphere", "ovirt", "packet", "packet-edge", "powervc-1", "powervs-multi-1",


### PR DESCRIPTION
Map the Orange Zone M83 libvirt VPN profile to libvirt-s390x-vpn-oz-quota-slice for Boskos lease acquisition.
https://github.com/openshift/release/pull/79967
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR registers a new cluster profile for libvirt s390x (IBM mainframe) clusters with VPN connectivity to the Orange Zone. The change enables Boskos, OpenShift CI's resource management system, to track and allocate leases for this cluster profile.

**What changed:**
The PR adds the `libvirt-s390x-vpn-oz` cluster profile constant to `pkg/api/clusterprofile.go` and wires it through all necessary cluster-profile mappings:
- Maps the profile to the cluster type string `libvirt-s390x-vpn-oz`
- Maps it to the Boskos lease resource `libvirt-s390x-vpn-oz-quota-slice` for resource quota management
- Registers it in the `LeaseTypeFromClusterType()` function so Boskos can properly resolve the lease resource for this profile

**Impact:**
CI operators and test developers can now use this new cluster profile in their test configurations. When jobs request the `libvirt-s390x-vpn-oz` profile, Boskos will automatically manage resource allocation through the corresponding quota-slice lease, enabling s390x architecture testing in the Orange Zone VPN environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->