### PR TITLE
DPTP-4917: Revert "fix: dockerfile registry.ci input detection with baseImages"

### DIFF
--- a/cmd/registry-replacer/main.go
+++ b/cmd/registry-replacer/main.go
@@ -383,7 +383,7 @@ func replacer(
 }
 
 func ensureReplacement(image *api.ProjectDirectoryImageBuildStepConfiguration, dockerfile []byte) ([]cidockerfile.OrgRepoTag, error) {
-	toReplace := cidockerfile.ExtractRegistryReferences(dockerfile)
+	toReplace := cidockerfile.ExtractRegistryReferences(dockerfile, "")
 	var result []cidockerfile.OrgRepoTag
 	for _, toReplace := range toReplace {
 		orgRepoTag, err := cidockerfile.OrgRepoTagFromPullString(toReplace)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -980,7 +980,7 @@ func readDockerfileForImage(image api.ProjectDirectoryImageBuildStepConfiguratio
 // required InputImageTagStepConfiguration steps to import them, as well as an updated
 // image configuration with the detected inputs added
 func processDetectedBaseImages(baseImages map[string]api.ImageStreamTagReference, image api.ProjectDirectoryImageBuildStepConfiguration, details dockerfileDetails) ([]api.StepConfiguration, api.ProjectDirectoryImageBuildStepConfiguration) {
-	detectedBaseImages := dockerfile.DetectInputsFromDockerfile(details.content, image.Inputs, image.From, baseImages)
+	detectedBaseImages := dockerfile.DetectInputsFromDockerfile(details.content, image.Inputs, image.From)
 	if len(detectedBaseImages) == 0 {
 		return nil, image
 	}

--- a/pkg/dockerfile/extract.go
+++ b/pkg/dockerfile/extract.go
@@ -24,9 +24,10 @@ func (ort OrgRepoTag) String() string {
 }
 
 // ExtractRegistryReferences finds all registry.ci.openshift.org and quay-proxy.ci.openshift.org references in the Dockerfile
-func ExtractRegistryReferences(dockerfile []byte) []string {
+func ExtractRegistryReferences(dockerfile []byte, from api.PipelineImageStreamTagReference) []string {
 	var refs []string
 	seen := sets.Set[string]{}
+	lastFromRef := ""
 
 	for _, line := range bytes.Split(dockerfile, []byte("\n")) {
 		upper := bytes.ToUpper(line)
@@ -39,10 +40,24 @@ func ExtractRegistryReferences(dockerfile []byte) []string {
 			continue
 		}
 		ref := string(match)
+		if bytes.HasPrefix(upper, []byte("FROM")) {
+			lastFromRef = ref
+		}
+
 		if !seen.Has(ref) {
 			refs = append(refs, ref)
 			seen.Insert(ref)
 		}
+	}
+	if from != "" {
+		// If from is specified, remove the last detected FROM ref, it will be replaced
+		var newRefs []string
+		for _, ref := range refs {
+			if ref != lastFromRef {
+				newRefs = append(newRefs, ref)
+			}
+		}
+		refs = newRefs
 	}
 	return refs
 }

--- a/pkg/dockerfile/inputs.go
+++ b/pkg/dockerfile/inputs.go
@@ -9,15 +9,11 @@ import (
 // DetectInputsFromDockerfile parses a Dockerfile and detects registry references that need to be added as base images
 // Returns a map of base image names to ImageStreamTagReferences
 // The ImageStreamTagReference.As field contains the original registry reference from the Dockerfile
-func DetectInputsFromDockerfile(dockerfile []byte, existingInputs map[string]api.ImageBuildInputs, from api.PipelineImageStreamTagReference, baseImages map[string]api.ImageStreamTagReference) map[string]api.ImageStreamTagReference {
-	registryRefs := ExtractRegistryReferences(dockerfile)
-	detected := make(map[string]api.ImageStreamTagReference)
+func DetectInputsFromDockerfile(dockerfile []byte, existingInputs map[string]api.ImageBuildInputs, from api.PipelineImageStreamTagReference) map[string]api.ImageStreamTagReference {
+	registryRefs := ExtractRegistryReferences(dockerfile, from)
+	baseImages := make(map[string]api.ImageStreamTagReference)
 
 	for _, ref := range registryRefs {
-		if from != "" && matchesFromBaseImage(ref, from, baseImages) {
-			logrus.WithField("reference", ref).WithField("from", from).Debug("Skipping Dockerfile input already provided by image from")
-			continue
-		}
 		if HasManualReplacementFor(existingInputs, ref) {
 			logrus.WithField("reference", ref).Debug("Skipping Dockerfile inputs detection: manual replacement exists")
 			continue
@@ -28,7 +24,7 @@ func DetectInputsFromDockerfile(dockerfile []byte, existingInputs map[string]api
 			continue
 		}
 		baseImageKey := orgRepoTag.String()
-		detected[baseImageKey] = api.ImageStreamTagReference{
+		baseImages[baseImageKey] = api.ImageStreamTagReference{
 			Namespace: orgRepoTag.Org,
 			Name:      orgRepoTag.Repo,
 			Tag:       orgRepoTag.Tag,
@@ -36,20 +32,5 @@ func DetectInputsFromDockerfile(dockerfile []byte, existingInputs map[string]api
 		}
 	}
 
-	return detected
-}
-
-func matchesFromBaseImage(ref string, from api.PipelineImageStreamTagReference, baseImages map[string]api.ImageStreamTagReference) bool {
-	if from == "" || baseImages == nil {
-		return false
-	}
-	base, ok := baseImages[string(from)]
-	if !ok {
-		return false
-	}
-	orgRepoTag, err := OrgRepoTagFromPullString(ref)
-	if err != nil {
-		return false
-	}
-	return orgRepoTag.Org == base.Namespace && orgRepoTag.Repo == base.Name && orgRepoTag.Tag == base.Tag
+	return baseImages
 }

--- a/pkg/dockerfile/inputs_test.go
+++ b/pkg/dockerfile/inputs_test.go
@@ -13,7 +13,6 @@ func TestDetectInputsFromDockerfile(t *testing.T) {
 		name           string
 		dockerfile     string
 		existingInputs map[string]api.ImageBuildInputs
-		baseImages     map[string]api.ImageStreamTagReference
 		expected       map[string]api.ImageStreamTagReference
 		from           api.PipelineImageStreamTagReference
 	}{
@@ -143,26 +142,20 @@ FROM registry.ci.openshift.org/ocp/4.19:base AS runtime
 			},
 		},
 		{
-			name: "from matches base image - skip duplicate",
+			name: "from: is specified - should exclude the last and only detected FROM ref",
 			dockerfile: `FROM registry.ci.openshift.org/ocp/4.19:base
 RUN echo "hello"
 `,
-			from: "src",
-			baseImages: map[string]api.ImageStreamTagReference{
-				"src": {Namespace: "ocp", Name: "4.19", Tag: "base"},
-			},
+			from:     "src",
 			expected: map[string]api.ImageStreamTagReference{},
 		},
 		{
-			name: "from matches only its base image in multi-stage",
+			name: "from: is specified - should exclude the last detected FROM ref",
 			dockerfile: `FROM registry.ci.openshift.org/ocp/4.18:base AS builder
 FROM registry.ci.openshift.org/ocp/4.19:base
 RUN echo "hello"
 `,
 			from: "src",
-			baseImages: map[string]api.ImageStreamTagReference{
-				"src": {Namespace: "ocp", Name: "4.19", Tag: "base"},
-			},
 			expected: map[string]api.ImageStreamTagReference{
 				"ocp_4.18_base": {
 					Namespace: "ocp",
@@ -173,35 +166,13 @@ RUN echo "hello"
 			},
 		},
 		{
-			name: "multi-stage cli with unrelated from",
-			dockerfile: `FROM registry.ci.openshift.org/ocp/4.14:cli AS cli
-FROM quay.io/centos/centos:stream9
-COPY --from=cli /usr/bin/oc /usr/bin/
-`,
-			from: "stream9",
-			baseImages: map[string]api.ImageStreamTagReference{
-				"stream9": {Namespace: "openshift", Name: "centos", Tag: "stream9"},
-			},
-			expected: map[string]api.ImageStreamTagReference{
-				"ocp_4.14_cli": {
-					Namespace: "ocp",
-					Name:      "4.14",
-					Tag:       "cli",
-					As:        "registry.ci.openshift.org/ocp/4.14:cli",
-				},
-			},
-		},
-		{
-			name: "from matches only its base image with COPY",
+			name: "from: is specified - should exclude the last detected FROM ref with COPY",
 			dockerfile: `FROM registry.ci.openshift.org/ocp/4.18:base AS builder
 FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.21
 COPY --from=registry.ci.openshift.org/ocp/4.19:base /something /somewhere
 RUN echo "hello"
 `,
 			from: "src",
-			baseImages: map[string]api.ImageStreamTagReference{
-				"src": {Namespace: "ocp", Name: "4.19", Tag: "base"},
-			},
 			expected: map[string]api.ImageStreamTagReference{
 				"ocp_4.18_base": {
 					Namespace: "ocp",
@@ -209,11 +180,11 @@ RUN echo "hello"
 					Tag:       "base",
 					As:        "registry.ci.openshift.org/ocp/4.18:base",
 				},
-				"openshift_release_rhel-9-release-golang-1.24-openshift-4.21": {
-					Namespace: "openshift",
-					Name:      "release",
-					Tag:       "rhel-9-release-golang-1.24-openshift-4.21",
-					As:        "registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.21",
+				"ocp_4.19_base": {
+					Namespace: "ocp",
+					Name:      "4.19",
+					Tag:       "base",
+					As:        "registry.ci.openshift.org/ocp/4.19:base",
 				},
 			},
 		},
@@ -221,7 +192,7 @@ RUN echo "hello"
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := DetectInputsFromDockerfile([]byte(tc.dockerfile), tc.existingInputs, tc.from, tc.baseImages)
+			result := DetectInputsFromDockerfile([]byte(tc.dockerfile), tc.existingInputs, tc.from)
 
 			if diff := cmp.Diff(tc.expected, result); diff != "" {
 				t.Errorf("result differs from expected:\n%s", diff)


### PR DESCRIPTION
Reverts openshift/ci-tools#5215

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR reverts the Dockerfile registry input detection changes from PR `#5215`. The revert simplifies the function signatures and removes cross-function dependencies in the Dockerfile processing pipeline:

**Components affected:**
- **Dockerfile input detection** (`pkg/dockerfile/inputs.go`): The `DetectInputsFromDockerfile` function no longer accepts an external `baseImages` parameter—it now creates and returns a new map internally. This removes the complexity of the `matchesFromBaseImage` helper function that was checking whether detected references already existed in pre-populated base images.
- **Registry reference extraction** (`pkg/dockerfile/extract.go`): The `ExtractRegistryReferences` function now accepts a `from` parameter to internally filter and exclude `FROM` stage references from the detected list, delegating this responsibility from callers.
- **Registry replacer tool** (`cmd/registry-replacer/main.go`) and **defaults processor** (`pkg/defaults/defaults.go`): Updated to work with the new simplified signatures—callers no longer need to pre-populate and pass baseImages maps.

**Impact:** 
The CI system's automatic detection of base images from Dockerfiles now operates independently without requiring external context about existing base images. Registry reference filtering based on the "from" stage happens within the extraction logic rather than through post-detection filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->