### PR TITLE
fix(prowgen): disable sparse checkout when build_if_affected is enabled

### DIFF
--- a/pkg/prowgen/jobbase.go
+++ b/pkg/prowgen/jobbase.go
@@ -97,7 +97,7 @@ func NewProwJobBaseBuilder(configSpec *cioperatorapi.ReleaseBuildConfiguration, 
 	if shouldSkipCloning {
 		b.base.UtilityConfig.DecorationConfig.SkipCloning = ptr.To(true)
 	} else {
-		disableSparseCheckout := configSpec.Prowgen != nil && configSpec.Prowgen.DisableSparseCheckout
+		disableSparseCheckout := (configSpec.Prowgen != nil && configSpec.Prowgen.DisableSparseCheckout) || configSpec.Images.BuildIfAffected
 		if !disableSparseCheckout {
 			b.base.UtilityConfig.DecorationConfig.SparseCheckoutFiles = sparseFiles
 		}

--- a/pkg/prowgen/jobbase_test.go
+++ b/pkg/prowgen/jobbase_test.go
@@ -138,6 +138,13 @@ func TestProwJobBaseBuilder(t *testing.T) {
 			podSpecBuilder:   NewCiOperatorPodSpecGenerator(),
 		},
 		{
+			name:           "job with images and build_if_affected disables sparse checkout",
+			info:           defaultInfo,
+			images:         ciop.ImageConfiguration{BuildIfAffected: true, Items: []ciop.ProjectDirectoryImageBuildStepConfiguration{{From: "base", To: "image"}}},
+			prefix:         "default",
+			podSpecBuilder: newFakePodSpecBuilder(),
+		},
+		{
 			name:           "default job without further configuration, including podspec",
 			info:           defaultInfo,
 			prefix:         "default",

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_images_and_build_if_affected_disables_sparse_checkout.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_images_and_build_if_affected_disables_sparse_checkout.yaml
@@ -1,0 +1,4 @@
+agent: kubernetes
+decorate: true
+decoration_config: {}
+name: default-ci-org-repo-branch-

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-postsubmits.yaml
@@ -65,9 +65,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    decoration_config:
-      sparse_checkout_files:
-      - Dockerfile
+    decoration_config: {}
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci-operator.openshift.io/variant: images-build-affected

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -239,9 +239,7 @@ presubmits:
     - ^master-
     context: ci/prow/images-build-affected-images
     decorate: true
-    decoration_config:
-      sparse_checkout_files:
-      - Dockerfile
+    decoration_config: {}
     labels:
       ci-operator.openshift.io/variant: images-build-affected
       ci.openshift.io/generator: prowgen
@@ -297,9 +295,7 @@ presubmits:
     - ^master-
     context: ci/prow/images-build-affected-unit
     decorate: true
-    decoration_config:
-      sparse_checkout_files:
-      - Dockerfile
+    decoration_config: {}
     labels:
       ci-operator.openshift.io/variant: images-build-affected
       ci.openshift.io/generator: prowgen


### PR DESCRIPTION
## Summary
- Sparse checkout only checks out Dockerfiles for image jobs, but `build_if_affected` requires the full Go source tree to run `packages.Load` for tool detection
- This caused `packages.Load` to fail with "directory not found" errors, silently falling back to building **all** images — defeating the purpose of `build_if_affected`
- Fix: disable sparse checkout when `images.build_if_affected` is true


🤖 Generated with [Claude Code](https://claude.com/claude-code)