### PR TITLE
private-prow-configs-mirror: propagate triggers config

### DIFF
--- a/cmd/private-prow-configs-mirror/main.go
+++ b/cmd/private-prow-configs-mirror/main.go
@@ -404,6 +404,29 @@ func injectPrivateLGTMPlugin(lgtms []plugins.Lgtm, orgRepos orgReposWithOfficial
 	}
 }
 
+func injectPrivateTriggers(triggers []plugins.Trigger, orgRepos orgReposWithOfficialImages) {
+	logrus.Info("Processing...")
+
+	for index, trigger := range triggers {
+		repos := sets.New[string]()
+		for _, orgRepo := range trigger.Repos {
+			if strings.HasPrefix(orgRepo, fmt.Sprintf("%s/", openshiftPrivOrg)) {
+				continue
+			}
+			repos.Insert(orgRepo)
+		}
+
+		for orgRepo := range repos {
+			if privateOrgRepoName, ok := orgRepos.privateOrgRepoFull(orgRepo); ok {
+				logrus.WithField("source_repo", orgRepo).WithField("private_repo", privateOrgRepoName).Info("Found")
+				repos.Insert(privateOrgRepoName)
+			}
+		}
+
+		triggers[index].Repos = sets.List(repos)
+	}
+}
+
 func injectPrivateBugzillaPlugin(bugzillaPlugins plugins.Bugzilla, orgRepos orgReposWithOfficialImages) {
 	logrus.Info("Processing...")
 
@@ -563,6 +586,7 @@ func main() {
 	injectPrivateLGTMPlugin(pluginsConfig.Lgtm, orgRepos)
 	injectPrivatePlugins(pluginsConfig.Plugins, orgRepos)
 	injectPrivateBugzillaPlugin(pluginsConfig.Bugzilla, orgRepos)
+	injectPrivateTriggers(pluginsConfig.Triggers, orgRepos)
 
 	if err := updateProwConfig(filepath.Join(o.releaseRepoPath, config.ConfigInRepoPath), prowConfig); err != nil {
 		logrus.WithError(err).Fatal("couldn't update prow config file")
@@ -582,6 +606,21 @@ func cleanStalePluginConfigs(config *plugins.Configuration) *plugins.Configurati
 		cleanedPlugins[orgOrRepo] = val
 	}
 	config.Plugins = cleanedPlugins
+
+	var cleanedTriggers []plugins.Trigger
+	for _, trigger := range config.Triggers {
+		var repos []string
+		for _, repo := range trigger.Repos {
+			if !strings.HasPrefix(repo, fmt.Sprintf("%s/", openshiftPrivOrg)) {
+				repos = append(repos, repo)
+			}
+		}
+		if len(repos) > 0 {
+			trigger.Repos = repos
+			cleanedTriggers = append(cleanedTriggers, trigger)
+		}
+	}
+	config.Triggers = cleanedTriggers
 
 	return config
 }

--- a/cmd/private-prow-configs-mirror/main_test.go
+++ b/cmd/private-prow-configs-mirror/main_test.go
@@ -596,6 +596,70 @@ func TestInjectPrivateLGTMPlugin(t *testing.T) {
 	}
 }
 
+func TestInjectPrivateTriggers(t *testing.T) {
+	testCases := []struct {
+		id       string
+		triggers []plugins.Trigger
+		expected []plugins.Trigger
+	}{
+		{
+			id: "no changes expected",
+			triggers: []plugins.Trigger{
+				{
+					Repos:       []string{"openshift/anotherRepo1", "testshift/anotherRepo2"},
+					TrustedApps: []string{"openshift-merge-bot"},
+				},
+				{
+					Repos:       []string{"openshift/anotherRepo3", "testshift/anotherRepo4"},
+					TrustedApps: []string{"openshift-merge-bot"},
+				},
+			},
+			expected: []plugins.Trigger{
+				{
+					Repos:       []string{"openshift/anotherRepo1", "testshift/anotherRepo2"},
+					TrustedApps: []string{"openshift-merge-bot"},
+				},
+				{
+					Repos:       []string{"openshift/anotherRepo3", "testshift/anotherRepo4"},
+					TrustedApps: []string{"openshift-merge-bot"},
+				},
+			},
+		},
+		{
+			id: "changes expected",
+			triggers: []plugins.Trigger{
+				{
+					Repos:       []string{"openshift/testRepo1", "testshift/anotherRepo2", "openshift-priv/testRepo3"},
+					TrustedApps: []string{"openshift-merge-bot"},
+				},
+				{
+					Repos:       []string{"openshift/anotherRepo3", "testshift/testRepo3", "openshift-priv/testRepo100"},
+					TrustedApps: []string{"openshift-merge-bot"},
+				},
+			},
+			expected: []plugins.Trigger{
+				{
+					Repos:       []string{"openshift-priv/testRepo1", "openshift/testRepo1", "testshift/anotherRepo2"},
+					TrustedApps: []string{"openshift-merge-bot"},
+				},
+				{
+					Repos:       []string{"openshift-priv/testshift-testRepo3", "openshift/anotherRepo3", "testshift/testRepo3"},
+					TrustedApps: []string{"openshift-merge-bot"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.id, func(t *testing.T) {
+			injectPrivateTriggers(tc.triggers, orgRepos)
+			if !reflect.DeepEqual(tc.triggers, tc.expected) {
+				t.Fatal(cmp.Diff(tc.triggers, tc.expected))
+			}
+		})
+	}
+}
+
 func TestInjectPrivateBugzillaPlugin(t *testing.T) {
 	testCases := []struct {
 		id       string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds support for propagating Prow plugin trigger configurations from public OpenShift repositories to their corresponding private mirror repositories.

## Changes

**New functionality in `private-prow-configs-mirror` tool:**

The PR introduces a new `injectPrivateTriggers()` function that enriches trigger rules with their private repository counterparts. When processing trigger configurations, the function:
- Iterates through each trigger rule's repository list
- Skips existing `openshift-priv/` entries to avoid duplicates
- Maps each public repo to its private equivalent (e.g., `openshift/testRepo1` → `openshift-priv/testRepo1`)
- Inserts the mapped private repos into the trigger's repository list

**Enhanced cleanup logic:**

The existing `cleanStalePluginConfigs()` function was extended to also handle trigger configurations by:
- Filtering out any triggers that reference only `openshift-priv/` repos (which are meant for private mirroring only)
- Removing `openshift-priv/` entries from remaining trigger rules to prevent duplication when the mirror process re-injects them

**Testing:**

Comprehensive unit tests validate both scenarios—when no changes are needed (repos already mapped) and when private repos need to be injected with proper deduplication.

## Impact

This change ensures that Prow trigger rules, which determine when CI jobs are automatically triggered based on repository events, are consistently synchronized across both public and private mirrored repositories. This allows the CI infrastructure to maintain parallel trigger configurations for private OpenShift components while avoiding configuration drift.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->