### PR TITLE
Fix issue DPTP-4756 Move home role ARN to Secret

### DIFF
--- a/pkg/api/constant.go
+++ b/pkg/api/constant.go
@@ -82,9 +82,10 @@ const (
 	STSHomeRoleARNParam           = "CI_STS_HOME_ROLE_ARN"
 	STSHubRoleARNParam            = "CI_STS_HUB_ROLE_ARN"
 	STSTargetRoleARNParam         = "CI_STS_TARGET_ROLE_ARN"
-	STSHomeRoleARNSecretKey       = "home_role_arn"
+	STSHomeRoleARNKey             = "home_role_arn"
 	STSHubRoleARNSecretKey        = "hub_role_arn"
 	STSTargetRoleARNSecretKey     = "target_role_arn"
+	STSClusterSecretName          = "aws-sts-cluster-config"
 
 	// SkipCensoringLabel is the label we use to mark a secret as not needing to be censored
 	SkipCensoringLabel = "ci.openshift.io/skip-censoring"

--- a/pkg/steps/lease.go
+++ b/pkg/steps/lease.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	coreapi "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -288,15 +289,27 @@ func (s *leaseStep) handleClusterProfile(ctx context.Context, l *stepLease, name
 		return fmt.Errorf("import secret %s for cluster profile %s: %w", cpDetails.Secret, s.clusterProfileName, err)
 	}
 
-	s.stsHomeRoleARN = string(secretData[api.STSHomeRoleARNSecretKey])
 	s.stsHubRoleARN = string(secretData[api.STSHubRoleARNSecretKey])
 	s.stsTargetRoleARN = string(secretData[api.STSTargetRoleARNSecretKey])
 
-	if s.stsHubRoleARN != "" && s.stsTargetRoleARN != "" && s.stsHomeRoleARN == "" {
-		logrus.Warnf("STS hub and target role ARNs are set for profile %s but home_role_arn is missing "+
-			"from the cluster profile secret; STS will not be activated", s.clusterProfileName)
-		s.stsHubRoleARN = ""
-		s.stsTargetRoleARN = ""
+	if s.stsHubRoleARN != "" && s.stsTargetRoleARN != "" {
+		secret := &coreapi.Secret{}
+		objKey := ctrlruntimeclient.ObjectKey{Namespace: "ci", Name: api.STSClusterSecretName}
+		if err := s.kubeClient.Get(ctx, objKey, secret); err != nil && !kerrors.IsNotFound(err) {
+			return fmt.Errorf("read Secret %s: %w", api.STSClusterSecretName, err)
+		}
+		if arn := string(secret.Data[api.STSHomeRoleARNKey]); arn != "" {
+			s.stsHomeRoleARN = arn
+			logrus.Infof("Resolved home_role_arn from Secret %s", api.STSClusterSecretName)
+		}
+
+		if s.stsHomeRoleARN == "" {
+			logrus.Warnf("STS hub and target role ARNs are set for profile %s but home_role_arn "+
+				"was not found in Secret %s; STS will not be activated",
+				s.clusterProfileName, api.STSClusterSecretName)
+			s.stsHubRoleARN = ""
+			s.stsTargetRoleARN = ""
+		}
 	}
 
 	s.clusterProfileSecretName = cpDetails.Secret

--- a/pkg/steps/lease_test.go
+++ b/pkg/steps/lease_test.go
@@ -475,18 +475,28 @@ func TestAcquireLeases(t *testing.T) {
 					Name: "us-east-1--aws-quota-slice-0",
 				},
 			},
-			objects: []ctrlruntimeclient.Object{&corev1.Secret{
-				ObjectMeta: v1.ObjectMeta{
-					Namespace: "ci",
-					Name:      "cluster-secrets-aws",
+			objects: []ctrlruntimeclient.Object{
+				&corev1.Secret{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: "ci",
+						Name:      "cluster-secrets-aws",
+					},
+					Data: map[string][]byte{
+						"k1":                          []byte("v1"),
+						api.STSHubRoleARNSecretKey:    []byte("arn:aws:iam::111:role/hub"),
+						api.STSTargetRoleARNSecretKey: []byte("arn:aws:iam::222:role/target"),
+					},
 				},
-				Data: map[string][]byte{
-					"k1":                          []byte("v1"),
-					api.STSHomeRoleARNSecretKey:   []byte("arn:aws:iam::000:role/home"),
-					api.STSHubRoleARNSecretKey:    []byte("arn:aws:iam::111:role/hub"),
-					api.STSTargetRoleARNSecretKey: []byte("arn:aws:iam::222:role/target"),
+				&corev1.Secret{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: "ci",
+						Name:      api.STSClusterSecretName,
+					},
+					Data: map[string][]byte{
+						api.STSHomeRoleARNKey: []byte("arn:aws:iam::000:role/home"),
+					},
 				},
-			}},
+			},
 			clusterProfiles: map[string]*api.ClusterProfileDetails{
 				"aws": {
 					Secret:    "cluster-secrets-aws",
@@ -508,12 +518,21 @@ func TestAcquireLeases(t *testing.T) {
 					{
 						ObjectMeta: v1.ObjectMeta{
 							Namespace:       "ci",
+							Name:            api.STSClusterSecretName,
+							ResourceVersion: "999",
+						},
+						Data: map[string][]byte{
+							api.STSHomeRoleARNKey: []byte("arn:aws:iam::000:role/home"),
+						},
+					},
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Namespace:       "ci",
 							Name:            "cluster-secrets-aws",
 							ResourceVersion: "999",
 						},
 						Data: map[string][]byte{
 							"k1":                          []byte("v1"),
-							api.STSHomeRoleARNSecretKey:   []byte("arn:aws:iam::000:role/home"),
 							api.STSHubRoleARNSecretKey:    []byte("arn:aws:iam::111:role/hub"),
 							api.STSTargetRoleARNSecretKey: []byte("arn:aws:iam::222:role/target"),
 						},
@@ -526,7 +545,175 @@ func TestAcquireLeases(t *testing.T) {
 						},
 						Data: map[string][]byte{
 							"k1":                          []byte("v1"),
-							api.STSHomeRoleARNSecretKey:   []byte("arn:aws:iam::000:role/home"),
+							api.STSHubRoleARNSecretKey:    []byte("arn:aws:iam::111:role/hub"),
+							api.STSTargetRoleARNSecretKey: []byte("arn:aws:iam::222:role/target"),
+						},
+						Immutable: ptr.To(true),
+					},
+				},
+			},
+			wantCalls: []string{
+				"acquireWaitWithPriority owner aws free leased random",
+				"releaseone owner us-east-1--aws-quota-slice-0 free",
+			},
+		},
+		{
+			name: "STS deactivated when cluster secret missing",
+			leases: []api.StepLease{{
+				ResourceType:   "aws",
+				Env:            api.DefaultLeaseEnv,
+				Count:          1,
+				ClusterProfile: "aws",
+			}},
+			resources: map[string]*common.Resource{
+				"acquireWaitWithPriority_aws_free_leased_random": {
+					Name: "us-east-1--aws-quota-slice-0",
+				},
+			},
+			objects: []ctrlruntimeclient.Object{&corev1.Secret{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "ci",
+					Name:      "cluster-secrets-aws",
+				},
+				Data: map[string][]byte{
+					"k1":                          []byte("v1"),
+					api.STSHubRoleARNSecretKey:    []byte("arn:aws:iam::111:role/hub"),
+					api.STSTargetRoleARNSecretKey: []byte("arn:aws:iam::222:role/target"),
+				},
+			}},
+			clusterProfiles: map[string]*api.ClusterProfileDetails{
+				"aws": {
+					Secret:    "cluster-secrets-aws",
+					LeaseType: "aws-quota-slice",
+				},
+			},
+			wantProvides: map[string]string{
+				"parameter":                       "map",
+				api.ClusterProfileSetEnv:          "",
+				api.ClusterProfileParam:           "aws",
+				api.ClusterProfileSecretNameParam: "cluster-secrets-aws",
+				api.STSHomeRoleARNParam:           "",
+				api.STSHubRoleARNParam:            "",
+				api.STSTargetRoleARNParam:         "",
+				api.DefaultLeaseEnv:               "us-east-1",
+			},
+			wantSecrets: corev1.SecretList{
+				Items: []corev1.Secret{
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Namespace:       "ci",
+							Name:            "cluster-secrets-aws",
+							ResourceVersion: "999",
+						},
+						Data: map[string][]byte{
+							"k1":                          []byte("v1"),
+							api.STSHubRoleARNSecretKey:    []byte("arn:aws:iam::111:role/hub"),
+							api.STSTargetRoleARNSecretKey: []byte("arn:aws:iam::222:role/target"),
+						},
+					},
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Namespace:       ns,
+							Name:            "cluster-secrets-aws",
+							ResourceVersion: "1",
+						},
+						Data: map[string][]byte{
+							"k1":                          []byte("v1"),
+							api.STSHubRoleARNSecretKey:    []byte("arn:aws:iam::111:role/hub"),
+							api.STSTargetRoleARNSecretKey: []byte("arn:aws:iam::222:role/target"),
+						},
+						Immutable: ptr.To(true),
+					},
+				},
+			},
+			wantCalls: []string{
+				"acquireWaitWithPriority owner aws free leased random",
+				"releaseone owner us-east-1--aws-quota-slice-0 free",
+			},
+		},
+		{
+			name: "STS deactivated when cluster secret has empty home_role_arn",
+			leases: []api.StepLease{{
+				ResourceType:   "aws",
+				Env:            api.DefaultLeaseEnv,
+				Count:          1,
+				ClusterProfile: "aws",
+			}},
+			resources: map[string]*common.Resource{
+				"acquireWaitWithPriority_aws_free_leased_random": {
+					Name: "us-east-1--aws-quota-slice-0",
+				},
+			},
+			objects: []ctrlruntimeclient.Object{
+				&corev1.Secret{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: "ci",
+						Name:      "cluster-secrets-aws",
+					},
+					Data: map[string][]byte{
+						"k1":                          []byte("v1"),
+						api.STSHubRoleARNSecretKey:    []byte("arn:aws:iam::111:role/hub"),
+						api.STSTargetRoleARNSecretKey: []byte("arn:aws:iam::222:role/target"),
+					},
+				},
+				&corev1.Secret{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: "ci",
+						Name:      api.STSClusterSecretName,
+					},
+					Data: map[string][]byte{
+						api.STSHomeRoleARNKey: []byte(""),
+					},
+				},
+			},
+			clusterProfiles: map[string]*api.ClusterProfileDetails{
+				"aws": {
+					Secret:    "cluster-secrets-aws",
+					LeaseType: "aws-quota-slice",
+				},
+			},
+			wantProvides: map[string]string{
+				"parameter":                       "map",
+				api.ClusterProfileSetEnv:          "",
+				api.ClusterProfileParam:           "aws",
+				api.ClusterProfileSecretNameParam: "cluster-secrets-aws",
+				api.STSHomeRoleARNParam:           "",
+				api.STSHubRoleARNParam:            "",
+				api.STSTargetRoleARNParam:         "",
+				api.DefaultLeaseEnv:               "us-east-1",
+			},
+			wantSecrets: corev1.SecretList{
+				Items: []corev1.Secret{
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Namespace:       "ci",
+							Name:            api.STSClusterSecretName,
+							ResourceVersion: "999",
+						},
+						Data: map[string][]byte{
+							api.STSHomeRoleARNKey: []byte(""),
+						},
+					},
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Namespace:       "ci",
+							Name:            "cluster-secrets-aws",
+							ResourceVersion: "999",
+						},
+						Data: map[string][]byte{
+							"k1":                          []byte("v1"),
+							api.STSHubRoleARNSecretKey:    []byte("arn:aws:iam::111:role/hub"),
+							api.STSTargetRoleARNSecretKey: []byte("arn:aws:iam::222:role/target"),
+						},
+					},
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Namespace:       ns,
+							Name:            "cluster-secrets-aws",
+							ResourceVersion: "1",
+						},
+						Data: map[string][]byte{
+							"k1":                          []byte("v1"),
 							api.STSHubRoleARNSecretKey:    []byte("arn:aws:iam::111:role/hub"),
 							api.STSTargetRoleARNSecretKey: []byte("arn:aws:iam::222:role/target"),
 						},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## STS Home Role ARN Configuration Moved to Dedicated Secret

This PR changes how STS (Secure Token Service) credentials are resolved by the lease step used by ci-operator tests: the home role ARN is moved out of per-cluster-profile secrets and into a dedicated cluster-wide secret in the ci namespace.

What changed in practice
- Component affected: ci-operator lease acquisition logic (pkg/steps/lease.go) that copies cluster-profile secrets into test namespaces and exposes STS parameters to jobs.
- Behavior change:
  - Hub and target role ARNs continue to be read from the cluster profile secret copied into the test namespace.
  - The home role ARN is now resolved from a cluster-wide secret named aws-sts-cluster-config (api.STSClusterSecretName) in the ci namespace when hub and target ARNs are present. A missing cluster secret is tolerated; other read errors are returned. If the home_role_arn is absent or empty, STS is not activated and hub/target ARNs are cleared.
- Constants (pkg/api/constant.go):
  - STSHomeRoleARNSecretKey was renamed to STSHomeRoleARNKey ("home_role_arn").
  - Added STSClusterSecretName = "aws-sts-cluster-config".
- Tests (pkg/steps/lease_test.go):
  - LeaseStep tests updated to reflect the split: cluster profile secret carries hub/target ARNs, aws-sts-cluster-config carries home_role_arn. Tests cover successful resolution, missing cluster secret, and empty home_role_arn scenarios.

Operational impact
- Operators must provision the cluster-wide STS home role ARN in the ci namespace secret named aws-sts-cluster-config to enable STS when cluster profile secrets contain hub/target ARNs.
- The change centralizes home-role management for easier rotation and avoids modifying cluster-profile secrets for home-role updates.
- The logic is defensive: if the home role ARN cannot be read or is empty, STS activation for the job is disabled to avoid partial/incorrect STS configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->