### PR TITLE
fix: resolve promotion digest from quay.io using push-secret

### DIFF
--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -353,9 +353,10 @@ func getMirrorRetryShell(registryConfig string, images []string, loglevel int) s
 done`, n, mirrorCmd, n)
 }
 
-// getResolveAndTagRetryShell resolves quay-proxy digest via oc image info and oc tags the IST; retries when QCI moves after mirror.
+// getResolveAndTagRetryShell resolves digest from quay.io (push-secret) and tags the IST with quay-proxy@digest.
 func getResolveAndTagRetryShell(registryConfig, quayProxyTag, isTag string, loglevel int, filterByOS string) string {
 	repo := quayProxyTag[:strings.LastIndex(quayProxyTag, ":")]
+	quayIOTag := strings.Replace(quayProxyTag, api.QCIAPPCIDomain, "quay.io", 1)
 	n := quayPromotionDigestTagAttempts
 	return fmt.Sprintf(`for r in {1..%d}; do
   _digest=$(oc image info --registry-config=%s --filter-by-os=%s %s | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
@@ -370,7 +371,7 @@ func getResolveAndTagRetryShell(registryConfig, quayProxyTag, isTag string, logl
   backoff=$(($RANDOM %% %d))s
   sleep "${backoff}"
 done
-`, n, registryConfig, filterByOS, quayProxyTag, loglevel, repo, isTag,
+`, n, registryConfig, filterByOS, quayIOTag, loglevel, repo, isTag,
 		isTag, n,
 		n,
 		isTag, n,

--- a/pkg/steps/release/promote_test.go
+++ b/pkg/steps/release/promote_test.go
@@ -1132,9 +1132,10 @@ func TestGetResolveAndTagRetryShell(t *testing.T) {
 	isTag := "ocp/4.21-quay:ovn-kubernetes"
 	got := getResolveAndTagRetryShell(regcfg, proxyTag, isTag, 2, "linux/amd64")
 
+	quayIOTag := "quay.io/openshift/ci:ocp_4.21_ovn-kubernetes"
 	for _, sub := range []string{
 		"for r in {1..5}",
-		"oc image info --registry-config=" + regcfg + " --filter-by-os=linux/amd64 " + proxyTag,
+		"oc image info --registry-config=" + regcfg + " --filter-by-os=linux/amd64 " + quayIOTag,
 		"oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} " + isTag,
 		"promotion-quay: digest-tag failed for " + isTag,
 		"promotion-quay: retrying digest-tag for " + isTag,

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_4.12.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_4.12.yaml
@@ -20,7 +20,7 @@ spec:
         sleep $backoff
       done
       for r in {1..5}; do
-        _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay-proxy.ci.openshift.org/openshift/ci:ocp_4.12_ovn-kubernetes | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+        _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
         if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.12:ovn-kubernetes; then
           break
         fi
@@ -34,7 +34,7 @@ spec:
       done
 
       for r in {1..5}; do
-        _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay-proxy.ci.openshift.org/openshift/ci:ocp_4.12_ovn-kubernetes-base | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+        _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
         if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.12:ovn-kubernetes-base; then
           break
         fi

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_multiple_tags.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_multiple_tags.yaml
@@ -20,7 +20,7 @@ spec:
         sleep $backoff
       done
       for r in {1..5}; do
-        _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay-proxy.ci.openshift.org/openshift/ci:ocp_4.21_ovn-kubernetes | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+        _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
         if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.21:ovn-kubernetes; then
           break
         fi
@@ -34,7 +34,7 @@ spec:
       done
 
       for r in {1..5}; do
-        _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay-proxy.ci.openshift.org/openshift/ci:ocp_4.21_ovn-kubernetes-base | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+        _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
         if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.21:ovn-kubernetes-base; then
           break
         fi
@@ -48,7 +48,7 @@ spec:
       done
 
       for r in {1..5}; do
-        _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay-proxy.ci.openshift.org/openshift/ci:ocp_4.21_ovn-kubernetes-microshift | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+        _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
         if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.21:ovn-kubernetes-microshift; then
           break
         fi

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_non_release_namespace.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_non_release_namespace.yaml
@@ -19,7 +19,7 @@ spec:
         sleep $backoff
       done
       for r in {1..5}; do
-        _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay-proxy.ci.openshift.org/openshift/ci:ocp_4.21_ovn-kubernetes | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+        _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
         if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.21:ovn-kubernetes; then
           break
         fi


### PR DESCRIPTION
https://search.dptools.openshift.org/?search=Reporting+job+state.*with+reason.*promoting_images&maxAge=6h&context=1&type=build-log&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

/cc @openshift/test-platform 

/hold

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Image Promotion Digest Resolution

This PR fixes how the release promotion process resolves image digests when promoting to quay.io. The change affects the **pkg/steps/release** component that handles OpenShift release image promotion to Quay.

### What Changed

The promotion process uses a two-step approach for official OpenShift image streams:
1. Mirror images to quay.io using `oc image mirror`
2. Resolve the exact digest from the mirrored image and tag it back to the release ImageStream

**The fix**: The digest resolution step now queries the direct `quay.io/openshift/ci` endpoint instead of going through the `quay-proxy.ci.openshift.org` proxy. This is done by rewriting the proxy tag domain name in the generated shell command.

### Practical Impact

For CI operators and users: This improves the reliability of release promotion by eliminating an unnecessary intermediary. The direct quay.io queries are authenticated using the same push-secret credentials that are already configured for promotion, making the process more straightforward and reducing potential proxy-related failure points. The actual tagging back to the release ImageStream still uses the proxy endpoint as before, but now with the correctly resolved digest from the authoritative quay.io source.

### Modified Files

- `pkg/steps/release/promote.go`: Updated `getResolveAndTagRetryShell()` to derive a `quayIOTag` by rewriting the proxy domain to `quay.io` and use it in the `oc image info` call
- `pkg/steps/release/promote_test.go`: Updated test expectations to verify digest queries target quay.io
- Test fixture files: Updated expected shell commands across four test scenarios (`promotion_quay_4.12.yaml`, `promotion_quay_multiple_tags.yaml`, `promotion_quay_non_release_namespace.yaml`, and related fixtures)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->