### PR TITLE
feat(promoted-image-governor): use quay.io openshift ci mapping sources

### DIFF
--- a/cmd/promoted-image-governor/main.go
+++ b/cmd/promoted-image-governor/main.go
@@ -256,7 +256,7 @@ func generateMappings(promotedTags []api.ImageStreamTagReference, mappingConfig 
 						if _, ok := mappings[filename]; !ok {
 							mappings[filename] = map[string]sets.Set[string]{}
 						}
-						src := api.QuayImageReference(api.ImageStreamTagReference{
+						src := api.QuayImage(api.ImageStreamTagReference{
 							Namespace: mappingConfig.SourceNamespace,
 							Name:      tag.Name,
 							Tag:       tag.Tag,

--- a/cmd/promoted-image-governor/main_test.go
+++ b/cmd/promoted-image-governor/main_test.go
@@ -220,20 +220,20 @@ func TestGenerateMappings(t *testing.T) {
 			},
 			expected: map[string]map[string]sets.Set[string]{
 				"mapping_origin_4_8": {
-					"quay-proxy.ci.openshift.org/openshift/ci:origin_4.8_bar": sets.New[string]("quay.io/openshift/origin-bar:4.8", "quay.io/openshift/origin-bar:4.8.0"),
-					"quay-proxy.ci.openshift.org/openshift/ci:origin_4.8_foo": sets.New[string]("quay.io/openshift/origin-foo:4.8", "quay.io/openshift/origin-foo:4.8.0"),
-					"quay-proxy.ci.openshift.org/openshift/ci:origin_4.8_ocp-some": sets.New[string](
+					"quay.io/openshift/ci:origin_4.8_bar": sets.New[string]("quay.io/openshift/origin-bar:4.8", "quay.io/openshift/origin-bar:4.8.0"),
+					"quay.io/openshift/ci:origin_4.8_foo": sets.New[string]("quay.io/openshift/origin-foo:4.8", "quay.io/openshift/origin-foo:4.8.0"),
+					"quay.io/openshift/ci:origin_4.8_ocp-some": sets.New[string](
 						"quay.io/openshift/origin-ocp-some:4.8",
 						"quay.io/openshift/origin-ocp-some:4.8.0",
 					),
 				},
 				"mapping_origin_4_9": {
-					"quay-proxy.ci.openshift.org/openshift/ci:origin_4.9_bar": sets.New[string](
+					"quay.io/openshift/ci:origin_4.9_bar": sets.New[string](
 						"quay.io/openshift/origin-bar:4.9",
 						"quay.io/openshift/origin-bar:4.9.0",
 						"quay.io/openshift/origin-bar:latest",
 					),
-					"quay-proxy.ci.openshift.org/openshift/ci:origin_4.9_some": sets.New[string](
+					"quay.io/openshift/ci:origin_4.9_some": sets.New[string](
 						"quay.io/openshift/origin-some:4.9",
 						"quay.io/openshift/origin-some:4.9.0",
 						"quay.io/openshift/origin-some:latest",
@@ -271,8 +271,8 @@ func TestGenerateMappings(t *testing.T) {
 				},
 			},
 			expectedErr: utilerrors.NewAggregate([]error{
-				fmt.Errorf("cannot define the same mirroring destination quay.io/openshift/origin-ovirt-installer:4.6 more than once for the source quay-proxy.ci.openshift.org/openshift/ci:origin_4.6_ovirt-installer in filename mapping_origin_4_6"),
-				fmt.Errorf("cannot define the same mirroring destination quay.io/openshift/origin-ovirt-installer:4.6.0 more than once for the source quay-proxy.ci.openshift.org/openshift/ci:origin_4.6_ovirt-installer in filename mapping_origin_4_6"),
+				fmt.Errorf("cannot define the same mirroring destination quay.io/openshift/origin-ovirt-installer:4.6 more than once for the source quay.io/openshift/ci:origin_4.6_ovirt-installer in filename mapping_origin_4_6"),
+				fmt.Errorf("cannot define the same mirroring destination quay.io/openshift/origin-ovirt-installer:4.6.0 more than once for the source quay.io/openshift/ci:origin_4.6_ovirt-installer in filename mapping_origin_4_6"),
 			}),
 		},
 		{
@@ -307,7 +307,7 @@ func TestGenerateMappings(t *testing.T) {
 			},
 			expected: map[string]map[string]sets.Set[string]{
 				"mapping_origin_4_6": {
-					"quay-proxy.ci.openshift.org/openshift/ci:origin_4.6_ovirt-installer": sets.New[string]("quay.io/openshift/origin-ovirt-installer:4.6", "quay.io/openshift/origin-ovirt-installer:4.6.0"),
+					"quay.io/openshift/ci:origin_4.6_ovirt-installer": sets.New[string]("quay.io/openshift/origin-ovirt-installer:4.6", "quay.io/openshift/origin-ovirt-installer:4.6.0"),
 				},
 			},
 		},


### PR DESCRIPTION
/cc @danilo-gemoli 
/hold

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## promoted-image-governor: Use quay.io OpenShift CI mapping sources

The **promoted-image-governor** tool has been updated to generate image mapping files using direct `quay.io/openshift/ci` source image references instead of proxied `quay-proxy.ci.openshift.org` references.

### What changed

In the `generateMappings` function, which generates mapping files for image mirroring, the source registry mapping is now constructed using `api.QuayImage()` instead of `api.QuayImageReference()`. This changes the source image format in generated mapping files from `quay-proxy.ci.openshift.org/openshift/ci:origin_X_Y_Z` to `quay.io/openshift/ci:origin_X_Y_Z`.

### Impact

The image mapping files used by the [periodic-image-mirroring-openshift](https://prow.ci.openshift.org/?job=periodic-image-mirroring-openshift) job that mirror promoted OpenShift container images will now source directly from `quay.io` instead of the CI proxy registry. These mappings are stored in the [openshift/release repository](https://github.com/openshift/release/tree/main/core-services/image-mirroring/openshift) and are maintained automatically by the tool to ensure correctness and reduce manual maintenance work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->