### PR TITLE
Remove old cluster profile set details type

### DIFF
--- a/pkg/api/clusterprofile.go
+++ b/pkg/api/clusterprofile.go
@@ -1,10 +1,8 @@
 package api
 
 import (
-	"encoding/json"
 	"fmt"
 	"slices"
-	"strings"
 
 	aggerrs "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -1275,33 +1273,9 @@ type ClusterProfileOwners struct {
 }
 type ClusterClaimOwnersMap map[string]ClusterClaimDetails
 
-// +kubebuilder:object:generate=false
-type ClusterProfileSetDetails struct {
-	ClusterProfileSetDetailsNew
-}
-
-func (cps *ClusterProfileSetDetails) UnmarshalJSON(data []byte) error {
-	cpsDetails := make(map[ClusterProfile][]string)
-
-	if strings.Contains(string(data), `"cluster_profile_sets"`) {
-		newCPSDetails := ClusterProfileSetDetailsNew{}
-		if err := json.Unmarshal(data, &newCPSDetails); err != nil {
-			return fmt.Errorf("new ClusterProfileSetDetails schema: %w", err)
-		}
-		cps.ClusterProfileSetDetailsNew = newCPSDetails
-	} else {
-		if err := json.Unmarshal(data, &cpsDetails); err != nil {
-			return fmt.Errorf("old ClusterProfileSetDetails schema: %w", err)
-		}
-		cps.ClusterProfileSets = cpsDetails
-	}
-
-	return nil
-}
-
 // TODO: This will replace `ClusterProfileSetDetails` once the migration is complete.
 // +kubebuilder:object:generate=false
-type ClusterProfileSetDetailsNew struct {
+type ClusterProfileSetDetails struct {
 	ClusterProfileSets map[ClusterProfile][]string `json:"cluster_profile_sets,omitempty"`
 
 	// TestsAllowlist holds a list of tests for which we do not enfoce policy
@@ -1311,7 +1285,7 @@ type ClusterProfileSetDetailsNew struct {
 	TestsAllowlist map[utilregexp.Regexp]map[utilregexp.Regexp]map[utilregexp.Regexp][]utilregexp.Regexp `json:"tests_allowlist,omitempty"`
 }
 
-func (cps ClusterProfileSetDetailsNew) FindSetByProfile(profile ClusterProfile) (ClusterProfile, bool) {
+func (cps ClusterProfileSetDetails) FindSetByProfile(profile ClusterProfile) (ClusterProfile, bool) {
 	for cpsName, cpDetails := range cps.ClusterProfileSets {
 		if slices.Contains(cpDetails, string(profile)) {
 			return cpsName, true
@@ -1320,7 +1294,7 @@ func (cps ClusterProfileSetDetailsNew) FindSetByProfile(profile ClusterProfile) 
 	return "", false
 }
 
-func (cps ClusterProfileSetDetailsNew) IsTestAllowlisted(test string, metadata Metadata) bool {
+func (cps ClusterProfileSetDetails) IsTestAllowlisted(test string, metadata Metadata) bool {
 	if cps.TestsAllowlist == nil {
 		return false
 	}

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -446,70 +445,6 @@ func TestResolveClusterProfileList(t *testing.T) {
 
 			if diff := cmp.Diff(tc.wantProfiles, tc.profiles); diff != "" {
 				t.Errorf("unexpected profiles: %s", diff)
-			}
-		})
-	}
-}
-
-func TestUnmarshalClusterProfileSetDetails(t *testing.T) {
-	t.Parallel()
-	for _, tc := range []struct {
-		name                         string
-		data                         string
-		wantClusterProfileSetDetails ClusterProfileSetDetails
-	}{
-		{
-			name: "Old schema",
-			data: `{
-		"openshift-org-aws": [
-			"aws",
-			"aws-2",
-			"aws-3",
-			"aws-4",
-			"aws-5"
-			]
-		}`,
-			wantClusterProfileSetDetails: ClusterProfileSetDetails{
-				ClusterProfileSetDetailsNew: ClusterProfileSetDetailsNew{
-					ClusterProfileSets: map[ClusterProfile][]string{
-						"openshift-org-aws": {"aws", "aws-2", "aws-3", "aws-4", "aws-5"},
-					},
-				},
-			},
-		},
-		{
-			name: "New schema",
-			data: `{
-"cluster_profile_sets": {
-	"openshift-org-aws": [
-			"aws",
-			"aws-2",
-			"aws-3",
-			"aws-4",
-			"aws-5"
-		]
-	}
-}`,
-			wantClusterProfileSetDetails: ClusterProfileSetDetails{
-				ClusterProfileSetDetailsNew: ClusterProfileSetDetailsNew{
-					ClusterProfileSets: map[ClusterProfile][]string{
-						"openshift-org-aws": {"aws", "aws-2", "aws-3", "aws-4", "aws-5"},
-					},
-				},
-			},
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			gotClusterProfileSetDetails := ClusterProfileSetDetails{}
-			if err := json.Unmarshal([]byte(tc.data), &gotClusterProfileSetDetails); err != nil {
-				t.Errorf("fail to unmarshal cluster profile set details: %s", err.Error())
-				return
-			}
-
-			if diff := cmp.Diff(&tc.wantClusterProfileSetDetails, &gotClusterProfileSetDetails); diff != "" {
-				t.Errorf("unexpected cluster profile set details:\n %s", diff)
 			}
 		})
 	}

--- a/pkg/validation/test_test.go
+++ b/pkg/validation/test_test.go
@@ -2476,10 +2476,8 @@ func TestValidateClusterProfiles(t *testing.T) {
 			metadata:       &api.Metadata{},
 			clusterProfile: "azure-2",
 			cpsDetails: api.ClusterProfileSetDetails{
-				ClusterProfileSetDetailsNew: api.ClusterProfileSetDetailsNew{
-					ClusterProfileSets: map[api.ClusterProfile][]string{
-						"openshift-org-azure": {"azure-2"},
-					},
+				ClusterProfileSets: map[api.ClusterProfile][]string{
+					"openshift-org-azure": {"azure-2"},
 				},
 			},
 			wantErrs: []error{errors.New(`foo: invalid cluster profile "azure-2", use the cluster profile set "openshift-org-azure" instead`)},
@@ -2490,13 +2488,11 @@ func TestValidateClusterProfiles(t *testing.T) {
 			testName:       "e2e-aws-ovn",
 			clusterProfile: "azure-2",
 			cpsDetails: api.ClusterProfileSetDetails{
-				ClusterProfileSetDetailsNew: api.ClusterProfileSetDetailsNew{
-					ClusterProfileSets: map[api.ClusterProfile][]string{
-						"openshift-org-azure": {"azure-2"},
-					},
-					TestsAllowlist: map[utilregexp.Regexp]map[utilregexp.Regexp]map[utilregexp.Regexp][]utilregexp.Regexp{
-						re("openshift/ci-tools"): {re("main"): {re(""): {re("e2e-aws-ovn")}}},
-					},
+				ClusterProfileSets: map[api.ClusterProfile][]string{
+					"openshift-org-azure": {"azure-2"},
+				},
+				TestsAllowlist: map[utilregexp.Regexp]map[utilregexp.Regexp]map[utilregexp.Regexp][]utilregexp.Regexp{
+					re("openshift/ci-tools"): {re("main"): {re(""): {re("e2e-aws-ovn")}}},
 				},
 			},
 		},
@@ -2506,13 +2502,11 @@ func TestValidateClusterProfiles(t *testing.T) {
 			testName:       "aws-ipi-public-ipv4-pool-byo-subnet-amd-f28-destructive",
 			clusterProfile: "azure-2",
 			cpsDetails: api.ClusterProfileSetDetails{
-				ClusterProfileSetDetailsNew: api.ClusterProfileSetDetailsNew{
-					ClusterProfileSets: map[api.ClusterProfile][]string{
-						"openshift-org-azure": {"azure-2"},
-					},
-					TestsAllowlist: map[utilregexp.Regexp]map[utilregexp.Regexp]map[utilregexp.Regexp][]utilregexp.Regexp{
-						re("openshift(-priv)?/openshift-tests-private"): {re("main"): {re("daily|nightly"): {re(".*-ipi-public-ipv4-pool-.*")}}},
-					},
+				ClusterProfileSets: map[api.ClusterProfile][]string{
+					"openshift-org-azure": {"azure-2"},
+				},
+				TestsAllowlist: map[utilregexp.Regexp]map[utilregexp.Regexp]map[utilregexp.Regexp][]utilregexp.Regexp{
+					re("openshift(-priv)?/openshift-tests-private"): {re("main"): {re("daily|nightly"): {re(".*-ipi-public-ipv4-pool-.*")}}},
 				},
 			},
 		},


### PR DESCRIPTION
This is a follow up of https://github.com/openshift/release/pull/79093. The backward compatibility with the old schema is no longer necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Cluster Profile Set Details Type Cleanup

This PR removes the legacy backward compatibility layer for cluster profile set details by eliminating the intermediate `ClusterProfileSetDetailsNew` schema type that was introduced during a previous migration (see openshift/release#79093).

## What's Changed

**Simplified Schema Structure**: The `ClusterProfileSetDetails` type no longer delegates to the intermediate `ClusterProfileSetDetailsNew` type. Instead, it now directly defines the `cluster_profile_sets` and `tests_allowlist` fields. This consolidates the cluster profile configuration into a single, cleaner type definition.

**Removed JSON Unmarshalling Support**: The custom `UnmarshalJSON` method that handled translation from the old schema format to the new one has been deleted. This legacy conversion logic is no longer needed since the migration referenced in the follow-up PR is complete.

**Updated Method Signatures**: The `FindSetByProfile` and `IsTestAllowlisted` helper methods now have `ClusterProfileSetDetails` as their receiver type instead of `ClusterProfileSetDetailsNew`, maintaining the same functionality but working directly with the simplified type.

**Test Updates**: Test cases in `pkg/validation/test_test.go` and unit tests in `pkg/api/types_test.go` have been updated to use the new consolidated type. The specific test validating the legacy JSON unmarshalling behavior (`TestUnmarshalClusterProfileSetDetails`) has been removed as it's no longer applicable.

## Impact

This is a cleanup that removes technical debt from the codebase. CI operators and users will not see any behavioral changes—this purely simplifies the internal representation of cluster profile configurations by removing the now-unnecessary backward compatibility scaffolding. The public API behavior for loading and using cluster profile sets remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->