### PR TITLE
NO-ISSUE: Register packet-osac cluster profile

### DIFF
--- a/pkg/api/clusterprofile.go
+++ b/pkg/api/clusterprofile.go
@@ -152,6 +152,7 @@ const (
 	ClusterProfilePacket                  ClusterProfile = "packet"
 	ClusterProfilePacketAssisted          ClusterProfile = "packet-assisted"
 	ClusterProfilePacketSNO               ClusterProfile = "packet-sno"
+	ClusterProfilePacketOSAC              ClusterProfile = "packet-osac"
 	ClusterProfileVSphereDis2             ClusterProfile = "vsphere-dis-2"
 	ClusterProfileVSphereMultizone2       ClusterProfile = "vsphere-multizone-2"
 	ClusterProfileVSphereConnected2       ClusterProfile = "vsphere-connected-2"
@@ -372,6 +373,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfilePacket,
 		ClusterProfilePacketAssisted,
 		ClusterProfilePacketSNO,
+		ClusterProfilePacketOSAC,
 
 		ClusterProfileVSphereDis2,
 		ClusterProfileVSphereMultizone2,
@@ -679,7 +681,8 @@ func (p ClusterProfile) ClusterType() string {
 		return "packet"
 	case
 		ClusterProfilePacketAssisted,
-		ClusterProfilePacketSNO:
+		ClusterProfilePacketSNO,
+		ClusterProfilePacketOSAC:
 		return "packet-edge"
 	case ClusterProfileKubevirt:
 		return "kubevirt"
@@ -1014,7 +1017,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "packet-quota-slice"
 	case
 		ClusterProfilePacketAssisted,
-		ClusterProfilePacketSNO:
+		ClusterProfilePacketSNO,
+		ClusterProfilePacketOSAC:
 		return "packet-edge-quota-slice"
 	case ClusterProfileVSphereDis2:
 		return "vsphere-dis-2-quota-slice"


### PR DESCRIPTION
## Summary
- Add `packet-osac` cluster profile for OSAC bare metal CI jobs
- Maps to existing `packet-edge` cluster type and `packet-edge-quota-slice` lease
- Enables OSAC to use a dedicated cluster profile decoupled from `packet-assisted`

Companion release PR will follow to update OSAC workflows and secret bootstrap config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Registers a new `packet-osac` cluster profile for OSAC bare metal CI

This PR adds a dedicated cluster profile for OSAC (OpenShift AI Cloud) to use for bare metal CI testing. 

**What changed:**
- Added a new `ClusterProfilePacketOSAC` constant representing the `"packet-osac"` profile
- Wired the new profile into the cluster infrastructure mapping system:
  - Maps to the existing `"packet-edge"` cluster type (which provides bare metal infrastructure via Packet)
  - Maps to the existing `"packet-edge-quota-slice"` lease type (which manages resource quotas)
  - Added to the list of all supported cluster profiles used by CI job validation

**Impact for CI users and operators:**
OSAC now has a dedicated cluster profile that can be independently configured in CI jobs, decoupled from the existing `packet-assisted` profile while still leveraging the same underlying Packet bare metal infrastructure. This enables OSAC workflows to use distinct cluster-specific secrets and configurations while sharing hardware resources through the quota lease mechanism. A companion PR is expected to follow that will update OSAC workflows and secret bootstrap configuration to use this new profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->