### PR TITLE
private-prow-configs-mirror: fix trigger injection for org-level and repo-level entries

### DIFF
--- a/cmd/private-prow-configs-mirror/main.go
+++ b/cmd/private-prow-configs-mirror/main.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -404,10 +405,10 @@ func injectPrivateLGTMPlugin(lgtms []plugins.Lgtm, orgRepos orgReposWithOfficial
 	}
 }
 
-func injectPrivateTriggers(triggers []plugins.Trigger, orgRepos orgReposWithOfficialImages) {
+func injectPrivateTriggers(triggers *[]plugins.Trigger, orgRepos orgReposWithOfficialImages) {
 	logrus.Info("Processing...")
 
-	for index, trigger := range triggers {
+	for index, trigger := range *triggers {
 		repos := sets.New[string]()
 		for _, orgRepo := range trigger.Repos {
 			if strings.HasPrefix(orgRepo, fmt.Sprintf("%s/", openshiftPrivOrg)) {
@@ -420,10 +421,51 @@ func injectPrivateTriggers(triggers []plugins.Trigger, orgRepos orgReposWithOffi
 			if privateOrgRepoName, ok := orgRepos.privateOrgRepoFull(orgRepo); ok {
 				logrus.WithField("source_repo", orgRepo).WithField("private_repo", privateOrgRepoName).Info("Found")
 				repos.Insert(privateOrgRepoName)
+			} else if !strings.Contains(orgRepo, "/") {
+				if _, ok := orgRepos[orgRepo]; ok {
+					logrus.WithField("source_org", orgRepo).WithField("private_org", openshiftPrivOrg).Info("Found")
+					repos.Insert(openshiftPrivOrg)
+				}
 			}
 		}
 
-		triggers[index].Repos = sets.List(repos)
+		(*triggers)[index].Repos = sets.List(repos)
+	}
+
+	sortedOrgs := make([]string, 0, len(orgRepos))
+	for org := range orgRepos {
+		sortedOrgs = append(sortedOrgs, org)
+	}
+	sort.Strings(sortedOrgs)
+	for _, org := range sortedOrgs {
+		repos := orgRepos[org]
+		var orgTrigger *plugins.Trigger
+		for i := range *triggers {
+			for _, repo := range (*triggers)[i].Repos {
+				if repo == org {
+					orgTrigger = &(*triggers)[i]
+					break
+				}
+			}
+			if orgTrigger != nil {
+				break
+			}
+		}
+		if orgTrigger == nil {
+			continue
+		}
+		privateRepoNames := make([]string, 0, len(repos))
+		for repo := range repos {
+			privateRepoNames = append(privateRepoNames, repos[repo])
+		}
+		sort.Strings(privateRepoNames)
+		for _, privateRepoName := range privateRepoNames {
+			privateOrgRepo := fmt.Sprintf("%s/%s", openshiftPrivOrg, privateRepoName)
+			repoTrigger := *orgTrigger
+			repoTrigger.Repos = []string{privateOrgRepo}
+			*triggers = append(*triggers, repoTrigger)
+			logrus.WithField("source_org", org).WithField("private_repo", privateOrgRepo).Info("Injecting repo-level trigger")
+		}
 	}
 }
 
@@ -586,7 +628,7 @@ func main() {
 	injectPrivateLGTMPlugin(pluginsConfig.Lgtm, orgRepos)
 	injectPrivatePlugins(pluginsConfig.Plugins, orgRepos)
 	injectPrivateBugzillaPlugin(pluginsConfig.Bugzilla, orgRepos)
-	injectPrivateTriggers(pluginsConfig.Triggers, orgRepos)
+	injectPrivateTriggers(&pluginsConfig.Triggers, orgRepos)
 
 	if err := updateProwConfig(filepath.Join(o.releaseRepoPath, config.ConfigInRepoPath), prowConfig); err != nil {
 		logrus.WithError(err).Fatal("couldn't update prow config file")

--- a/cmd/private-prow-configs-mirror/main_test.go
+++ b/cmd/private-prow-configs-mirror/main_test.go
@@ -603,7 +603,7 @@ func TestInjectPrivateTriggers(t *testing.T) {
 		expected []plugins.Trigger
 	}{
 		{
-			id: "no changes expected",
+			id: "no changes expected for repos not in orgRepos",
 			triggers: []plugins.Trigger{
 				{
 					Repos:       []string{"openshift/anotherRepo1", "testshift/anotherRepo2"},
@@ -626,7 +626,7 @@ func TestInjectPrivateTriggers(t *testing.T) {
 			},
 		},
 		{
-			id: "changes expected",
+			id: "repo-level mapping and stale priv entries removed",
 			triggers: []plugins.Trigger{
 				{
 					Repos:       []string{"openshift/testRepo1", "testshift/anotherRepo2", "openshift-priv/testRepo3"},
@@ -648,11 +648,34 @@ func TestInjectPrivateTriggers(t *testing.T) {
 				},
 			},
 		},
+		{
+			id: "org-level trigger creates org and repo-level entries",
+			triggers: []plugins.Trigger{
+				{
+					Repos:       []string{"openshift"},
+					TrustedApps: []string{"openshift-merge-bot"},
+				},
+			},
+			expected: []plugins.Trigger{
+				{
+					Repos:       []string{"openshift", "openshift-priv"},
+					TrustedApps: []string{"openshift-merge-bot"},
+				},
+				{
+					Repos:       []string{"openshift-priv/testRepo1"},
+					TrustedApps: []string{"openshift-merge-bot"},
+				},
+				{
+					Repos:       []string{"openshift-priv/testRepo2"},
+					TrustedApps: []string{"openshift-merge-bot"},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.id, func(t *testing.T) {
-			injectPrivateTriggers(tc.triggers, orgRepos)
+			injectPrivateTriggers(&tc.triggers, orgRepos)
 			if !reflect.DeepEqual(tc.triggers, tc.expected) {
 				t.Fatal(cmp.Diff(tc.triggers, tc.expected))
 			}


### PR DESCRIPTION
## Summary
- Fix `injectPrivateTriggers` to handle org-level trigger entries (e.g., `repos: ["openshift"]` → adds `"openshift-priv"`)
- Create repo-level trigger entries for each private repo, so per-file `check-trigger-trusted-apps` validation passes
- The previous implementation (#5229) only handled `org/repo`-format entries via `privateOrgRepoFull()`, which silently skipped bare org names. It also only modified existing trigger entries without creating new repo-level ones needed by the sharded config validation.

This fixes the `check-trigger-trusted-apps` failure blocking openshift/release auto-config-brancher PRs (e.g., https://github.com/openshift/release/pull/79551).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## private-prow-configs-mirror: Fix trigger injection for org-level and repo-level entries

This PR fixes injectPrivateTriggers in the private-prow-configs-mirror tool so Prow plugin trigger configuration for mirrored private repos (openshift-priv) is generated correctly from both org-level and repo-level public trigger entries.

What changed (practical effect)
- The tool now mutates the plugins.Trigger slice directly (accepts a pointer) and:
  - Recognizes bare org entries (e.g., repos: ["openshift"]) as org-level triggers and injects the corresponding openshift-priv org-level entry.
  - Generates deterministic per-repo openshift-priv/<repo> trigger entries for every private mirror of public repos, ensuring each private repo has its own repo-level trigger.
  - Removes stale openshift-priv entries and filters existing openshift-priv entries to avoid duplicates.
- main() was updated to call injectPrivateTriggers with a pointer; sort is used to ensure deterministic ordering.

Component affected
- CLI tool: cmd/private-prow-configs-mirror (part of the ci-tools repository used to produce Prow plugin configs for OpenShift CI).

Why this matters for CI operators/users
- Prior behavior only handled explicit org/repo trigger strings and silently skipped bare org names, and it never created the required repo-level openshift-priv entries. As a result, per-file check-trigger-trusted-apps validation (used for sharded plugin configs) could fail and block automation (example: openshift/release PRs such as `#79551`).
- With this PR, org-level triggers correctly expand into both an org-level openshift-priv entry and individual repo-level openshift-priv/<repo> entries, so sharded validation passes and release automation PRs are unblocked.

Tests
- TestInjectPrivateTriggers was updated to call injectPrivateTriggers by pointer and includes a new subtest verifying that org-level triggers produce both the org-level private trigger and the derived repo-level private triggers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->