### PR TITLE
Revert "Merge pull request #5203 from danilo-gemoli/feat/qci-appci/mu…

### DIFF
--- a/cmd/qci-appci/main.go
+++ b/cmd/qci-appci/main.go
@@ -22,9 +22,7 @@ import (
 
 	authenticationv1 "k8s.io/api/authentication/v1"
 	authorizationv1 "k8s.io/api/authorization/v1"
-	aggerrs "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/tools/clientcmd"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/prow/pkg/config/secret"
 	"sigs.k8s.io/prow/pkg/interrupts"
@@ -34,19 +32,18 @@ import (
 )
 
 type options struct {
-	listenAddr             string
-	exposedHost            string
-	gracePeriod            time.Duration
-	robotUsernameFile      string
-	robotPasswordFile      string
-	tokenSecretFile        string
-	tokenValidityRaw       string
-	tokenValidity          time.Duration
-	tlsCertFile            string
-	tlsKeyFile             string
-	intervalRaw            string
-	interval               time.Duration
-	supplementalKubeconfig string
+	listenAddr        string
+	exposedHost       string
+	gracePeriod       time.Duration
+	robotUsernameFile string
+	robotPasswordFile string
+	tokenSecretFile   string
+	tokenValidityRaw  string
+	tokenValidity     time.Duration
+	tlsCertFile       string
+	tlsKeyFile        string
+	intervalRaw       string
+	interval          time.Duration
 }
 
 func gatherOptions() (*options, error) {
@@ -62,7 +59,6 @@ func gatherOptions() (*options, error) {
 	fs.StringVar(&o.tlsCertFile, "tls-cert-file", "", "Path to a tls cert file. Must not be empty.")
 	fs.StringVar(&o.tlsKeyFile, "tls-key-file", "", "Path to a tls key file. Must not be empty.")
 	fs.StringVar(&o.intervalRaw, "interval", "30s", "Parseable duration string that specifies the period to refresh robot's quay.io bearer token")
-	fs.StringVar(&o.supplementalKubeconfig, "supplemental-kubeconfig", "", "Supplemental cluster used to check tokens validity")
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		return nil, fmt.Errorf("failed to parse flags: %w", err)
 	}
@@ -136,24 +132,7 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to create proxy handler")
 	}
-
-	var tokenService ClusterTokenService = newTokenService(ctx, inClusterConfig.Host, ocClient)
-	if opts.supplementalKubeconfig != "" {
-		config, err := clientcmd.BuildConfigFromFlags("", opts.supplementalKubeconfig)
-		if err != nil {
-			logrus.WithError(err).Fatal("Failed to read supplemental kubeconfig")
-		}
-
-		supplementalOCClient, err := ctrlruntimeclient.New(config, ctrlruntimeclient.Options{})
-		if err != nil {
-			logrus.WithError(err).Fatal("Failed to create supplemental oc client")
-		}
-
-		supplementalTokenService := newTokenService(ctx, config.Host, supplementalOCClient)
-		tokenService = newMultiClusterTokenService(tokenService, supplementalTokenService)
-	}
-
-	handler := getRouter(proxyHandler, opts.exposedHost, tokenService, appTokenService, secret.GetSecret, opts.robotUsernameFile, opts.robotPasswordFile)
+	handler := getRouter(proxyHandler, opts.exposedHost, newTokenService(ctx, ocClient), appTokenService, secret.GetSecret, opts.robotUsernameFile, opts.robotPasswordFile)
 	interrupts.ListenAndServeTLS(&http.Server{Addr: opts.listenAddr, Handler: handler}, opts.tlsCertFile, opts.tlsKeyFile, opts.gracePeriod)
 	interrupts.WaitForGracefulShutdown()
 }
@@ -395,62 +374,19 @@ type QuayService interface {
 
 type ClusterTokenService interface {
 	Validate(token string) (bool, error)
-	Host() string
 }
 
-func newMultiClusterTokenService(clusterTokenServices ...ClusterTokenService) *multiClusterTokenService {
-	return &multiClusterTokenService{
-		clusterTokenServices: clusterTokenServices,
-		logger:               logrus.WithField("subComponent", "newMultiClusterTokenService"),
-	}
-}
-
-type multiClusterTokenService struct {
-	logger               *logrus.Entry
-	clusterTokenServices []ClusterTokenService
-}
-
-func (m *multiClusterTokenService) Validate(token string) (bool, error) {
-	errs := make([]error, 0)
-
-	for _, cts := range m.clusterTokenServices {
-		isValid, err := cts.Validate(token)
-
-		if err != nil {
-			m.logger.WithField("host", cts.Host()).WithError(err).Error("Failed to validate token")
-			errs = append(errs, err)
-			continue
-		}
-
-		if isValid {
-			return true, nil
-		}
-	}
-
-	return false, aggerrs.NewAggregate(errs)
-}
-
-func (m *multiClusterTokenService) Host() string {
-	return ""
-}
-
-type simpleClusterTokenService struct {
+type SimpleClusterTokenService struct {
 	ctx    context.Context
 	client ctrlruntimeclient.Client
-	host   string
 	logger *logrus.Entry
 }
 
-func newTokenService(ctx context.Context, host string, client ctrlruntimeclient.Client) *simpleClusterTokenService {
-	return &simpleClusterTokenService{
-		ctx:    ctx,
-		client: client,
-		host:   host,
-		logger: logrus.WithField("subComponent", "simpleClusterTokenService").WithField("host", host),
-	}
+func newTokenService(ctx context.Context, client ctrlruntimeclient.Client) ClusterTokenService {
+	return &SimpleClusterTokenService{ctx: ctx, client: client, logger: logrus.WithField("subComponent", "simpleClusterTokenService")}
 }
 
-func (s *simpleClusterTokenService) Validate(token string) (bool, error) {
+func (s *SimpleClusterTokenService) Validate(token string) (bool, error) {
 	t := time.Now()
 	var username string
 	var ret bool
@@ -498,10 +434,6 @@ func (s *simpleClusterTokenService) Validate(token string) (bool, error) {
 	}
 	ret = sar.Status.Allowed
 	return ret, nil
-}
-
-func (s *simpleClusterTokenService) Host() string {
-	return s.host
 }
 
 type appHandler struct {

--- a/cmd/qci-appci/main_test.go
+++ b/cmd/qci-appci/main_test.go
@@ -16,32 +16,13 @@ import (
 )
 
 type fakeClusterTokenService struct {
-	validTokenPattern string
-	errTokenPattern   string
-	host              string
 }
 
 func (s *fakeClusterTokenService) Validate(token string) (bool, error) {
-	switch token {
-	case s.errTokenPattern:
-		return false, fmt.Errorf("host %s fails to validate %s", s.host, token)
-	case s.validTokenPattern:
-		return true, nil
-	default:
+	if token == "w" {
 		return false, nil
 	}
-}
-
-func (s *fakeClusterTokenService) Host() string {
-	return ""
-}
-
-func newFakeClusterTokenService(validTokenPattern, errTokenPattern, host string) *fakeClusterTokenService {
-	return &fakeClusterTokenService{
-		validTokenPattern: validTokenPattern,
-		errTokenPattern:   errTokenPattern,
-		host:              host,
-	}
+	return true, nil
 }
 
 type fakeQuayService struct {
@@ -268,7 +249,7 @@ func TestGetRouter(t *testing.T) {
 			for k, v := range tc.requestHeaders {
 				req.Header.Set(k, v)
 			}
-			handler := getRouter(fakeProxy, "host:12321", newFakeClusterTokenService("p", "e", ""), &fakeAppTokenService{}, func(s string) []byte { return []byte(s) }, "u", "p")
+			handler := getRouter(fakeProxy, "host:12321", &fakeClusterTokenService{}, &fakeAppTokenService{}, func(s string) []byte { return []byte(s) }, "u", "p")
 			rr := httptest.NewRecorder()
 			handler.ServeHTTP(rr, req)
 
@@ -329,74 +310,6 @@ func TestJWTTokenService(t *testing.T) {
 				if diff := cmp.Diff(actualValidateErr, actualValidateErr, testhelper.EquateErrorMessage); diff != "" {
 					t.Errorf("%s actualValidateErr differs from expected:\n%s", tc.name, diff)
 				}
-			}
-		})
-	}
-}
-
-func TestMultiClusterTokenService(t *testing.T) {
-	s := func(cts ...ClusterTokenService) []ClusterTokenService {
-		return cts
-	}
-
-	for _, tc := range []struct {
-		name                 string
-		token                string
-		clusterTokenServices []ClusterTokenService
-		wantIsValid          bool
-		wantErr              string
-	}{
-		{
-			name:                 "single: valid token",
-			token:                "v",
-			clusterTokenServices: s(newFakeClusterTokenService("v", "e", "appci")),
-			wantIsValid:          true,
-		},
-		{
-			name:                 "multi: first service validates token",
-			token:                "v",
-			clusterTokenServices: s(newFakeClusterTokenService("v", "e", "appci"), newFakeClusterTokenService("w", "e", "coreci")),
-			wantIsValid:          true,
-		},
-		{
-			name:                 "multi: second service validates token",
-			token:                "v",
-			clusterTokenServices: s(newFakeClusterTokenService("w", "e", "appci"), newFakeClusterTokenService("v", "e", "coreci")),
-			wantIsValid:          true,
-		},
-		{
-			name:                 "multi: invalid token",
-			token:                "w",
-			clusterTokenServices: s(newFakeClusterTokenService("v", "e", "appci"), newFakeClusterTokenService("v", "e", "coreci")),
-		},
-		{
-			name:                 "multi: first service in error but token is valid",
-			token:                "e",
-			clusterTokenServices: s(newFakeClusterTokenService("v", "e", "appci"), newFakeClusterTokenService("e", "E", "coreci")),
-			wantIsValid:          true,
-		},
-		{
-			name:                 "multi: all services in error",
-			token:                "e",
-			clusterTokenServices: s(newFakeClusterTokenService("v", "e", "appci"), newFakeClusterTokenService("v", "e", "coreci")),
-			wantErr:              "[host appci fails to validate e, host coreci fails to validate e]",
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			multi := newMultiClusterTokenService(tc.clusterTokenServices...)
-			gotIsValid, err := multi.Validate(tc.token)
-
-			gotErr := ""
-			if err != nil {
-				gotErr = err.Error()
-			}
-
-			if tc.wantErr != gotErr {
-				t.Errorf("want error %s but got %s", tc.wantErr, gotErr)
-			}
-
-			if tc.wantIsValid != gotIsValid {
-				t.Errorf("want valid %t but got %t", tc.wantIsValid, gotIsValid)
 			}
 		})
 	}


### PR DESCRIPTION
…lti-cluster-token-service"

This reverts commit 71180ad5f4d4e1de929824838b8343ca4ea01e8f, reversing changes made to 0a2e393b00a09df68bdde9698ce0818fff304121.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR reverts the multi-cluster token service feature that was recently merged (PR `#5203`). The qci-appci service, which acts as a reverse proxy for the `quay.io/openshift/ci` image repository, is simplified to validate tokens against only a single in-cluster Kubernetes cluster rather than supporting multiple clusters.

## Practical Impact

**qci-appci** (the Quay CI proxy service) no longer supports multi-cluster authentication scenarios. Token validation now operates exclusively through the in-cluster Kubernetes API using `TokenReview` and RBAC `SubjectAccessReview` calls, eliminating the need for supplemental kubeconfig files or cross-cluster token aggregation logic.

## Changes

**cmd/qci-appci/main.go:**
- Simplified `ClusterTokenService` interface: removed the `Host()` method, keeping only `Validate(token string) (bool, error)`
- Renamed `simpleClusterTokenService` to `SimpleClusterTokenService` (now exported)
- Removed multi-cluster token service composition and aggregate error handling
- Handler initialization now directly passes the single `SimpleClusterTokenService` instance to the router instead of creating composite services

**cmd/qci-appci/main_test.go:**
- Simplified `fakeClusterTokenService` test helper by removing host/pattern-based validation logic
- Removed the `TestMultiClusterTokenService` test case entirely
- Test setup now constructs the fake service directly without multi-cluster configuration

## Lines Changed
+17 / -85 in main.go
+3 / -90 in main_test.go

<!-- end of auto-generated comment: release notes by coderabbit.ai -->