### PR TITLE
ci-operator: Generic DeferredParameters

### DIFF
--- a/pkg/api/graph.go
+++ b/pkg/api/graph.go
@@ -105,7 +105,7 @@ func setMultiArchForChildren(node *StepNode) {
 type InputDefinition []string
 
 // +k8s:deepcopy-gen=false
-type ParameterMap map[string]func() (string, error)
+type ParameterMap map[string]func() (any, error)
 
 // StepLink abstracts the types of links that steps
 // require and create.

--- a/pkg/api/parameters.go
+++ b/pkg/api/parameters.go
@@ -16,56 +16,26 @@ type Parameters interface {
 	Get(name string) (string, error)
 }
 
-type overrideParameters struct {
-	params    Parameters
-	overrides map[string]string
-}
-
-func (p *overrideParameters) Has(name string) bool {
-	if _, ok := p.overrides[name]; ok {
-		return true
-	}
-	return p.params.Has(name)
-}
-
-func (p *overrideParameters) HasInput(name string) bool {
-	return p.params.HasInput(name)
-}
-
-func (p *overrideParameters) Get(name string) (string, error) {
-	if value, ok := p.overrides[name]; ok {
-		return value, nil
-	}
-	return p.params.Get(name)
-}
-
-func NewOverrideParameters(params Parameters, overrides map[string]string) Parameters {
-	return &overrideParameters{
-		params:    params,
-		overrides: overrides,
-	}
-}
-
 // +k8s:deepcopy-gen=false
 type DeferredParameters struct {
 	lock   sync.Mutex
 	params Parameters
-	fns    ParameterMap
-	values map[string]string
+	fns    map[string]func() (any, error)
+	values map[string]any
 }
 
 func NewDeferredParameters(params Parameters) *DeferredParameters {
 	return &DeferredParameters{
 		params: params,
-		fns:    make(ParameterMap),
-		values: make(map[string]string),
+		fns:    make(map[string]func() (any, error)),
+		values: make(map[string]any),
 	}
 }
 
-func (p *DeferredParameters) Map() (map[string]string, error) {
+func (p *DeferredParameters) Map() (map[string]any, error) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
-	m := make(map[string]string, len(p.fns))
+	m := make(map[string]any, len(p.fns))
 	for k, fn := range p.fns {
 		if v, ok := p.values[k]; ok {
 			m[k] = v
@@ -81,7 +51,7 @@ func (p *DeferredParameters) Map() (map[string]string, error) {
 	return m, nil
 }
 
-func (p *DeferredParameters) Set(name, value string) {
+func (p *DeferredParameters) Set(name string, value any) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 	if _, ok := p.fns[name]; ok {
@@ -95,7 +65,7 @@ func (p *DeferredParameters) Set(name, value string) {
 	p.values[name] = value
 }
 
-func (p *DeferredParameters) Add(name string, fn func() (string, error)) {
+func (p *DeferredParameters) Add(name string, fn func() (any, error)) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 	if _, ok := p.fns[name]; ok {
@@ -141,34 +111,44 @@ func (p *DeferredParameters) has(name string) bool {
 }
 
 func (p *DeferredParameters) Get(name string) (string, error) {
-	if ret, err := p.get(name); ret != "" {
-		return ret, nil
-	} else if err != nil {
-		return ret, err
+	ret, err := p.get(name)
+	if err != nil {
+		return "", err
 	}
+
+	if retStr, ok := ret.(string); ok && retStr != "" {
+		return retStr, nil
+	}
+
 	if p.params != nil {
 		return p.params.Get(name)
 	}
+
 	return "", nil
 }
 
-func (p *DeferredParameters) get(name string) (string, error) {
+func (p *DeferredParameters) get(name string) (any, error) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
+
 	if value, ok := p.values[name]; ok {
 		return value, nil
 	}
+
 	if value, ok := os.LookupEnv(name); ok {
 		p.values[name] = value
 		return value, nil
 	}
+
 	if fn, ok := p.fns[name]; ok {
 		value, err := fn()
 		if err != nil {
-			return "", fmt.Errorf("could not lazily evaluate deferred parameter %q: %w", name, err)
+			return nil, fmt.Errorf("could not lazily evaluate deferred parameter %q: %w", name, err)
 		}
+
 		p.values[name] = value
 		return value, nil
 	}
-	return "", nil
+
+	return nil, nil
 }

--- a/pkg/api/parameters_test.go
+++ b/pkg/api/parameters_test.go
@@ -11,51 +11,51 @@ func TestDeferredParametersMap(t *testing.T) {
 	var testCases = []struct {
 		purpose  string
 		dp       *DeferredParameters
-		expected map[string]string
+		expected map[string]any
 	}{{
 		purpose: "values[N]=V, fns[N] is not set, so returned map does not have key 'N'",
 		dp: &DeferredParameters{
-			values: map[string]string{"K1": "V1"},
-			fns:    map[string]func() (string, error){},
+			values: map[string]any{"K1": "V1"},
+			fns:    map[string]func() (any, error){},
 		},
-		expected: map[string]string{},
+		expected: map[string]any{},
 	}, {
 		purpose: "fns[N] is set, values[N] is not, so returned map has key 'N' set to fns[N]()",
 		dp: &DeferredParameters{
-			values: map[string]string{},
-			fns:    map[string]func() (string, error){"K1": func() (string, error) { return "V1", nil }},
+			values: map[string]any{},
+			fns:    map[string]func() (any, error){"K1": func() (any, error) { return "V1", nil }},
 		},
-		expected: map[string]string{"K1": "V1"},
+		expected: map[string]any{"K1": "V1"},
 	}, {
 		purpose: "fns[N] is set, values[N] is set, so returned map has key 'N' set to values[N]",
 		dp: &DeferredParameters{
-			values: map[string]string{"K1": "V1"},
-			fns:    map[string]func() (string, error){"K1": func() (string, error) { return "F1", nil }},
+			values: map[string]any{"K1": "V1"},
+			fns:    map[string]func() (any, error){"K1": func() (any, error) { return "F1", nil }},
 		},
-		expected: map[string]string{"K1": "V1"},
+		expected: map[string]any{"K1": "V1"},
 	}, {
 		purpose: "returned map contains all names",
 		dp: &DeferredParameters{
-			values: map[string]string{"K1": "V1", "K2": "V2"},
-			fns: map[string]func() (string, error){
-				"K1": func() (string, error) { return "should not be returned", nil },
-				"K2": func() (string, error) { return "should not be returned", nil },
-				"K3": func() (string, error) { return "F3", nil },
-				"K4": func() (string, error) { return "F4", nil },
+			values: map[string]any{"K1": "V1", "K2": "V2"},
+			fns: map[string]func() (any, error){
+				"K1": func() (any, error) { return "should not be returned", nil },
+				"K2": func() (any, error) { return "should not be returned", nil },
+				"K3": func() (any, error) { return "F3", nil },
+				"K4": func() (any, error) { return "F4", nil },
 			},
 		},
-		expected: map[string]string{"K1": "V1", "K2": "V2", "K3": "F3", "K4": "F4"},
+		expected: map[string]any{"K1": "V1", "K2": "V2", "K3": "F3", "K4": "F4"},
 	}, {
 		purpose: "parent values are not returned",
 		dp: &DeferredParameters{
 			params: &DeferredParameters{
-				values: map[string]string{"K1": "V1"},
-				fns: map[string]func() (string, error){
-					"K2": func() (string, error) { return "V2", nil },
+				values: map[string]any{"K1": "V1"},
+				fns: map[string]func() (any, error){
+					"K2": func() (any, error) { return "V2", nil },
 				},
 			},
 		},
-		expected: map[string]string{},
+		expected: map[string]any{},
 	}}
 
 	for _, tc := range testCases {
@@ -89,7 +89,7 @@ func TestDeferredParametersGetSet(t *testing.T) {
 		purpose: "Existing key is not overwritten",
 		dp: &DeferredParameters{
 			fns:    make(ParameterMap),
-			values: map[string]string{"key": "oldValue"},
+			values: map[string]any{"key": "oldValue"},
 		},
 		name:     "key",
 		callSet:  true,
@@ -100,10 +100,10 @@ func TestDeferredParametersGetSet(t *testing.T) {
 	}, {
 		purpose: "Existing key is not set if lazy evaluation func is set",
 		dp: &DeferredParameters{
-			fns: map[string]func() (string, error){
-				"key": func() (string, error) { return "lazyValue", nil },
+			fns: map[string]func() (any, error){
+				"key": func() (any, error) { return "lazyValue", nil },
 			},
-			values: map[string]string{},
+			values: map[string]any{},
 		},
 		name:     "key",
 		callSet:  true,
@@ -139,55 +139,55 @@ func TestDeferredParametersParent(t *testing.T) {
 	}{{
 		name: "values, no parent",
 		params: &DeferredParameters{
-			values: map[string]string{"K": "expected"},
-			fns:    map[string]func() (string, error){},
+			values: map[string]any{"K": "expected"},
+			fns:    map[string]func() (any, error){},
 		},
 	}, {
 		name: "fns, no parent",
 		params: &DeferredParameters{
-			values: map[string]string{},
-			fns: map[string]func() (string, error){
-				"K": func() (string, error) { return "expected", nil },
+			values: map[string]any{},
+			fns: map[string]func() (any, error){
+				"K": func() (any, error) { return "expected", nil },
 			},
 		},
 	}, {
 		name: "values, parent",
 		params: &DeferredParameters{
-			values: map[string]string{"K": "expected"},
-			fns:    map[string]func() (string, error){},
+			values: map[string]any{"K": "expected"},
+			fns:    map[string]func() (any, error){},
 			params: &DeferredParameters{
-				values: map[string]string{"K": "unexpected"},
+				values: map[string]any{"K": "unexpected"},
 			},
 		},
 	}, {
 		name: "fns, parent",
 		params: &DeferredParameters{
-			values: map[string]string{},
-			fns: map[string]func() (string, error){
-				"K": func() (string, error) { return "expected", nil },
+			values: map[string]any{},
+			fns: map[string]func() (any, error){
+				"K": func() (any, error) { return "expected", nil },
 			},
 			params: &DeferredParameters{
-				values: map[string]string{"K": "unexpected"},
+				values: map[string]any{"K": "unexpected"},
 			},
 		},
 	}, {
 		name: "from parent's values",
 		params: &DeferredParameters{
-			values: map[string]string{},
-			fns:    map[string]func() (string, error){},
+			values: map[string]any{},
+			fns:    map[string]func() (any, error){},
 			params: &DeferredParameters{
-				values: map[string]string{"K": "expected"},
+				values: map[string]any{"K": "expected"},
 			},
 		},
 	}, {
 		name: "from parent's fns",
 		params: &DeferredParameters{
-			values: map[string]string{},
-			fns:    map[string]func() (string, error){},
+			values: map[string]any{},
+			fns:    map[string]func() (any, error){},
 			params: &DeferredParameters{
-				values: map[string]string{},
-				fns: map[string]func() (string, error){
-					"K": func() (string, error) { return "expected", nil },
+				values: map[string]any{},
+				fns: map[string]func() (any, error){
+					"K": func() (any, error) { return "expected", nil },
 				},
 			},
 		},

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -94,11 +94,11 @@ func fromConfig(ctx context.Context, cfg *Config) ([]api.Step, []api.Step, error
 	for _, target := range cfg.RequiredTargets {
 		requiredNames.Insert(target)
 	}
-	cfg.params.Add("JOB_NAME", func() (string, error) { return cfg.JobSpec.Job, nil })
-	cfg.params.Add("JOB_NAME_HASH", func() (string, error) { return cfg.JobSpec.JobNameHash(), nil })
-	cfg.params.Add("JOB_NAME_SAFE", func() (string, error) { return strings.Replace(cfg.JobSpec.Job, "_", "-", -1), nil })
-	cfg.params.Add("UNIQUE_HASH", func() (string, error) { return cfg.JobSpec.UniqueHash(), nil })
-	cfg.params.Add("NAMESPACE", func() (string, error) { return cfg.JobSpec.Namespace(), nil })
+	cfg.params.Add("JOB_NAME", func() (any, error) { return cfg.JobSpec.Job, nil })
+	cfg.params.Add("JOB_NAME_HASH", func() (any, error) { return cfg.JobSpec.JobNameHash(), nil })
+	cfg.params.Add("JOB_NAME_SAFE", func() (any, error) { return strings.Replace(cfg.JobSpec.Job, "_", "-", -1), nil })
+	cfg.params.Add("UNIQUE_HASH", func() (any, error) { return cfg.JobSpec.UniqueHash(), nil })
+	cfg.params.Add("NAMESPACE", func() (any, error) { return cfg.JobSpec.Namespace(), nil })
 	inputImages := make(inputImageSet)
 	var overridableSteps []api.Step
 	var buildSteps []api.Step
@@ -1082,7 +1082,7 @@ func sourceStepForRef(ref *prowapi.Refs, primaryRef bool) api.StepConfiguration 
 	}}
 }
 
-func paramsHasAllParametersAsInput(p api.Parameters, params map[string]func() (string, error)) (map[string]string, bool) {
+func paramsHasAllParametersAsInput(p api.Parameters, params map[string]func() (any, error)) (map[string]string, bool) {
 	if len(params) == 0 {
 		return nil, false
 	}

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -1337,7 +1337,7 @@ func TestFromConfig(t *testing.T) {
 		enableLeaseClient   bool
 		expectedSteps       []string
 		expectedPost        []string
-		expectedParams      map[string]string
+		expectedParams      map[string]any
 		expectedErr         error
 	}{{
 		name:          "no steps",
@@ -1356,14 +1356,14 @@ func TestFromConfig(t *testing.T) {
 			"[output-images]",
 			"[images]",
 		},
-		expectedParams: map[string]string{
+		expectedParams: map[string]any{
 			"LOCAL_IMAGE_BASE_IMAGE": "public_docker_image_repository:base_image",
 		},
 	}, {
 		name:          "source build",
 		refs:          &prowapi.Refs{Org: "org", Repo: "repo"},
 		expectedSteps: []string{"src", "[output-images]", "[images]"},
-		expectedParams: map[string]string{
+		expectedParams: map[string]any{
 			"LOCAL_IMAGE_SRC": "public_docker_image_repository:src",
 		},
 	}, {
@@ -1384,7 +1384,7 @@ func TestFromConfig(t *testing.T) {
 			"[output-images]",
 			"[images]",
 		},
-		expectedParams: map[string]string{
+		expectedParams: map[string]any{
 			"LOCAL_IMAGE_CI_BUNDLE0": "public_docker_image_repository:ci-bundle0",
 			"LOCAL_IMAGE_CI_INDEX":   "public_docker_image_repository:ci-index",
 		},
@@ -1401,7 +1401,7 @@ func TestFromConfig(t *testing.T) {
 			"[output-images]",
 			"[images]",
 		},
-		expectedParams: map[string]string{
+		expectedParams: map[string]any{
 			"LOCAL_IMAGE_TO": "public_docker_image_repository:to",
 		},
 	}, {
@@ -1455,7 +1455,7 @@ func TestFromConfig(t *testing.T) {
 			"[output-images]",
 			"[images]",
 		},
-		expectedParams: map[string]string{
+		expectedParams: map[string]any{
 			"LOCAL_IMAGE_BASE_RPM_IMAGE_WITHOUT_RPMS": "public_docker_image_repository:base_rpm_image-without-rpms",
 		},
 	}, {
@@ -1485,7 +1485,7 @@ func TestFromConfig(t *testing.T) {
 			"[output-images]",
 			"[images]",
 		},
-		expectedParams: map[string]string{
+		expectedParams: map[string]any{
 			"LOCAL_IMAGE_BASE_RPM_IMAGE_ORG.REPO1_WITHOUT_RPMS": "public_docker_image_repository:base_rpm_image-org.repo1-without-rpms",
 			"LOCAL_IMAGE_BASE_RPM_IMAGE_ORG.REPO2_WITHOUT_RPMS": "public_docker_image_repository:base_rpm_image-org.repo2-without-rpms",
 		},
@@ -1500,7 +1500,7 @@ func TestFromConfig(t *testing.T) {
 			"[output-images]",
 			"[images]",
 		},
-		expectedParams: map[string]string{
+		expectedParams: map[string]any{
 			"LOCAL_IMAGE_RPMS": "public_docker_image_repository:rpms",
 		},
 	}, {
@@ -1526,7 +1526,7 @@ func TestFromConfig(t *testing.T) {
 			"[output-images]",
 			"[images]",
 		},
-		expectedParams: map[string]string{
+		expectedParams: map[string]any{
 			"LOCAL_IMAGE_RPMS_ORG.REPO1": "public_docker_image_repository:rpms-org.repo1",
 			"LOCAL_IMAGE_RPMS_ORG.REPO2": "public_docker_image_repository:rpms-org.repo2",
 		},
@@ -1546,7 +1546,7 @@ func TestFromConfig(t *testing.T) {
 			"[release-inputs]",
 			"[images]",
 		},
-		expectedParams: map[string]string{
+		expectedParams: map[string]any{
 			"IMAGE_FORMAT":          "public_docker_image_repository/ns/stable:${component}",
 			"RELEASE_IMAGE_INITIAL": "public_docker_image_repository:initial",
 			"RELEASE_IMAGE_LATEST":  "public_docker_image_repository:latest",
@@ -1572,7 +1572,7 @@ func TestFromConfig(t *testing.T) {
 			"[release-inputs]",
 			"[images]",
 		},
-		expectedParams: map[string]string{
+		expectedParams: map[string]any{
 			"IMAGE_FORMAT":                  "public_docker_image_repository/ns/stable:${component}",
 			"RELEASE_IMAGE_INITIAL":         "public_docker_image_repository:initial",
 			"RELEASE_IMAGE_LATEST":          "public_docker_image_repository:latest",
@@ -1588,7 +1588,7 @@ func TestFromConfig(t *testing.T) {
 			},
 		},
 		expectedSteps: []string{"[release:release]", "[images]"},
-		expectedParams: map[string]string{
+		expectedParams: map[string]any{
 			utils.ReleaseImageEnv("release"): "public_docker_image_repository:release",
 			"ORIGINAL_RELEASE_IMAGE_RELEASE": "",
 		},
@@ -1607,7 +1607,7 @@ func TestFromConfig(t *testing.T) {
 			},
 		},
 		expectedSteps: []string{"[release:release]", "[images]"},
-		expectedParams: map[string]string{
+		expectedParams: map[string]any{
 			utils.ReleaseImageEnv("release"): "public_docker_image_repository:release",
 			"ORIGINAL_RELEASE_IMAGE_RELEASE": "",
 		},
@@ -1783,7 +1783,7 @@ func TestFromConfig(t *testing.T) {
 			"[output-images]",
 			"[output:stable:machine-os-content]",
 		},
-		expectedParams: map[string]string{
+		expectedParams: map[string]any{
 			"LOCAL_IMAGE_MACHINE_OS_CONTENT": "public_docker_image_repository:machine-os-content",
 		},
 	}, {
@@ -1843,7 +1843,7 @@ func TestFromConfig(t *testing.T) {
 			"[output-images]",
 			"[images]",
 		},
-		expectedParams: map[string]string{
+		expectedParams: map[string]any{
 			"LOCAL_IMAGE_TOOL1": "public_docker_image_repository:tool1",
 			"LOCAL_IMAGE_TOOL2": "public_docker_image_repository:tool2",
 		},
@@ -1867,14 +1867,14 @@ func TestFromConfig(t *testing.T) {
 			"[output-images]",
 			"[images]",
 		},
-		expectedParams: map[string]string{
+		expectedParams: map[string]any{
 			"LOCAL_IMAGE_TOOL1": "public_docker_image_repository:tool1",
 		},
 	}, {
 		name:              "enable lease proxy server",
 		enableLeaseClient: true,
 		expectedSteps:     []string{"[output-images]", "[images]", "lease-proxy-server"},
-		expectedParams: map[string]string{
+		expectedParams: map[string]any{
 			"LEASE_PROXY_SERVER_URL": "http://10.0.0.1:8080",
 		},
 	}} {
@@ -1892,7 +1892,7 @@ func TestFromConfig(t *testing.T) {
 			}
 			params := api.NewDeferredParameters(tc.env)
 			for k, v := range tc.params {
-				params.Add(k, func() (string, error) { return v, nil })
+				params.Add(k, func() (any, error) { return v, nil })
 			}
 			graphConf := FromConfigStatic(&tc.config)
 			cfg := &Config{
@@ -1944,7 +1944,7 @@ func TestFromConfig(t *testing.T) {
 				t.Fatal(err)
 			}
 			if tc.expectedParams == nil {
-				tc.expectedParams = map[string]string{}
+				tc.expectedParams = map[string]any{}
 			}
 			for k, v := range map[string]string{
 				"JOB_NAME":      "job_name",

--- a/pkg/steps/input_image_tag.go
+++ b/pkg/steps/input_image_tag.go
@@ -207,7 +207,9 @@ func (s *inputImageTagStep) Creates() []api.StepLink {
 func (s *inputImageTagStep) Provides() api.ParameterMap {
 	tag := s.config.To
 	return api.ParameterMap{
-		utils.PipelineImageEnvFor(tag): utils.ImageDigestFor(s.client, s.jobSpec.Namespace, api.PipelineImageStream, string(tag)),
+		utils.PipelineImageEnvFor(tag): func() (any, error) {
+			return utils.ImageDigestFor(s.client, s.jobSpec.Namespace, api.PipelineImageStream, string(tag))()
+		},
 	}
 }
 

--- a/pkg/steps/ip_pool.go
+++ b/pkg/steps/ip_pool.go
@@ -87,7 +87,7 @@ func (s *ipPoolStep) Provides() api.ParameterMap {
 
 	// Disable unparam lint as we need to confirm to this interface, but there will never be an error
 	//nolint:unparam
-	parameters[api.DefaultIPPoolLeaseEnv] = func() (string, error) {
+	parameters[api.DefaultIPPoolLeaseEnv] = func() (any, error) {
 		if !s.stepRun.Load() {
 			return "", nil
 		}

--- a/pkg/steps/ip_pool_test.go
+++ b/pkg/steps/ip_pool_test.go
@@ -149,7 +149,7 @@ func (blockingStep) Creates() []api.StepLink { return []api.StepLink{api.ImagesR
 
 func (blockingStep) Provides() api.ParameterMap {
 	return api.ParameterMap{
-		"parameter": func() (string, error) { return "map", nil },
+		"parameter": func() (any, error) { return "map", nil },
 	}
 }
 

--- a/pkg/steps/lease.go
+++ b/pkg/steps/lease.go
@@ -93,21 +93,21 @@ func (s *leaseStep) Provides() api.ParameterMap {
 	}
 
 	// nolint:unparam
-	parameters[api.ClusterProfileSetEnv] = func() (string, error) { return s.clusterProfileSetName, nil }
+	parameters[api.ClusterProfileSetEnv] = func() (any, error) { return s.clusterProfileSetName, nil }
 	// nolint:unparam
-	parameters[api.ClusterProfileParam] = func() (string, error) { return s.clusterProfileName, nil }
+	parameters[api.ClusterProfileParam] = func() (any, error) { return s.clusterProfileName, nil }
 	// nolint:unparam
-	parameters[api.ClusterProfileSecretNameParam] = func() (string, error) { return s.clusterProfileSecretName, nil }
+	parameters[api.ClusterProfileSecretNameParam] = func() (any, error) { return s.clusterProfileSecretName, nil }
 	// nolint:unparam
-	parameters[api.STSHomeRoleARNParam] = func() (string, error) { return s.stsHomeRoleARN, nil }
+	parameters[api.STSHomeRoleARNParam] = func() (any, error) { return s.stsHomeRoleARN, nil }
 	// nolint:unparam
-	parameters[api.STSHubRoleARNParam] = func() (string, error) { return s.stsHubRoleARN, nil }
+	parameters[api.STSHubRoleARNParam] = func() (any, error) { return s.stsHubRoleARN, nil }
 	// nolint:unparam
-	parameters[api.STSTargetRoleARNParam] = func() (string, error) { return s.stsTargetRoleARN, nil }
+	parameters[api.STSTargetRoleARNParam] = func() (any, error) { return s.stsTargetRoleARN, nil }
 
 	for _, l := range s.leases {
 		// nolint:unparam
-		parameters[l.Env] = func() (string, error) {
+		parameters[l.Env] = func() (any, error) {
 			if len(l.resources) == 0 {
 				return "", nil
 			}

--- a/pkg/steps/lease_proxy.go
+++ b/pkg/steps/lease_proxy.go
@@ -41,7 +41,7 @@ func (*stepLeaseProxyServer) Creates() []api.StepLink {
 func (s *stepLeaseProxyServer) Provides() api.ParameterMap {
 	return api.ParameterMap{
 		//nolint:unparam // Remove this as soon as this functions can return an error as well.
-		api.LeaseProxyServerURLEnvVarName: func() (string, error) {
+		api.LeaseProxyServerURLEnvVarName: func() (any, error) {
 			return s.srvAddr, nil
 		},
 	}

--- a/pkg/steps/lease_proxy_test.go
+++ b/pkg/steps/lease_proxy_test.go
@@ -18,16 +18,16 @@ func TestLeaseProxyProvides(t *testing.T) {
 	for _, tc := range []struct {
 		name           string
 		httpSrvAddr    string
-		expectedParams map[string]string
+		expectedParams map[string]any
 	}{
 		{
 			name:           "Empty HTTP server addr",
-			expectedParams: map[string]string{api.LeaseProxyServerURLEnvVarName: ""},
+			expectedParams: map[string]any{api.LeaseProxyServerURLEnvVarName: ""},
 		},
 		{
 			name:           "Non empty HTTP server addr",
 			httpSrvAddr:    "http://10.0.0.1:8080",
-			expectedParams: map[string]string{api.LeaseProxyServerURLEnvVarName: "http://10.0.0.1:8080"},
+			expectedParams: map[string]any{api.LeaseProxyServerURLEnvVarName: "http://10.0.0.1:8080"},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -35,7 +35,7 @@ func TestLeaseProxyProvides(t *testing.T) {
 
 			step := LeaseProxyStep(logrus.NewEntry(&logrus.Logger{}), tc.httpSrvAddr, &http.ServeMux{}, nil)
 
-			gotParams := make(map[string]string)
+			gotParams := make(map[string]any)
 			for k, f := range step.Provides() {
 				v, err := f()
 				if err != nil {

--- a/pkg/steps/lease_test.go
+++ b/pkg/steps/lease_test.go
@@ -49,7 +49,7 @@ func (stepNeedsLease) Creates() []api.StepLink { return []api.StepLink{api.Image
 
 func (stepNeedsLease) Provides() api.ParameterMap {
 	return api.ParameterMap{
-		"parameter": func() (string, error) { return "map", nil },
+		"parameter": func() (any, error) { return "map", nil },
 	}
 }
 
@@ -268,7 +268,7 @@ func TestAcquireLeases(t *testing.T) {
 		resources               map[string]*common.Resource
 		objects                 []ctrlruntimeclient.Object
 		clusterProfiles         map[string]*api.ClusterProfileDetails
-		wantProvides            map[string]string
+		wantProvides            map[string]any
 		wantSecrets             corev1.SecretList
 		wantCalls               []string
 	}{
@@ -291,7 +291,7 @@ func TestAcquireLeases(t *testing.T) {
 					Name: "res-type-1--slice-0",
 				},
 			},
-			wantProvides: map[string]string{
+			wantProvides: map[string]any{
 				api.ClusterProfileSetEnv:          "",
 				api.ClusterProfileParam:           "",
 				api.ClusterProfileSecretNameParam: "",
@@ -339,7 +339,7 @@ func TestAcquireLeases(t *testing.T) {
 					LeaseType: "aws-quota-slice",
 				},
 			},
-			wantProvides: map[string]string{
+			wantProvides: map[string]any{
 				"parameter":                       "map",
 				api.ClusterProfileSetEnv:          "",
 				api.ClusterProfileParam:           "aws",
@@ -417,7 +417,7 @@ func TestAcquireLeases(t *testing.T) {
 					LeaseType: "aws-quota-slice",
 				},
 			},
-			wantProvides: map[string]string{
+			wantProvides: map[string]any{
 				"parameter":                       "map",
 				api.ClusterProfileSetEnv:          "",
 				api.ClusterProfileParam:           "aws",
@@ -503,7 +503,7 @@ func TestAcquireLeases(t *testing.T) {
 					LeaseType: "aws-quota-slice",
 				},
 			},
-			wantProvides: map[string]string{
+			wantProvides: map[string]any{
 				"parameter":                       "map",
 				api.ClusterProfileSetEnv:          "",
 				api.ClusterProfileParam:           "aws",
@@ -587,7 +587,7 @@ func TestAcquireLeases(t *testing.T) {
 					LeaseType: "aws-quota-slice",
 				},
 			},
-			wantProvides: map[string]string{
+			wantProvides: map[string]any{
 				"parameter":                       "map",
 				api.ClusterProfileSetEnv:          "",
 				api.ClusterProfileParam:           "aws",
@@ -672,7 +672,7 @@ func TestAcquireLeases(t *testing.T) {
 					LeaseType: "aws-quota-slice",
 				},
 			},
-			wantProvides: map[string]string{
+			wantProvides: map[string]any{
 				"parameter":                       "map",
 				api.ClusterProfileSetEnv:          "",
 				api.ClusterProfileParam:           "aws",
@@ -758,7 +758,7 @@ func TestAcquireLeases(t *testing.T) {
 					LeaseType: "aws-quota-slice",
 				},
 			},
-			wantProvides: map[string]string{
+			wantProvides: map[string]any{
 				"parameter":                       "map",
 				api.ClusterProfileSetEnv:          "aws-set",
 				api.ClusterProfileParam:           "aws",
@@ -816,7 +816,7 @@ func TestAcquireLeases(t *testing.T) {
 				t.Errorf("unexpected run error: %s", err)
 			}
 
-			gotProvides := make(map[string]string)
+			gotProvides := make(map[string]any)
 			for k, f := range provides {
 				v, err := f()
 				if err != nil {

--- a/pkg/steps/multi_stage/gen_test.go
+++ b/pkg/steps/multi_stage/gen_test.go
@@ -121,7 +121,7 @@ func TestGeneratePods(t *testing.T) {
 			}},
 			paramsFunc: func() api.Parameters {
 				params := api.NewDeferredParameters(nil)
-				params.Add(api.ClusterProfileSecretNameParam, func() (string, error) {
+				params.Add(api.ClusterProfileSecretNameParam, func() (any, error) {
 					return "cluster-secrets-aws-5", nil
 				})
 				return params
@@ -186,7 +186,7 @@ func TestGeneratePods(t *testing.T) {
 			},
 			paramsFunc: func() api.Parameters {
 				params := api.NewDeferredParameters(nil)
-				params.Add(api.ClusterProfileSecretNameParam, func() (string, error) {
+				params.Add(api.ClusterProfileSecretNameParam, func() (any, error) {
 					return "cluster-secrets-aws-5", nil
 				})
 				return params

--- a/pkg/steps/multi_stage/multi_stage_test.go
+++ b/pkg/steps/multi_stage/multi_stage_test.go
@@ -420,7 +420,7 @@ func TestProfileSecretName(t *testing.T) {
 			stepName: "step-0",
 			paramsFunc: func() api.Parameters {
 				params := api.NewDeferredParameters(nil)
-				params.Add(api.ClusterProfileSecretNameParam, func() (string, error) {
+				params.Add(api.ClusterProfileSecretNameParam, func() (any, error) {
 					return "foobar", nil
 				})
 				return params

--- a/pkg/steps/output_image_tag.go
+++ b/pkg/steps/output_image_tag.go
@@ -132,9 +132,11 @@ func (s *outputImageTagStep) Provides() api.ParameterMap {
 		return nil
 	}
 	return api.ParameterMap{
-		utils.StableImageEnv(s.config.To.As): utils.ImageDigestFor(s.client, func() string {
-			return s.config.To.Namespace
-		}, s.config.To.Name, s.config.To.Tag),
+		utils.StableImageEnv(s.config.To.As): func() (any, error) {
+			return utils.ImageDigestFor(s.client, func() string {
+				return s.config.To.Namespace
+			}, s.config.To.Name, s.config.To.Tag)()
+		},
 	}
 }
 

--- a/pkg/steps/pipeline_image_cache.go
+++ b/pkg/steps/pipeline_image_cache.go
@@ -91,7 +91,9 @@ func (s *pipelineImageCacheStep) Provides() api.ParameterMap {
 		return nil
 	}
 	return api.ParameterMap{
-		utils.PipelineImageEnvFor(s.config.To): utils.ImageDigestFor(s.client, s.jobSpec.Namespace, api.PipelineImageStream, string(s.config.To)),
+		utils.PipelineImageEnvFor(s.config.To): func() (any, error) {
+			return utils.ImageDigestFor(s.client, s.jobSpec.Namespace, api.PipelineImageStream, string(s.config.To))()
+		},
 	}
 }
 

--- a/pkg/steps/project_image.go
+++ b/pkg/steps/project_image.go
@@ -184,7 +184,9 @@ func (s *projectDirectoryImageBuildStep) Provides() api.ParameterMap {
 		return nil
 	}
 	return api.ParameterMap{
-		utils.PipelineImageEnvFor(s.config.To): utils.ImageDigestFor(s.client, s.jobSpec.Namespace, api.PipelineImageStream, string(s.config.To)),
+		utils.PipelineImageEnvFor(s.config.To): func() (any, error) {
+			return utils.ImageDigestFor(s.client, s.jobSpec.Namespace, api.PipelineImageStream, string(s.config.To))()
+		},
 	}
 }
 

--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -269,7 +269,9 @@ func (s *assembleReleaseStep) Creates() []api.StepLink {
 
 func (s *assembleReleaseStep) Provides() api.ParameterMap {
 	return api.ParameterMap{
-		utils.ReleaseImageEnv(s.name): utils.ImageDigestFor(s.client, s.jobSpec.Namespace, api.ReleaseImageStream, s.name),
+		utils.ReleaseImageEnv(s.name): func() (any, error) {
+			return utils.ImageDigestFor(s.client, s.jobSpec.Namespace, api.ReleaseImageStream, s.name)()
+		},
 	}
 }
 

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -316,10 +316,12 @@ func (s *importReleaseStep) Creates() []api.StepLink {
 func (s *importReleaseStep) Provides() api.ParameterMap {
 	env := utils.ReleaseImageEnv(s.name)
 	return api.ParameterMap{
-		env: utils.ImageDigestFor(s.client, s.jobSpec.Namespace, api.ReleaseImageStream, s.name),
+		env: func() (any, error) {
+			return utils.ImageDigestFor(s.client, s.jobSpec.Namespace, api.ReleaseImageStream, s.name)()
+		},
 		// Disable unparam lint as we need to confirm to this interface, but there will never be an error
 		//nolint:unparam
-		fmt.Sprintf("ORIGINAL_%s", env): func() (string, error) {
+		fmt.Sprintf("ORIGINAL_%s", env): func() (any, error) {
 			return s.originalPullSpec, nil
 		},
 	}

--- a/pkg/steps/release/release_images.go
+++ b/pkg/steps/release/release_images.go
@@ -170,7 +170,7 @@ func (s *releaseImagesTagStep) Provides() api.ParameterMap {
 	}
 }
 
-func (s *releaseImagesTagStep) imageFormat() (string, error) {
+func (s *releaseImagesTagStep) imageFormat() (any, error) {
 	spec, err := s.repositoryPullSpec()
 	if err != nil {
 		return "REGISTRY", err

--- a/pkg/steps/rpm_server.go
+++ b/pkg/steps/rpm_server.go
@@ -370,7 +370,7 @@ func (s *rpmServerStep) Creates() []api.StepLink {
 	return []api.StepLink{api.RPMRepoLink()}
 }
 
-func (s *rpmServerStep) rpmRepoURL() (string, error) {
+func (s *rpmServerStep) rpmRepoURL() (any, error) {
 	host, err := admittedHostForRoute(s.client, s.jobSpec.Namespace(), RPMRepoName, time.Minute)
 	if err != nil {
 		return "", fmt.Errorf("unable to calculate rpm repo URL: %w", err)

--- a/pkg/steps/rpm_server_test.go
+++ b/pkg/steps/rpm_server_test.go
@@ -26,7 +26,7 @@ func TestRPMServerStepProvides(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		jobSpec  api.JobSpec
-		expected [][2]string
+		expected [][2]any
 	}{{
 		name: "no refs",
 	}, {
@@ -36,7 +36,7 @@ func TestRPMServerStepProvides(t *testing.T) {
 				Refs: &prowapi.Refs{Org: "org", Repo: "repo"},
 			},
 		},
-		expected: [][2]string{{"RPM_REPO_ORG_REPO", "http://host"}},
+		expected: [][2]any{{"RPM_REPO_ORG_REPO", "http://host"}},
 	}, {
 		name: "extra refs",
 		jobSpec: api.JobSpec{
@@ -47,7 +47,7 @@ func TestRPMServerStepProvides(t *testing.T) {
 				},
 			},
 		},
-		expected: [][2]string{
+		expected: [][2]any{
 			{"RPM_REPO_ORG0_REPO0", "http://host"},
 			{"RPM_REPO_ORG1_REPO1", "http://host"},
 		},
@@ -62,7 +62,7 @@ func TestRPMServerStepProvides(t *testing.T) {
 				},
 			},
 		},
-		expected: [][2]string{
+		expected: [][2]any{
 			{"RPM_REPO_ORG0_REPO0", "http://host"},
 			{"RPM_REPO_ORG1_REPO1", "http://host"},
 			{"RPM_REPO_ORG_REPO", "http://host"},
@@ -86,13 +86,13 @@ func TestRPMServerStepProvides(t *testing.T) {
 			tc.jobSpec.SetNamespace(ns)
 			step := RPMServerStep(api.RPMServeStepConfiguration{}, client, &tc.jobSpec)
 			providesMap := step.Provides()
-			var provides [][2]string
+			var provides [][2]any
 			for _, k := range util.SortedKeys(providesMap) {
 				s, err := providesMap[k]()
 				if err != nil {
 					t.Fatal(err)
 				}
-				provides = append(provides, [2]string{k, s})
+				provides = append(provides, [2]any{k, s})
 			}
 			testhelper.Diff(t, "parameter map", provides, tc.expected)
 		})

--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -817,7 +817,9 @@ func (s *sourceStep) Creates() []api.StepLink {
 
 func (s *sourceStep) Provides() api.ParameterMap {
 	return api.ParameterMap{
-		utils.PipelineImageEnvFor(s.config.To): utils.ImageDigestFor(s.client, s.jobSpec.Namespace, api.PipelineImageStream, string(s.config.To)),
+		utils.PipelineImageEnvFor(s.config.To): func() (any, error) {
+			return utils.ImageDigestFor(s.client, s.jobSpec.Namespace, api.PipelineImageStream, string(s.config.To))()
+		},
 	}
 }
 

--- a/pkg/steps/write_params.go
+++ b/pkg/steps/write_params.go
@@ -42,11 +42,17 @@ func (s *writeParametersStep) run() error {
 		return fmt.Errorf("failed to resolve parameters: %w", err)
 	}
 	for k, v := range values {
-		if safeEnv.MatchString(v) {
-			params = append(params, fmt.Sprintf("%s=%s", k, v))
+		vStr, ok := v.(string)
+		if !ok {
+			logrus.Debugf("Skipping non-string parameter %q (type %T)", k, v)
 			continue
 		}
-		params = append(params, fmt.Sprintf("%s='%s'", k, strings.Replace(strings.Replace(v, "\\", "\\\\", -1), "'", "\\'", -1)))
+
+		if safeEnv.MatchString(vStr) {
+			params = append(params, fmt.Sprintf("%s=%s", k, vStr))
+			continue
+		}
+		params = append(params, fmt.Sprintf("%s='%s'", k, strings.Replace(strings.Replace(vStr, "\\", "\\\\", -1), "'", "\\'", -1)))
 	}
 
 	sort.Strings(params)

--- a/pkg/steps/write_params_test.go
+++ b/pkg/steps/write_params_test.go
@@ -11,8 +11,8 @@ import (
 
 func TestWriteParamsStep(t *testing.T) {
 	params := api.NewDeferredParameters(nil)
-	params.Add("K1", func() (string, error) { return "V1", nil })
-	params.Add("K2", func() (string, error) { return "V:2", nil })
+	params.Add("K1", func() (any, error) { return "V1", nil })
+	params.Add("K2", func() (any, error) { return "V:2", nil })
 	paramFile, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Errorf("Failed to create temporary file: %v", err)


### PR DESCRIPTION
Allow `DeferredParameters` to store generic objects `any` rather than `string` solely.
The semantic of the main get method:
```golang
type Parameters interface {
  Get(name string) (string, error)
}
```
doesn't change: if it exists and is a `string` type, return a parameter stored with name `name`.

This is part of some preparatory work to move cluster profiles definition out of the code base.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR generalizes ci-operator's parameter system so deferred parameters can hold arbitrary values (any) instead of only strings. It's preparatory work to move cluster profile definitions (and other richer parameter data) out of the codebase and into configurable inputs.

## What changed in practice

- Core parameter producers and storage now return and hold any-typed values:
  - ParameterMap entries are now func() (any, error) rather than func() (string, error).
  - DeferredParameters stores cached results as map[string]any and accepts deferred evaluators that return (any, error).
  - DeferredParameters.Map() now returns map[string]any.
- The exported Parameters.Get(name string) (string, error) method is unchanged to preserve backwards compatibility: it still returns a string only when the stored value is a non-empty string; non-string values (or absent keys) fall back to wrapped parameter lookups or an empty string.
- The legacy overrideParameters / NewOverrideParameters helper was removed.

## Components affected and behavioral impact

- ci-operator parameter evaluation (pkg/api/*): can now represent richer, typed parameter values (e.g., structs, numbers, nested objects) produced lazily by steps or defaults.
- Step implementations (pkg/steps/* and pkg/defaults/*): many steps now register parameter factories that return (any, error) or wrap existing producers in closures that evaluate to any. The runtime semantics of when values are produced are unchanged — only the value type widened.
- Parameter emission (pkg/steps/write_params.go): when writing environment parameters, non-string values are now skipped (with a debug log) instead of being coerced; string values are written exactly as before with the same quoting/escaping rules.
- Tests: unit tests across parameters, defaults, and steps were updated to use map[string]any and factory funcs returning (any, error).

## Why this matters to CI users and operators

- Enables storing and passing structured configuration (not just strings) through ci-operator's parameter system — a prerequisite for moving complex definitions like cluster profiles out of the code and into CI configuration.
- Existing callers that use Parameters.Get(...) to fetch string parameters continue to work without changes; however, operators should be aware that some parameters may now be non-strings and thus will not be emitted as environment variables by the write-parameters step.
- No runtime change in when parameters are evaluated; changes are type-level and backward-compatible for string consumers, but non-string values need explicit handling by any code that consumes the new map[string]any outputs.

## Backward compatibility and migration notes

- Public API: Parameters.Get signature unchanged; most existing code remains compatible.
- Any code that inspects DeferredParameters.Map() or expects map[string]string must be updated to handle map[string]any.
- When exposing parameters as shell envs, only string values will be written; if new features rely on non-string parameter values being serialized, call sites must be updated to serialize them explicitly.

## Tests & risk

- Tests were updated across the codebase to reflect the broader type support; coverage remains focused on lazy evaluation, caching, and inheritance behavior.
- The change is primarily a type generalization with localized adjustments; primary risks are places that assumed string values (now guarded by skipping non-strings) and any downstream code that consumed map[string]string directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->