### PR TITLE
Prevent pj-rehearse to enter a loop by its own comment

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -407,7 +407,7 @@ func main() {
 			})
 		})
 		eventServer.RegisterHandleIssueCommentEvent(func(l *logrus.Entry, event github.IssueCommentEvent) {
-			if !event.Issue.IsPullRequest() || event.Action != github.IssueCommentActionCreated {
+			if !event.Issue.IsPullRequest() || event.Action != github.IssueCommentActionCreated || !commentRegex.MatchString(event.Comment.Body) {
 				return
 			}
 			dispatcher.dispatch(l, func() {

--- a/cmd/pj-rehearse/server.go
+++ b/cmd/pj-rehearse/server.go
@@ -289,9 +289,10 @@ func (s *server) commentAffectedJobsOnPR(pullRequest *github.PullRequest, logger
 }
 
 func (s *server) handleIssueComment(l *logrus.Entry, event github.IssueCommentEvent) {
-	if !event.Issue.IsPullRequest() || github.IssueCommentActionCreated != event.Action {
+	if !event.Issue.IsPullRequest() || github.IssueCommentActionCreated != event.Action || !commentRegex.MatchString(event.Comment.Body) {
 		return
 	}
+
 	org := event.Repo.Owner.Login
 	repo := event.Repo.Name
 	number := event.Issue.Number


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## pj-rehearse: Prevent infinite loop from self-generated comments

This PR fixes a critical issue in the `pj-rehearse` Prow plugin where it could inadvertently trigger itself recursively by processing its own generated comments on pull requests.

### Problem

The `pj-rehearse` tool is a CI infrastructure component that handles `/pj-rehearse` commands in PR comments to orchestrate test job rehearsals. Previously, its issue-comment event handler would process all newly-created comments on pull requests without validating their content. This meant it could process comments it generated itself. When `pj-rehearse` created a comment containing the `/pj-rehearse` command pattern, it would detect and process that comment again, creating an infinite loop.

### Solution

Both the handler registration (`cmd/pj-rehearse/main.go`) and the server handler (`cmd/pj-rehearse/server.go`) now validate incoming comments against the `/pj-rehearse` command pattern using a compiled regex filter before processing. The handler now only triggers when all three conditions are met:
1. The comment is on a pull request
2. The action is `created`
3. The comment body matches the `/pj-rehearse` command pattern (regex: `^/pj-rehearse\f*.*$`)

This ensures that only legitimate user commands targeting the tool are processed, while incidental comments—including those generated by the tool itself—are ignored.

### Impact

This prevents `pj-rehearse` from entering self-triggered loops during normal operation while maintaining full functionality for user-initiated `/pj-rehearse` commands. This improves the stability of the OpenShift CI job rehearsal workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->