### PR TITLE
fix(ci-operator): keep registry.ci builder FROM when final stage is external

### DIFF
--- a/pkg/dockerfile/extract.go
+++ b/pkg/dockerfile/extract.go
@@ -14,6 +14,9 @@ import (
 // RegistryRegex matches registry references to registry.ci.openshift.org or quay-proxy.ci.openshift.org
 var RegistryRegex = regexp.MustCompile(`(registry\.(?:svc\.)?ci\.openshift\.org|quay-proxy\.ci\.openshift\.org)/[^\s\\]+`)
 
+// dockerfileLineContinuation matches Dockerfile backslash line continuations.
+var dockerfileLineContinuation = regexp.MustCompile(`\\\r?\n[ \t]*`)
+
 // OrgRepoTag represents a parsed image reference
 type OrgRepoTag struct {
 	Org, Repo, Tag string
@@ -23,16 +26,26 @@ func (ort OrgRepoTag) String() string {
 	return ort.Org + "_" + ort.Repo + "_" + ort.Tag
 }
 
-// ExtractRegistryReferences finds all registry.ci.openshift.org and quay-proxy.ci.openshift.org references in the Dockerfile
+// ExtractRegistryReferences finds registry.ci.openshift.org and quay-proxy.ci.openshift.org references in
+// Dockerfile FROM, COPY --from=, and RUN instructions (e.g. podman pull).
 func ExtractRegistryReferences(dockerfile []byte, from api.PipelineImageStreamTagReference) []string {
+	dockerfile = dockerfileLineContinuation.ReplaceAll(dockerfile, []byte(" "))
+
 	var refs []string
 	seen := sets.Set[string]{}
-	lastFromRef := ""
+	var lastFromLineRegistryRef string
 
 	for _, line := range bytes.Split(dockerfile, []byte("\n")) {
 		upper := bytes.ToUpper(line)
-		if !bytes.Contains(upper, []byte("FROM")) && !bytes.Contains(upper, []byte("COPY")) {
+		if !bytes.Contains(upper, []byte("FROM")) && !bytes.Contains(upper, []byte("COPY")) && !bytes.Contains(upper, []byte("RUN")) {
 			continue
+		}
+
+		if bytes.HasPrefix(upper, []byte("FROM")) {
+			lastFromLineRegistryRef = ""
+			if match := RegistryRegex.Find(line); match != nil {
+				lastFromLineRegistryRef = string(match)
+			}
 		}
 
 		match := RegistryRegex.Find(line)
@@ -40,20 +53,17 @@ func ExtractRegistryReferences(dockerfile []byte, from api.PipelineImageStreamTa
 			continue
 		}
 		ref := string(match)
-		if bytes.HasPrefix(upper, []byte("FROM")) {
-			lastFromRef = ref
-		}
 
 		if !seen.Has(ref) {
 			refs = append(refs, ref)
 			seen.Insert(ref)
 		}
 	}
-	if from != "" {
-		// If from is specified, remove the last detected FROM ref, it will be replaced
+	if from != "" && lastFromLineRegistryRef != "" {
+		// images[].from replaces the final Dockerfile stage; exclude only that stage's registry.ci reference
 		var newRefs []string
 		for _, ref := range refs {
-			if ref != lastFromRef {
+			if ref != lastFromLineRegistryRef {
 				newRefs = append(newRefs, ref)
 			}
 		}

--- a/pkg/dockerfile/inputs_test.go
+++ b/pkg/dockerfile/inputs_test.go
@@ -166,6 +166,50 @@ RUN echo "hello"
 			},
 		},
 		{
+			name: "RUN podman pull registry.ci reference",
+			dockerfile: `FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+RUN podman pull registry.ci.openshift.org/ocp/4.19:tools && cp bin/tool /usr/bin/tool
+`,
+			expected: map[string]api.ImageStreamTagReference{
+				"ocp_4.19_tools": {
+					Namespace: "ocp",
+					Name:      "4.19",
+					Tag:       "tools",
+					As:        "registry.ci.openshift.org/ocp/4.19:tools",
+				},
+			},
+		},
+		{
+			name: "RUN podman pull with line continuation",
+			dockerfile: `FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+RUN podman pull \
+    registry.ci.openshift.org/ocp/4.19:tools && cp bin/tool /usr/bin/tool
+`,
+			expected: map[string]api.ImageStreamTagReference{
+				"ocp_4.19_tools": {
+					Namespace: "ocp",
+					Name:      "4.19",
+					Tag:       "tools",
+					As:        "registry.ci.openshift.org/ocp/4.19:tools",
+				},
+			},
+		},
+		{
+			name: "from: ubi with external final stage keeps builder registry.ci FROM",
+			dockerfile: `FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS builder
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+`,
+			from: "ubi",
+			expected: map[string]api.ImageStreamTagReference{
+				"ocp_builder_rhel-9-golang-1.22-openshift-4.18": {
+					Namespace: "ocp",
+					Name:      "builder",
+					Tag:       "rhel-9-golang-1.22-openshift-4.18",
+					As:        "registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18",
+				},
+			},
+		},
+		{
 			name: "from: is specified - should exclude the last detected FROM ref with COPY",
 			dockerfile: `FROM registry.ci.openshift.org/ocp/4.18:base AS builder
 FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.21


### PR DESCRIPTION
/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dockerfile Input Detection with External Final Stage

**Component**: ci-operator (Dockerfile parsing for build input detection)

**Problem**: ci-operator's Dockerfile scanner previously missed some registry.ci.openshift.org references in real-world Dockerfiles. It also incorrectly excluded all registry.ci references when the final stage used an external base image (via `from`), which broke multi-stage builds that relied on registry.ci builder stages.

**What changed**:
- ExtractRegistryReferences (pkg/dockerfile/extract.go) now:
  - Normalizes Dockerfile line continuations (replaces backslash-newline with spaces) so matches can span continued lines.
  - Scans RUN instructions in addition to FROM and COPY, so image references in commands like `podman pull` are detected.
  - Deduplicates matches with a seen set.
  - Tracks the registry captured from the final FROM line only, and excludes only that registry when a final external `from` is specified — earlier builder-stage registry.ci references are preserved.

**Behavioral impact**: Multi-stage Dockerfiles that use registry.ci builder images (e.g., OCP builders) in intermediate stages and an external final base image (e.g., Red Hat UBI) will now have the registry.ci builder references correctly detected and wired as build inputs. Detection is also more robust across line continuations and image pulls inside RUN commands.

**Tests**: Added table-driven tests (pkg/dockerfile/inputs_test.go) covering:
- detection of registry.ci references in `podman pull` (single-line and continued-line forms),
- a case where a builder-stage FROM uses registry.ci while the final stage is an external UBI image, asserting the builder registry is retained.

**Practical benefit**: Reduces manual configuration and prevents accidental omission of required builder images from CI build inputs, improving reliability for multi-stage builds that mix internal builder images and external base images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->