### PR TITLE
DPTP-4929: add disable_pod_scaler opt-out for test and image build pods

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -702,6 +702,7 @@ func (o *options) Complete() error {
 	}
 
 	handleTargetAdditionalSuffix(o)
+	setDisablePodScalerFromTarget(o)
 
 	if o.enableSecretsStoreCSIDriver {
 		if err := api.LoadGSMConfigFromFile(o.gsmConfigPath, &o.gsmConfig); err != nil {
@@ -764,6 +765,18 @@ func parseKeyValParams(input []string, paramType string) (map[string]string, err
 	}
 
 	return params, nil
+}
+
+func setDisablePodScalerFromTarget(o *options) {
+	if o.jobSpec.Target == "" || o.jobSpec.Target == "all" {
+		return
+	}
+	for _, test := range o.configSpec.Tests {
+		if test.As == o.jobSpec.Target && test.DisablePodScaler {
+			o.jobSpec.DisablePodScaler = true
+			return
+		}
+	}
 }
 
 func handleTargetAdditionalSuffix(o *options) {

--- a/cmd/pod-scaler/admission.go
+++ b/cmd/pod-scaler/admission.go
@@ -150,7 +150,7 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 }
 
 func shouldScalePod(pod *corev1.Pod) (bool, error) {
-	scale, present := pod.Annotations["ci-workload-autoscaler.openshift.io/scale"]
+	scale, present := pod.Annotations[api.WorkloadAutoscalerScaleAnnotation]
 	if present {
 		return strconv.ParseBool(scale)
 	}

--- a/pkg/api/constant.go
+++ b/pkg/api/constant.go
@@ -64,6 +64,9 @@ const (
 
 	AutoScalePodsLabel = "ci.openshift.io/scale-pods"
 
+	// WorkloadAutoscalerScaleAnnotation opts a pod out of pod-scaler admission when set to "false".
+	WorkloadAutoscalerScaleAnnotation = "ci-workload-autoscaler.openshift.io/scale"
+
 	NamespaceDir = "build-resources"
 
 	APPCIKubeAPIURL = "https://api.ci.l2s4.p1.openshiftapps.com:6443"

--- a/pkg/api/job_spec.go
+++ b/pkg/api/job_spec.go
@@ -30,6 +30,9 @@ type JobSpec struct {
 	Metadata               Metadata `json:"metadata,omitempty"`
 	Target                 string   `json:"target,omitempty"`
 	TargetAdditionalSuffix string   `json:"target_additional_suffix,omitempty"`
+
+	// DisablePodScaler opts workload pods in this job out of pod-scaler admission.
+	DisablePodScaler bool `json:"disable_pod_scaler,omitempty"`
 }
 
 // Namespace returns the namespace of the job. Must not be evaluated

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -895,6 +895,9 @@ type TestStepConfiguration struct {
 	// DisableRehearsal prevents this specific test from being picked up for rehearsals.
 	DisableRehearsal bool `json:"disable_rehearsal,omitempty"`
 
+	// DisablePodScaler opts generated test and image build pods out of pod-scaler admission.
+	DisablePodScaler bool `json:"disable_pod_scaler,omitempty"`
+
 	// RestrictNetworkAccess restricts network access to RedHat intranet.
 	RestrictNetworkAccess *bool `json:"restrict_network_access,omitempty"`
 

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -218,6 +218,12 @@ func PodStep(name string, config PodStepConfiguration, resources api.ResourceCon
 	}
 }
 
+func applyPodScalerOptOut(jobSpec *api.JobSpec, annotations map[string]string) {
+	if jobSpec != nil && jobSpec.DisablePodScaler {
+		annotations[api.WorkloadAutoscalerScaleAnnotation] = "false"
+	}
+}
+
 func GenerateBasePod(
 	jobSpec *api.JobSpec,
 	baseLabels map[string]string,
@@ -238,15 +244,17 @@ func GenerateBasePod(
 	if err != nil {
 		return nil, err
 	}
+	annotations := map[string]string{
+		JobSpecAnnotation:                     jobSpec.RawSpec(),
+		annotationContainersForSubTestResults: containerName,
+	}
+	applyPodScalerOptOut(jobSpec, annotations)
 	pod := &coreapi.Pod{
 		ObjectMeta: meta.ObjectMeta{
-			Namespace: jobSpec.Namespace(),
-			Name:      name,
-			Labels:    LabelsFor(jobSpec, baseLabels, ""),
-			Annotations: map[string]string{
-				JobSpecAnnotation:                     jobSpec.RawSpec(),
-				annotationContainersForSubTestResults: containerName,
-			},
+			Namespace:   jobSpec.Namespace(),
+			Name:        name,
+			Labels:      LabelsFor(jobSpec, baseLabels, ""),
+			Annotations: annotations,
 		},
 		Spec: coreapi.PodSpec{
 			NodeName:      nodeName,

--- a/pkg/steps/pod_test.go
+++ b/pkg/steps/pod_test.go
@@ -297,6 +297,20 @@ func (ps *podStatusChangingClient) Create(ctx context.Context, o ctrlruntimeclie
 	return ps.WithWatch.Create(ctx, o, opts...)
 }
 
+func TestGenerateBasePodDisablePodScaler(t *testing.T) {
+	ps := expectedPodStepTemplate()
+	ps.jobSpec.DisablePodScaler = true
+	pod, err := GenerateBasePod(ps.jobSpec, nil, ps.config.As, ps.config.NodeName, ps.name,
+		[]string{"/bin/bash"}, "image", corev1.ResourceRequirements{}, "artifacts",
+		ps.jobSpec.DecorationConfig, ps.jobSpec.RawSpec(), nil, &GeneratePodOptions{})
+	if err != nil {
+		t.Fatalf("GenerateBasePod: %v", err)
+	}
+	if got := pod.Annotations[api.WorkloadAutoscalerScaleAnnotation]; got != "false" {
+		t.Fatalf("annotation %q, want false", got)
+	}
+}
+
 func TestTestStepAndRequires(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -325,14 +325,16 @@ func buildFromSource(jobSpec *api.JobSpec, fromTag, toTag api.PipelineImageStrea
 
 	layer := buildapi.ImageOptimizationSkipLayers
 	labels := LabelsFor(jobSpec, map[string]string{CreatesLabel: buildName}, ref)
+	buildAnnotations := map[string]string{
+		JobSpecAnnotation: jobSpec.RawSpec(),
+	}
+	applyPodScalerOptOut(jobSpec, buildAnnotations)
 	build := &buildapi.Build{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      buildName,
-			Namespace: jobSpec.Namespace(),
-			Labels:    labels,
-			Annotations: map[string]string{
-				JobSpecAnnotation: jobSpec.RawSpec(),
-			},
+			Name:        buildName,
+			Namespace:   jobSpec.Namespace(),
+			Labels:      labels,
+			Annotations: buildAnnotations,
 		},
 		Spec: buildapi.BuildSpec{
 			CommonSpec: buildapi.CommonSpec{

--- a/pkg/steps/source_test.go
+++ b/pkg/steps/source_test.go
@@ -265,6 +265,17 @@ func TestBuildFromSource(t *testing.T) {
 		ref                           string
 	}{
 		{
+			name: "pod scaler opt-out",
+			jobSpec: &api.JobSpec{
+				DisablePodScaler: true,
+				JobSpec: downwardapi.JobSpec{
+					Job:       "job",
+					BuildID:   "buildId",
+					ProwJobID: "prowJobId",
+				},
+			},
+		},
+		{
 			name: "build args",
 			jobSpec: &api.JobSpec{
 				JobSpec: downwardapi.JobSpec{

--- a/pkg/steps/testdata/zz_fixture_TestBuildFromSource_pod_scaler_opt_out.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestBuildFromSource_pod_scaler_opt_out.yaml
@@ -1,0 +1,53 @@
+metadata:
+  annotations:
+    ci-workload-autoscaler.openshift.io/scale: "false"
+    ci.openshift.io/job-spec: ""
+  creationTimestamp: null
+  labels:
+    OPENSHIFT_CI: "true"
+    ci.openshift.io/jobid: prowJobId
+    ci.openshift.io/jobname: job
+    ci.openshift.io/jobtype: ""
+    ci.openshift.io/metadata.branch: ""
+    ci.openshift.io/metadata.org: ""
+    ci.openshift.io/metadata.repo: ""
+    ci.openshift.io/metadata.target: ""
+    ci.openshift.io/metadata.variant: ""
+    created-by-ci: "true"
+    creates: ""
+  namespace: test-namespace
+spec:
+  nodeSelector: null
+  output:
+    imageLabels:
+    - name: io.openshift.build.commit.author
+    - name: io.openshift.build.commit.date
+    - name: io.openshift.build.commit.id
+    - name: io.openshift.build.commit.message
+    - name: io.openshift.build.commit.ref
+    - name: io.openshift.build.name
+    - name: io.openshift.build.namespace
+    - name: io.openshift.build.source-context-dir
+    - name: io.openshift.build.source-location
+    - name: vcs-ref
+    - name: vcs-type
+    - name: vcs-url
+    to:
+      kind: ImageStreamTag
+      name: 'pipeline:'
+      namespace: test-namespace
+  postCommit: {}
+  resources: {}
+  source: {}
+  strategy:
+    dockerStrategy:
+      env:
+      - name: BUILD_LOGLEVEL
+        value: "0"
+      forcePull: true
+      imageOptimizationPolicy: SkipLayers
+      noCache: true
+    type: Docker
+status:
+  output: {}
+  phase: ""

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -655,6 +655,8 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"        # of pull request workflows. Setting this field will\n" +
 	"        # create a periodic job instead of a presubmit\n" +
 	"        cron: \"\"\n" +
+	"        # DisablePodScaler opts generated test and image build pods out of pod-scaler admission.\n" +
+	"        disable_pod_scaler: true\n" +
 	"        # DisableRehearsal prevents this specific test from being picked up for rehearsals.\n" +
 	"        disable_rehearsal: true\n" +
 	"        # Interval is how frequently the test should be run based\n" +
@@ -1587,6 +1589,8 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"      # of pull request workflows. Setting this field will\n" +
 	"      # create a periodic job instead of a presubmit\n" +
 	"      cron: \"\"\n" +
+	"      # DisablePodScaler opts generated test and image build pods out of pod-scaler admission.\n" +
+	"      disable_pod_scaler: true\n" +
 	"      # DisableRehearsal prevents this specific test from being picked up for rehearsals.\n" +
 	"      disable_rehearsal: true\n" +
 	"      # Interval is how frequently the test should be run based\n" +


### PR DESCRIPTION
Adds optional disable_pod_scaler: true on ci-operator tests so generated test pods and image build pods get ci-workload-autoscaler.openshift.io/scale: "false" and skip pod-scaler admission.

/cc @smg247 @openshift/test-platform 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Pod Scaler Opt-Out Configuration

This PR adds the ability to opt out of the pod-scaler admission (which automatically scales workload pods) on a per-test basis. The feature is useful for test and image build pods that should not be scaled by the workload autoscaler.

### Key Changes

**New Configuration Options:**
- Added `DisablePodScaler` boolean field to `TestStepConfiguration` in the test step configuration
- Added `DisablePodScaler` boolean field to `JobSpec` to allow job-level control
- These options can be set in CI configuration to disable pod scaling for specific tests or entire jobs

**Shared Annotation Constant:**
- Introduced a shared constant `WorkloadAutoscalerScaleAnnotation` (`ci-workload-autoscaler.openshift.io/scale`) in `pkg/api/constant.go` to standardize the annotation key used across components

**Pod and Build Generation Updates:**
- Modified pod generation logic (`pkg/steps/pod.go`) to inject the autoscaler opt-out annotation (`ci-workload-autoscaler.openshift.io/scale: "false"`) when `DisablePodScaler` is enabled
- Modified build generation logic for image builds (`pkg/steps/source.go`) to also apply the opt-out annotation
- Updated `cmd/pod-scaler/admission.go` to use the shared annotation constant instead of hardcoded strings

**Target-Specific Disabling:**
- Added logic in `cmd/ci-operator/main.go` that automatically enables pod-scaler disabling at the job level when the resolved target test has `DisablePodScaler` configured, providing an easy way to opt out specific test targets without modifying job specs

### Testing

Added comprehensive tests to verify the feature works correctly:
- Unit test for pod generation with pod-scaler disabled (`TestGenerateBasePodDisablePodScaler`)
- Integration test case in `TestBuildFromSource` with a fixture file demonstrating the expected behavior for builds with pod-scaler disabled

<!-- end of auto-generated comment: release notes by coderabbit.ai -->