### PR TITLE
fix(release): batch quay promotion when float tag count is high

### DIFF
--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -385,6 +385,9 @@ const (
 	quayImageIncomingSuffix = "_incoming"
 	quayImagePreSuffix      = "__pre"
 	quayImagePost1Suffix    = "__post1"
+
+	// promotionMirrorChunkSize limits pairs per oc image mirror invocation to avoid argv overflow inside the pod.
+	promotionMirrorChunkSize = 15
 )
 
 type quayFloatPromotion struct {
@@ -393,50 +396,100 @@ type quayFloatPromotion struct {
 	pruneTag string
 }
 
-// getStagedQuayFloatPromotionShell returns shell that repoints floatTag from its incoming staging tag.
-// If floatTag already exists on the registry, the current image is copied to pruneTag (when set) and
-// floatTag+quayImagePreSuffix before the repoint; floatTag+quayImagePost1Suffix is added afterward.
-func getStagedQuayFloatPromotionShell(registryConfig, floatTag, pruneTag string) string {
-	incomingTag := floatTag + quayImageIncomingSuffix
-	preTag := floatTag + quayImagePreSuffix
-	post1Tag := floatTag + quayImagePost1Suffix
-
-	checkOld := fmt.Sprintf(`_OLD_EXISTS=false
-if oc image info --registry-config=%s %s >/dev/null 2>&1; then _OLD_EXISTS=true; fi`, registryConfig, floatTag)
-
-	var backupOld string
-	if pruneTag != "" {
-		backupOld = fmt.Sprintf(`if [ "${_OLD_EXISTS}" = "true" ]; then
-%s
-%s
-fi`,
-			indentShell(getMirrorRetryShell(registryConfig, []string{fmt.Sprintf("%s=%s", floatTag, pruneTag)})),
-			indentShell(getMirrorRetryShell(registryConfig, []string{fmt.Sprintf("%s=%s", floatTag, preTag)})),
-		)
-	} else {
-		backupOld = fmt.Sprintf(`if [ "${_OLD_EXISTS}" = "true" ]; then
-%s
-fi`, indentShell(getMirrorRetryShell(registryConfig, []string{fmt.Sprintf("%s=%s", floatTag, preTag)})))
+// getMirrorRetryShellChunked mirrors image pairs in fixed-size chunks to keep oc image mirror argv bounded.
+func getMirrorRetryShellChunked(registryConfig string, images []string, chunkSize int) string {
+	if len(images) == 0 {
+		return ""
 	}
-
-	latch := getMirrorRetryShell(registryConfig, []string{fmt.Sprintf("%s=%s", incomingTag, floatTag)})
-
-	postLatch := fmt.Sprintf(`if [ "${_OLD_EXISTS}" = "true" ]; then
-%s
-fi`, indentShell(getMirrorRetryShell(registryConfig, []string{fmt.Sprintf("%s=%s", floatTag, post1Tag)})))
-
-	return strings.Join([]string{checkOld, backupOld, latch, postLatch}, "\n")
+	if chunkSize <= 0 {
+		chunkSize = len(images)
+	}
+	var sections []string
+	for start := 0; start < len(images); start += chunkSize {
+		end := start + chunkSize
+		if end > len(images) {
+			end = len(images)
+		}
+		sections = append(sections, getMirrorRetryShell(registryConfig, images[start:end]))
+	}
+	return strings.Join(sections, "\n")
 }
 
-func indentShell(script string) string {
-	const prefix = "  "
-	lines := strings.Split(script, "\n")
-	for i, line := range lines {
-		if line != "" {
-			lines[i] = prefix + line
-		}
+// getMirrorRetryShellFromPairsVar mirrors pairs collected in a shell variable (space-separated src=dest).
+func getMirrorRetryShellFromPairsVar(registryConfig, pairsVar string) string {
+	mirrorCmd := fmt.Sprintf("oc image mirror --loglevel=2 --keep-manifest-list --registry-config=%s --max-per-registry=10 ${%s}", registryConfig, pairsVar)
+	n := quayPromotionMirrorAttempts
+	return fmt.Sprintf(`if [ -n "${%s}" ]; then
+for r in {1..%d}; do
+  echo Mirror attempt $r
+  if %s; then break; fi
+  if [ "${r}" -eq %d ]; then
+    exit 1
+  fi
+  backoff=$(($RANDOM %% 120))s
+  echo Sleeping randomized $backoff before retry
+  sleep $backoff
+done
+fi`, pairsVar, n, mirrorCmd, n)
+}
+
+// getBatchedStagedQuayFloatPromotionShell runs staged quay float promotion in ordered phases:
+// check existing floats, batch backup mirrors, batch latch incoming->float, batch __post1 mirrors.
+// Mirror steps are chunked so both the pod argv and per-oc-image-mirror argv stay bounded.
+func getBatchedStagedQuayFloatPromotionShell(registryConfig string, promotions []quayFloatPromotion) string {
+	if len(promotions) == 0 {
+		return ""
 	}
-	return strings.Join(lines, "\n")
+
+	var checks []string
+	var backupSections []string
+	var latchPairs []string
+	var post1Sections []string
+
+	for i, promotion := range promotions {
+		floatTag := promotion.floatTag
+		incomingTag := floatTag + quayImageIncomingSuffix
+		preTag := floatTag + quayImagePreSuffix
+		post1Tag := floatTag + quayImagePost1Suffix
+
+		checks = append(checks, fmt.Sprintf(`_HAD_OLD_%d=false
+if oc image info --registry-config=%s %s >/dev/null 2>&1; then _HAD_OLD_%d=true; fi`, i, registryConfig, floatTag, i))
+
+		latchPairs = append(latchPairs, fmt.Sprintf("%s=%s", incomingTag, floatTag))
+
+		if promotion.pruneTag != "" {
+			backupSections = append(backupSections, fmt.Sprintf(`if [ "${_HAD_OLD_%d}" = "true" ]; then _BACKUP_PAIRS="${_BACKUP_PAIRS}%s=%s %s=%s "; fi`, i, floatTag, promotion.pruneTag, floatTag, preTag))
+		} else {
+			backupSections = append(backupSections, fmt.Sprintf(`if [ "${_HAD_OLD_%d}" = "true" ]; then _BACKUP_PAIRS="${_BACKUP_PAIRS}%s=%s "; fi`, i, floatTag, preTag))
+		}
+
+		post1Sections = append(post1Sections, fmt.Sprintf(`if [ "${_HAD_OLD_%d}" = "true" ]; then _POST1_PAIRS="${_POST1_PAIRS}%s=%s "; fi`, i, floatTag, post1Tag))
+	}
+
+	sections := []string{strings.Join(checks, "\n")}
+	sections = append(sections, getConditionalMirrorRetryShellChunks(registryConfig, "_BACKUP_PAIRS", backupSections)...)
+	sections = append(sections, getMirrorRetryShellChunked(registryConfig, latchPairs, promotionMirrorChunkSize))
+	sections = append(sections, getConditionalMirrorRetryShellChunks(registryConfig, "_POST1_PAIRS", post1Sections)...)
+
+	return strings.Join(sections, "\n")
+}
+
+// getConditionalMirrorRetryShellChunks builds pair variables and mirror retries in fixed-size chunks.
+func getConditionalMirrorRetryShellChunks(registryConfig, pairsVar string, pairBuilders []string) []string {
+	if len(pairBuilders) == 0 {
+		return nil
+	}
+	var sections []string
+	for start := 0; start < len(pairBuilders); start += promotionMirrorChunkSize {
+		end := start + promotionMirrorChunkSize
+		if end > len(pairBuilders) {
+			end = len(pairBuilders)
+		}
+		sections = append(sections, fmt.Sprintf(`%s=""`, pairsVar))
+		sections = append(sections, pairBuilders[start:end]...)
+		sections = append(sections, getMirrorRetryShellFromPairsVar(registryConfig, pairsVar))
+	}
+	return sections
 }
 
 func getPromotionPod(imageMirrorTarget map[string]string, timeStr string, namespace string, name string, cliImage string, nodeArchitectures []string) *coreapi.Pod {
@@ -506,7 +559,6 @@ func getPromotionPod(imageMirrorTarget map[string]string, timeStr string, namesp
 	}
 
 	registryConfig := filepath.Join(api.RegistryPushCredentialsCICentralSecretMountPath, coreapi.DockerConfigJsonKey)
-	command := []string{"/bin/sh", "-c"}
 
 	var commands []string
 
@@ -543,15 +595,13 @@ func getPromotionPod(imageMirrorTarget map[string]string, timeStr string, namesp
 
 	var args []string
 	if isQuayStep && len(incomingImages) > 0 {
-		args = append(args, getMirrorRetryShell(registryConfig, incomingImages))
+		args = append(args, getMirrorRetryShellChunked(registryConfig, incomingImages, promotionMirrorChunkSize))
 	}
 	if isQuayStep && len(quayFloatPromotions) > 0 {
 		sort.Slice(quayFloatPromotions, func(i, j int) bool {
 			return quayFloatPromotions[i].floatTag < quayFloatPromotions[j].floatTag
 		})
-		for _, promotion := range quayFloatPromotions {
-			args = append(args, getStagedQuayFloatPromotionShell(registryConfig, promotion.floatTag, promotion.pruneTag))
-		}
+		args = append(args, getBatchedStagedQuayFloatPromotionShell(registryConfig, quayFloatPromotions))
 	}
 	if len(pruneImages) > 0 {
 		// See https://github.com/openshift/release/blob/2080ec4a49337c27577a4b2ff08a538e96436e65/hack/qci_registry_pruner.py for details.
@@ -562,7 +612,6 @@ func getPromotionPod(imageMirrorTarget map[string]string, timeStr string, namesp
 	}
 
 	args = append(args, commands...)
-	args = []string{strings.Join(args, "\n")}
 
 	image := cliImage
 	nodeSelector := map[string]string{"kubernetes.io/arch": "amd64"}
@@ -587,8 +636,8 @@ func getPromotionPod(imageMirrorTarget map[string]string, timeStr string, namesp
 				{
 					Name:    "promotion",
 					Image:   image,
-					Command: command,
-					Args:    args,
+					Command: []string{"/bin/sh", "-c"},
+					Args:    []string{strings.Join(args, "\n")},
 					Env: []coreapi.EnvVar{
 						// Discovery cache only: without KUBECACHEDIR, client-go defaults to $HOME/.kube/cache; with no
 						// writable HOME in the container that becomes /.kube and logs many INFO lines ("permission denied").

--- a/pkg/steps/release/promote_test.go
+++ b/pkg/steps/release/promote_test.go
@@ -1266,6 +1266,54 @@ func TestPromotionCLIImageFromRegistry(t *testing.T) {
 	}
 }
 
+func TestGetPromotionPodKeepsStagedFlowForManyFloatTags(t *testing.T) {
+	t.Parallel()
+
+	imageMirror := map[string]string{}
+	digest := "registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:" + strings.Repeat("a", 64)
+	for i := 0; i < 80; i++ {
+		floatTag := fmt.Sprintf("quay.io/openshift/ci:ci_tool_%d", i)
+		imageMirror[floatTag] = digest
+		imageMirror[fmt.Sprintf("quay.io/openshift/ci:20240603235401_prune_ci_tool_%d", i)] = floatTag
+		imageMirror[fmt.Sprintf("ci/ci-quay:tool-%d", i)] = "quay-proxy.ci.openshift.org/openshift/ci@sha256:" + strings.Repeat("b", 64)
+	}
+
+	pod := getPromotionPod(imageMirror, "20240603235401", "ci-op-large", "promotion-quay", "stable:cli", []string{"amd64"})
+	if len(pod.Spec.Containers[0].Args) != 1 {
+		t.Fatalf("expected inline promotion script, got args %v", pod.Spec.Containers[0].Args)
+	}
+	script := pod.Spec.Containers[0].Args[0]
+	for _, marker := range []string{"_HAD_OLD_0", "_BACKUP_PAIRS", "_incoming", "__pre", "__post1"} {
+		if !strings.Contains(script, marker) {
+			t.Fatalf("expected staged promotion marker %q in script", marker)
+		}
+	}
+}
+
+func TestGetBatchedStagedQuayFloatPromotionShell(t *testing.T) {
+	t.Parallel()
+
+	registryConfig := "/etc/push-secret/.dockerconfigjson"
+	promotions := []quayFloatPromotion{
+		{floatTag: "quay.io/openshift/ci:ci_a", pruneTag: "quay.io/openshift/ci:20240603235401_prune_ci_a"},
+		{floatTag: "quay.io/openshift/ci:ci_b"},
+	}
+
+	script := getBatchedStagedQuayFloatPromotionShell(registryConfig, promotions)
+	for _, want := range []string{
+		"_HAD_OLD_0",
+		"_HAD_OLD_1",
+		"_BACKUP_PAIRS",
+		"quay.io/openshift/ci:ci_a__pre",
+		"quay.io/openshift/ci:ci_a_incoming=quay.io/openshift/ci:ci_a",
+		"__post1",
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("expected %q in batched staged shell", want)
+		}
+	}
+}
+
 func TestGetPromotionPodFallbackImageDoesNotPinArm64Node(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay.yaml
@@ -18,33 +18,17 @@ spec:
         echo Sleeping randomized $backoff before retry
         sleep $backoff
       done
-      _OLD_EXISTS=false
-      if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_a_latest >/dev/null 2>&1; then _OLD_EXISTS=true; fi
-      if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ci_a_latest=quay.io/openshift/ci:20240603235401_prune_ci_a_latest; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ci_a_latest=quay.io/openshift/ci:ci_a_latest__pre; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-      fi
+      _HAD_OLD_0=false
+      if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_a_latest >/dev/null 2>&1; then _HAD_OLD_0=true; fi
+      _HAD_OLD_1=false
+      if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_c_latest >/dev/null 2>&1; then _HAD_OLD_1=true; fi
+      _BACKUP_PAIRS=""
+      if [ "${_HAD_OLD_0}" = "true" ]; then _BACKUP_PAIRS="${_BACKUP_PAIRS}quay.io/openshift/ci:ci_a_latest=quay.io/openshift/ci:20240603235401_prune_ci_a_latest quay.io/openshift/ci:ci_a_latest=quay.io/openshift/ci:ci_a_latest__pre "; fi
+      if [ "${_HAD_OLD_1}" = "true" ]; then _BACKUP_PAIRS="${_BACKUP_PAIRS}quay.io/openshift/ci:ci_c_latest=quay.io/openshift/ci:20240603235401_prune_ci_c_latest quay.io/openshift/ci:ci_c_latest=quay.io/openshift/ci:ci_c_latest__pre "; fi
+      if [ -n "${_BACKUP_PAIRS}" ]; then
       for r in {1..5}; do
         echo Mirror attempt $r
-        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ci_a_latest_incoming=quay.io/openshift/ci:ci_a_latest; then break; fi
+        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 ${_BACKUP_PAIRS}; then break; fi
         if [ "${r}" -eq 5 ]; then
           exit 1
         fi
@@ -52,45 +36,10 @@ spec:
         echo Sleeping randomized $backoff before retry
         sleep $backoff
       done
-      if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ci_a_latest=quay.io/openshift/ci:ci_a_latest__post1; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-      fi
-      _OLD_EXISTS=false
-      if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_c_latest >/dev/null 2>&1; then _OLD_EXISTS=true; fi
-      if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ci_c_latest=quay.io/openshift/ci:20240603235401_prune_ci_c_latest; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ci_c_latest=quay.io/openshift/ci:ci_c_latest__pre; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
       fi
       for r in {1..5}; do
         echo Mirror attempt $r
-        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ci_c_latest_incoming=quay.io/openshift/ci:ci_c_latest; then break; fi
+        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ci_a_latest_incoming=quay.io/openshift/ci:ci_a_latest quay.io/openshift/ci:ci_c_latest_incoming=quay.io/openshift/ci:ci_c_latest; then break; fi
         if [ "${r}" -eq 5 ]; then
           exit 1
         fi
@@ -98,17 +47,20 @@ spec:
         echo Sleeping randomized $backoff before retry
         sleep $backoff
       done
-      if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ci_c_latest=quay.io/openshift/ci:ci_c_latest__post1; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
+      _POST1_PAIRS=""
+      if [ "${_HAD_OLD_0}" = "true" ]; then _POST1_PAIRS="${_POST1_PAIRS}quay.io/openshift/ci:ci_a_latest=quay.io/openshift/ci:ci_a_latest__post1 "; fi
+      if [ "${_HAD_OLD_1}" = "true" ]; then _POST1_PAIRS="${_POST1_PAIRS}quay.io/openshift/ci:ci_c_latest=quay.io/openshift/ci:ci_c_latest__post1 "; fi
+      if [ -n "${_POST1_PAIRS}" ]; then
+      for r in {1..5}; do
+        echo Mirror attempt $r
+        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 ${_POST1_PAIRS}; then break; fi
+        if [ "${r}" -eq 5 ]; then
+          exit 1
+        fi
+        backoff=$(($RANDOM % 120))s
+        echo Sleeping randomized $backoff before retry
+        sleep $backoff
+      done
       fi
       set +e
       for r in {1..2}; do echo "Tag attempt $r (all together)"; oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@sha256:ddd ci/${component}-quay:c quay-proxy.ci.openshift.org/openshift/ci@sha256:bbb ci/ci-quay:${component} && break; :; done

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_4.12.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_4.12.yaml
@@ -18,33 +18,17 @@ spec:
         echo Sleeping randomized $backoff before retry
         sleep $backoff
       done
-      _OLD_EXISTS=false
-      if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.12_ovn-kubernetes >/dev/null 2>&1; then _OLD_EXISTS=true; fi
-      if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes__pre; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-      fi
+      _HAD_OLD_0=false
+      if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.12_ovn-kubernetes >/dev/null 2>&1; then _HAD_OLD_0=true; fi
+      _HAD_OLD_1=false
+      if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base >/dev/null 2>&1; then _HAD_OLD_1=true; fi
+      _BACKUP_PAIRS=""
+      if [ "${_HAD_OLD_0}" = "true" ]; then _BACKUP_PAIRS="${_BACKUP_PAIRS}quay.io/openshift/ci:ocp_4.12_ovn-kubernetes=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes quay.io/openshift/ci:ocp_4.12_ovn-kubernetes=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes__pre "; fi
+      if [ "${_HAD_OLD_1}" = "true" ]; then _BACKUP_PAIRS="${_BACKUP_PAIRS}quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes-base quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base__pre "; fi
+      if [ -n "${_BACKUP_PAIRS}" ]; then
       for r in {1..5}; do
         echo Mirror attempt $r
-        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes_incoming=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes; then break; fi
+        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 ${_BACKUP_PAIRS}; then break; fi
         if [ "${r}" -eq 5 ]; then
           exit 1
         fi
@@ -52,45 +36,10 @@ spec:
         echo Sleeping randomized $backoff before retry
         sleep $backoff
       done
-      if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes__post1; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-      fi
-      _OLD_EXISTS=false
-      if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base >/dev/null 2>&1; then _OLD_EXISTS=true; fi
-      if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes-base; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base__pre; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
       fi
       for r in {1..5}; do
         echo Mirror attempt $r
-        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base_incoming=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base; then break; fi
+        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes_incoming=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base_incoming=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base; then break; fi
         if [ "${r}" -eq 5 ]; then
           exit 1
         fi
@@ -98,17 +47,20 @@ spec:
         echo Sleeping randomized $backoff before retry
         sleep $backoff
       done
-      if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base__post1; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
+      _POST1_PAIRS=""
+      if [ "${_HAD_OLD_0}" = "true" ]; then _POST1_PAIRS="${_POST1_PAIRS}quay.io/openshift/ci:ocp_4.12_ovn-kubernetes=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes__post1 "; fi
+      if [ "${_HAD_OLD_1}" = "true" ]; then _POST1_PAIRS="${_POST1_PAIRS}quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base__post1 "; fi
+      if [ -n "${_POST1_PAIRS}" ]; then
+      for r in {1..5}; do
+        echo Mirror attempt $r
+        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 ${_POST1_PAIRS}; then break; fi
+        if [ "${r}" -eq 5 ]; then
+          exit 1
+        fi
+        backoff=$(($RANDOM % 120))s
+        echo Sleeping randomized $backoff before retry
+        sleep $backoff
+      done
       fi
       for r in {1..5}; do
         _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_multiple_tags.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_multiple_tags.yaml
@@ -18,33 +18,20 @@ spec:
         echo Sleeping randomized $backoff before retry
         sleep $backoff
       done
-      _OLD_EXISTS=false
-      if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes >/dev/null 2>&1; then _OLD_EXISTS=true; fi
-      if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes__pre; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-      fi
+      _HAD_OLD_0=false
+      if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes >/dev/null 2>&1; then _HAD_OLD_0=true; fi
+      _HAD_OLD_1=false
+      if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base >/dev/null 2>&1; then _HAD_OLD_1=true; fi
+      _HAD_OLD_2=false
+      if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift >/dev/null 2>&1; then _HAD_OLD_2=true; fi
+      _BACKUP_PAIRS=""
+      if [ "${_HAD_OLD_0}" = "true" ]; then _BACKUP_PAIRS="${_BACKUP_PAIRS}quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes__pre "; fi
+      if [ "${_HAD_OLD_1}" = "true" ]; then _BACKUP_PAIRS="${_BACKUP_PAIRS}quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes-base quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base__pre "; fi
+      if [ "${_HAD_OLD_2}" = "true" ]; then _BACKUP_PAIRS="${_BACKUP_PAIRS}quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes-microshift quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift__pre "; fi
+      if [ -n "${_BACKUP_PAIRS}" ]; then
       for r in {1..5}; do
         echo Mirror attempt $r
-        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes_incoming=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes; then break; fi
+        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 ${_BACKUP_PAIRS}; then break; fi
         if [ "${r}" -eq 5 ]; then
           exit 1
         fi
@@ -52,45 +39,10 @@ spec:
         echo Sleeping randomized $backoff before retry
         sleep $backoff
       done
-      if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes__post1; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-      fi
-      _OLD_EXISTS=false
-      if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base >/dev/null 2>&1; then _OLD_EXISTS=true; fi
-      if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes-base; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base__pre; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
       fi
       for r in {1..5}; do
         echo Mirror attempt $r
-        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base_incoming=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base; then break; fi
+        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes_incoming=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base_incoming=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift_incoming=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift; then break; fi
         if [ "${r}" -eq 5 ]; then
           exit 1
         fi
@@ -98,45 +50,14 @@ spec:
         echo Sleeping randomized $backoff before retry
         sleep $backoff
       done
-      if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base__post1; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-      fi
-      _OLD_EXISTS=false
-      if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift >/dev/null 2>&1; then _OLD_EXISTS=true; fi
-      if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes-microshift; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift__pre; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-      fi
+      _POST1_PAIRS=""
+      if [ "${_HAD_OLD_0}" = "true" ]; then _POST1_PAIRS="${_POST1_PAIRS}quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes__post1 "; fi
+      if [ "${_HAD_OLD_1}" = "true" ]; then _POST1_PAIRS="${_POST1_PAIRS}quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base__post1 "; fi
+      if [ "${_HAD_OLD_2}" = "true" ]; then _POST1_PAIRS="${_POST1_PAIRS}quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift__post1 "; fi
+      if [ -n "${_POST1_PAIRS}" ]; then
       for r in {1..5}; do
         echo Mirror attempt $r
-        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift_incoming=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift; then break; fi
+        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 ${_POST1_PAIRS}; then break; fi
         if [ "${r}" -eq 5 ]; then
           exit 1
         fi
@@ -144,17 +65,6 @@ spec:
         echo Sleeping randomized $backoff before retry
         sleep $backoff
       done
-      if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift__post1; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
       fi
       for r in {1..5}; do
         _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_non_release_namespace.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_non_release_namespace.yaml
@@ -18,23 +18,17 @@ spec:
         echo Sleeping randomized $backoff before retry
         sleep $backoff
       done
-      _OLD_EXISTS=false
-      if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_ci_sanitize-prow-jobs >/dev/null 2>&1; then _OLD_EXISTS=true; fi
-      if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ci_ci_sanitize-prow-jobs=quay.io/openshift/ci:ci_ci_sanitize-prow-jobs__pre; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-      fi
+      _HAD_OLD_0=false
+      if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_ci_sanitize-prow-jobs >/dev/null 2>&1; then _HAD_OLD_0=true; fi
+      _HAD_OLD_1=false
+      if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes >/dev/null 2>&1; then _HAD_OLD_1=true; fi
+      _BACKUP_PAIRS=""
+      if [ "${_HAD_OLD_0}" = "true" ]; then _BACKUP_PAIRS="${_BACKUP_PAIRS}quay.io/openshift/ci:ci_ci_sanitize-prow-jobs=quay.io/openshift/ci:ci_ci_sanitize-prow-jobs__pre "; fi
+      if [ "${_HAD_OLD_1}" = "true" ]; then _BACKUP_PAIRS="${_BACKUP_PAIRS}quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes__pre "; fi
+      if [ -n "${_BACKUP_PAIRS}" ]; then
       for r in {1..5}; do
         echo Mirror attempt $r
-        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ci_ci_sanitize-prow-jobs_incoming=quay.io/openshift/ci:ci_ci_sanitize-prow-jobs; then break; fi
+        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 ${_BACKUP_PAIRS}; then break; fi
         if [ "${r}" -eq 5 ]; then
           exit 1
         fi
@@ -42,35 +36,10 @@ spec:
         echo Sleeping randomized $backoff before retry
         sleep $backoff
       done
-      if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ci_ci_sanitize-prow-jobs=quay.io/openshift/ci:ci_ci_sanitize-prow-jobs__post1; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-      fi
-      _OLD_EXISTS=false
-      if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes >/dev/null 2>&1; then _OLD_EXISTS=true; fi
-      if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes__pre; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
       fi
       for r in {1..5}; do
         echo Mirror attempt $r
-        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes_incoming=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes; then break; fi
+        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ci_ci_sanitize-prow-jobs_incoming=quay.io/openshift/ci:ci_ci_sanitize-prow-jobs quay.io/openshift/ci:ocp_4.21_ovn-kubernetes_incoming=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes; then break; fi
         if [ "${r}" -eq 5 ]; then
           exit 1
         fi
@@ -78,17 +47,20 @@ spec:
         echo Sleeping randomized $backoff before retry
         sleep $backoff
       done
-      if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes__post1; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
+      _POST1_PAIRS=""
+      if [ "${_HAD_OLD_0}" = "true" ]; then _POST1_PAIRS="${_POST1_PAIRS}quay.io/openshift/ci:ci_ci_sanitize-prow-jobs=quay.io/openshift/ci:ci_ci_sanitize-prow-jobs__post1 "; fi
+      if [ "${_HAD_OLD_1}" = "true" ]; then _POST1_PAIRS="${_POST1_PAIRS}quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes__post1 "; fi
+      if [ -n "${_POST1_PAIRS}" ]; then
+      for r in {1..5}; do
+        echo Mirror attempt $r
+        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 ${_POST1_PAIRS}; then break; fi
+        if [ "${r}" -eq 5 ]; then
+          exit 1
+        fi
+        backoff=$(($RANDOM % 120))s
+        echo Sleeping randomized $backoff before retry
+        sleep $backoff
+      done
       fi
       for r in {1..5}; do
         _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)


### PR DESCRIPTION
- Fall back to batch `oc image mirror` for `promotion-quay` when more than 10 float tags are promoted in one pod.
- Fixes `Argument list too long` on `branch-ci-openshift-ci-tools-main-images` caused by per-tag staged promotion shell.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR changes how the promotion-quay step in ci-tools constructs and runs quay promotion work so it no longer fails with "Argument list too long" when many float tags are promoted.

What changed (practical effect)
- Component affected: the release promotion step (pkg/steps/release) that generates the promotion-quay pod and its inline /bin/sh script.
- Behavior: instead of generating one long per-float-tag shell block for every float tag, promotion now builds batched oc image mirror invocations (chunked pair lists) with retry loops. Float-tag staged promotions are produced as a single ordered, multi-phase batched shell that:
  - checks which float tags already exist,
  - conditionally backs up existing images into prune/__pre tags (aggregated),
  - latches incoming staging tags to float tags in chunked mirror phases,
  - mirrors post1 tags in chunked phases,
  - keeps oc image mirror argv length bounded by splitting pairs into fixed-size chunks.
- Implementation detail: the promotion pod container spec now sets Command to ["/bin/sh","-c"] and Args to the joined script (no extra intermediate string wrapping).

Why this matters to CI users/operators
- Fixes the "Argument list too long" failures observed in high-volume promotions (e.g., branch-ci-openshift-ci-tools-main-images) by falling back to batched mirror invocations when float tag counts are high.
- Preserves per-tag validation and ordering for typical smaller promotions while allowing large promotions to complete reliably.

Operational notes
- A chunking constant governs mirror chunk size (keeps each oc image mirror invocation size-bounded).
- Existing behavior for small numbers of float tags remains functionally equivalent, but large promotions use the batched staged flow.
- Tests: new unit tests were added to validate generation of the batched staged promotion scripts; CI verification that the problematic promotion-quay pod starts successfully is pending.

Code/test impact
- Changes are limited to the release promotion generation and associated test fixtures; no public API changes.
- Several promotion YAML test fixtures and promote.go/promote_test.go were updated to reflect the new batched shell generation.

Overall, this PR makes promotion-quay robust for high-volume float-tag promotions by switching to chunked batched oc image mirror workflows while preserving existing behavior for common cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->