### PR TITLE
Fix issue DPTP-4756 Remove env var

### DIFF
--- a/pkg/steps/multi_stage/gen.go
+++ b/pkg/steps/multi_stage/gen.go
@@ -565,10 +565,6 @@ func addSTSVolumes(pod *coreapi.Pod) {
 			ReadOnly:  true,
 		},
 	)
-	container.Env = append(container.Env,
-		coreapi.EnvVar{Name: "AWS_CONFIG_FILE", Value: path.Join(stsConfigMountPath, "config")},
-		coreapi.EnvVar{Name: "AWS_SDK_LOAD_CONFIG", Value: "1"},
-	)
 }
 
 func addCliInjector(imagestream string, pod *coreapi.Pod) {

--- a/pkg/steps/multi_stage/testdata/zz_fixture_TestGeneratePods_STS_volumes.yaml
+++ b/pkg/steps/multi_stage/testdata/zz_fixture_TestGeneratePods_STS_volumes.yaml
@@ -93,10 +93,6 @@
         value: aws
       - name: CLUSTER_PROFILE_DIR
         value: /var/run/secrets/ci.openshift.io/cluster-profile
-      - name: AWS_CONFIG_FILE
-        value: /var/run/secrets/aws/config/config
-      - name: AWS_SDK_LOAD_CONFIG
-        value: "1"
       - name: SHARED_DIR
         value: /var/run/secrets/ci.openshift.io/multi-stage
       - name: LEASE_PROXY_CLIENT_SH


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Remove AWS SDK environment variables from STS volume setup

This PR removes the `AWS_CONFIG_FILE` and `AWS_SDK_LOAD_CONFIG` environment variables that were previously automatically injected when setting up Service Account Token (STS) volumes in multi-stage CI test execution.

### Impact on CI Infrastructure

**Component affected:** Multi-stage pod generation (ci-operator)

When the `addSTSVolumes` function configures STS support for multi-stage tests, it no longer sets these AWS SDK configuration environment variables in the test container. The projected service account token volume and AWS config ConfigMap volumes continue to be properly mounted; only the explicit environment variable injection has been removed.

This change simplifies the environment setup for tests using AWS STS authentication. Tests that depend on these environment variables being automatically set by the test infrastructure will need to configure them explicitly in their own setup code if required.

### Files Modified
- `pkg/steps/multi_stage/gen.go` - Removed environment variable setup from the `addSTSVolumes` function
- `pkg/steps/multi_stage/testdata/zz_fixture_TestGeneratePods_STS_volumes.yaml` - Test fixture updated to match the new expected pod specification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->