### PR TITLE
Using a shell function to mirror instead of repeating the code

### DIFF
--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -283,9 +283,13 @@ func getMirrorCommand(registryConfig string, images []string, loglevel int) stri
 		loglevel, registryConfig, strings.Join(images, " "))
 }
 
-func getTagCommand(tagSpecs []string, loglevel int) string {
-	return fmt.Sprintf("oc tag --source=docker --loglevel=%d --reference-policy='source' --import-mode='PreserveOriginal' --reference %s",
-		loglevel, strings.Join(tagSpecs, " "))
+func getTagLoopCommand(tagSpecs []string, loglevel int) string {
+	return fmt.Sprintf(`
+while read tag; do
+oc tag --source=docker --loglevel=%d --reference-policy='source' --import-mode='PreserveOriginal' --reference $tag || break
+done <<EOF
+%s
+EOF`, loglevel, strings.Join(tagSpecs, "\n"))
 }
 
 // quayProxyTagFromISKey derives the quay-proxy floating tag from an IS tag key.
@@ -335,22 +339,29 @@ func promotionCLIImageInfoFilterOS(nodeArchitectures []string) string {
 const (
 	quayPromotionDigestTagAttempts = 5
 	quayPromotionMirrorAttempts    = 5
+	quayPromotionLogLevel          = 2
 )
+
+const mirrorShellFunction = `function mirror {
+for r in $(seq 1 $1); do
+  echo Mirror attempt $r
+  if oc image mirror --loglevel=$2 --keep-manifest-list --registry-config=$3 --max-per-registry=10 $4; then break; fi
+  if [ "${r}" -eq $1 ]; then
+    exit 1
+  fi
+  backoff=$(($RANDOM % 120))s
+  echo Sleeping randomized $backoff before retry
+  sleep $backoff
+done
+}`
 
 // getMirrorRetryShell mirrors images with retries and fails the promotion pod if all attempts fail.
 func getMirrorRetryShell(registryConfig string, images []string) string {
-	mirrorCmd := getMirrorCommand(registryConfig, images, 2)
-	n := quayPromotionMirrorAttempts
-	return fmt.Sprintf(`for r in {1..%d}; do
-  echo Mirror attempt $r
-  if %s; then break; fi
-  if [ "${r}" -eq %d ]; then
-    exit 1
-  fi
-  backoff=$(($RANDOM %% 120))s
-  echo Sleeping randomized $backoff before retry
-  sleep $backoff
-done`, n, mirrorCmd, n)
+	var mirrorCmds []string
+	for _, image := range images {
+		mirrorCmds = append(mirrorCmds, fmt.Sprintf("mirror %d %d %s %s", quayPromotionMirrorAttempts, quayPromotionLogLevel, registryConfig, image))
+	}
+	return strings.Join(mirrorCmds, "\n")
 }
 
 // getResolveAndTagRetryShell resolves digest from quay.io (push-secret) and tags the IST with quay-proxy@digest.
@@ -379,7 +390,12 @@ done
 }
 
 const (
-	retryLoopTemplate    = "for r in {1..%d}; do echo %s; %s && break; %s; done"
+	retryLoopTemplate = `for r in {1..%d}; do 
+echo %s
+%s
+[[ $? -ne 0 ]] && break
+%s
+done`
 	retryLoopWithBackoff = "backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before retry; sleep $backoff"
 
 	quayImageIncomingSuffix = "_incoming"
@@ -507,7 +523,6 @@ func getPromotionPod(imageMirrorTarget map[string]string, timeStr string, namesp
 
 	registryConfig := filepath.Join(api.RegistryPushCredentialsCICentralSecretMountPath, coreapi.DockerConfigJsonKey)
 	command := []string{"/bin/sh", "-c"}
-
 	var commands []string
 
 	// Generate mirror commands if there are images to mirror
@@ -524,24 +539,15 @@ func getPromotionPod(imageMirrorTarget map[string]string, timeStr string, namesp
 
 	// Non-official IS tags (ci/ci-quay, ${component} templates) keep best-effort batch tagging.
 	if isQuayStep && len(tags) > 0 {
-		tagCommands := []string{"set +e"}
-
-		singleCmd := fmt.Sprintf(retryLoopTemplate, 2, `"Tag attempt $r (all together)"`, getTagCommand(tags, 2), ":")
-		tagCommands = append(tagCommands, singleCmd)
-		for _, tagPair := range tags {
-			individualCmd := fmt.Sprintf(retryLoopTemplate, 3, `"Tag attempt $r (individual)"`, getTagCommand([]string{tagPair}, 2), retryLoopWithBackoff)
-			tagCommands = append(tagCommands, individualCmd)
-		}
-
-		tagCommands = append(tagCommands, "set -e")
-		commands = append(commands, strings.Join(tagCommands, "\n"))
+		tagCmd := fmt.Sprintf(retryLoopTemplate, 2, `"Tag attempt $r"`, getTagLoopCommand(tags, 2), ":")
+		commands = append(commands, tagCmd)
 	} else if len(tags) > 0 {
 		// For regular promotion, use the original retry logic
-		tagCommand := fmt.Sprintf(retryLoopTemplate, 5, "Tag attempt $r", getTagCommand(tags, 2), retryLoopWithBackoff)
+		tagCommand := fmt.Sprintf(retryLoopTemplate, 5, "Tag attempt $r", getTagLoopCommand(tags, 2), retryLoopWithBackoff)
 		commands = append(commands, tagCommand)
 	}
 
-	var args []string
+	args := []string{mirrorShellFunction}
 	if isQuayStep && len(incomingImages) > 0 {
 		args = append(args, getMirrorRetryShell(registryConfig, incomingImages))
 	}

--- a/pkg/steps/release/promote_test.go
+++ b/pkg/steps/release/promote_test.go
@@ -1113,16 +1113,9 @@ func TestGetPublicImageReference(t *testing.T) {
 func TestGetMirrorRetryShell(t *testing.T) {
 	regcfg := "/etc/push-secret/.dockerconfigjson"
 	got := getMirrorRetryShell(regcfg, []string{"src=dst"})
-	for _, sub := range []string{
-		"for r in {1..5}",
-		"Mirror attempt $r",
-		"oc image mirror",
-		`[ "${r}" -eq 5 ]`,
-		"exit 1",
-	} {
-		if !strings.Contains(got, sub) {
-			t.Fatalf("missing substring %q in:\n%s", sub, got)
-		}
+	shouldBe := "mirror 5 2 /etc/push-secret/.dockerconfigjson src=dst"
+	if !strings.Contains(got, shouldBe) {
+		t.Fatalf("wrong shell mirror function call %q should be %q", got, shouldBe)
 	}
 }
 

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case.yaml
@@ -8,16 +8,20 @@ spec:
   containers:
   - args:
     - |-
-      for r in {1..5}; do
+      function mirror {
+      for r in $(seq 1 $1); do
         echo Mirror attempt $r
-        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:afd71aa3cbbf7d2e00cd8696747b2abf164700147723c657919c20b13d13ec62=registry.ci.openshift.org/ci/applyconfig:latest docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb=registry.ci.openshift.org/ci/bin:latest; then break; fi
-        if [ "${r}" -eq 5 ]; then
+        if oc image mirror --loglevel=$2 --keep-manifest-list --registry-config=$3 --max-per-registry=10 $4; then break; fi
+        if [ "${r}" -eq $1 ]; then
           exit 1
         fi
         backoff=$(($RANDOM % 120))s
         echo Sleeping randomized $backoff before retry
         sleep $backoff
       done
+      }
+      mirror 5 2 /etc/push-secret/.dockerconfigjson docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:afd71aa3cbbf7d2e00cd8696747b2abf164700147723c657919c20b13d13ec62=registry.ci.openshift.org/ci/applyconfig:latest
+      mirror 5 2 /etc/push-secret/.dockerconfigjson docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb=registry.ci.openshift.org/ci/bin:latest
     command:
     - /bin/sh
     - -c

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case__arm64_only.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case__arm64_only.yaml
@@ -8,16 +8,20 @@ spec:
   containers:
   - args:
     - |-
-      for r in {1..5}; do
+      function mirror {
+      for r in $(seq 1 $1); do
         echo Mirror attempt $r
-        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:afd71aa3cbbf7d2e00cd8696747b2abf164700147723c657919c20b13d13ec62=registry.ci.openshift.org/ci/applyconfig:latest docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb=registry.ci.openshift.org/ci/bin:latest; then break; fi
-        if [ "${r}" -eq 5 ]; then
+        if oc image mirror --loglevel=$2 --keep-manifest-list --registry-config=$3 --max-per-registry=10 $4; then break; fi
+        if [ "${r}" -eq $1 ]; then
           exit 1
         fi
         backoff=$(($RANDOM % 120))s
         echo Sleeping randomized $backoff before retry
         sleep $backoff
       done
+      }
+      mirror 5 2 /etc/push-secret/.dockerconfigjson docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:afd71aa3cbbf7d2e00cd8696747b2abf164700147723c657919c20b13d13ec62=registry.ci.openshift.org/ci/applyconfig:latest
+      mirror 5 2 /etc/push-secret/.dockerconfigjson docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb=registry.ci.openshift.org/ci/bin:latest
     command:
     - /bin/sh
     - -c

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case__multi_architecture.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case__multi_architecture.yaml
@@ -8,16 +8,20 @@ spec:
   containers:
   - args:
     - |-
-      for r in {1..5}; do
+      function mirror {
+      for r in $(seq 1 $1); do
         echo Mirror attempt $r
-        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:afd71aa3cbbf7d2e00cd8696747b2abf164700147723c657919c20b13d13ec62=registry.ci.openshift.org/ci/applyconfig:latest docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb=registry.ci.openshift.org/ci/bin:latest; then break; fi
-        if [ "${r}" -eq 5 ]; then
+        if oc image mirror --loglevel=$2 --keep-manifest-list --registry-config=$3 --max-per-registry=10 $4; then break; fi
+        if [ "${r}" -eq $1 ]; then
           exit 1
         fi
         backoff=$(($RANDOM % 120))s
         echo Sleeping randomized $backoff before retry
         sleep $backoff
       done
+      }
+      mirror 5 2 /etc/push-secret/.dockerconfigjson docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:afd71aa3cbbf7d2e00cd8696747b2abf164700147723c657919c20b13d13ec62=registry.ci.openshift.org/ci/applyconfig:latest
+      mirror 5 2 /etc/push-secret/.dockerconfigjson docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb=registry.ci.openshift.org/ci/bin:latest
     command:
     - /bin/sh
     - -c

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay.yaml
@@ -7,114 +7,31 @@ metadata:
 spec:
   containers:
   - args:
-    - |-
-      for r in {1..5}; do
-        echo Mirror attempt $r
-        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb=quay.io/openshift/ci:ci_a_latest_incoming registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:ddd=quay.io/openshift/ci:ci_c_latest_incoming; then break; fi
-        if [ "${r}" -eq 5 ]; then
-          exit 1
-        fi
-        backoff=$(($RANDOM % 120))s
-        echo Sleeping randomized $backoff before retry
-        sleep $backoff
-      done
-      _OLD_EXISTS=false
-      if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_a_latest >/dev/null 2>&1; then _OLD_EXISTS=true; fi
-      if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ci_a_latest=quay.io/openshift/ci:20240603235401_prune_ci_a_latest; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ci_a_latest=quay.io/openshift/ci:ci_a_latest__pre; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-      fi
-      for r in {1..5}; do
-        echo Mirror attempt $r
-        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ci_a_latest_incoming=quay.io/openshift/ci:ci_a_latest; then break; fi
-        if [ "${r}" -eq 5 ]; then
-          exit 1
-        fi
-        backoff=$(($RANDOM % 120))s
-        echo Sleeping randomized $backoff before retry
-        sleep $backoff
-      done
-      if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ci_a_latest=quay.io/openshift/ci:ci_a_latest__post1; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-      fi
-      _OLD_EXISTS=false
-      if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_c_latest >/dev/null 2>&1; then _OLD_EXISTS=true; fi
-      if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ci_c_latest=quay.io/openshift/ci:20240603235401_prune_ci_c_latest; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ci_c_latest=quay.io/openshift/ci:ci_c_latest__pre; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-      fi
-      for r in {1..5}; do
-        echo Mirror attempt $r
-        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ci_c_latest_incoming=quay.io/openshift/ci:ci_c_latest; then break; fi
-        if [ "${r}" -eq 5 ]; then
-          exit 1
-        fi
-        backoff=$(($RANDOM % 120))s
-        echo Sleeping randomized $backoff before retry
-        sleep $backoff
-      done
-      if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ci_c_latest=quay.io/openshift/ci:ci_c_latest__post1; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-      fi
-      set +e
-      for r in {1..2}; do echo "Tag attempt $r (all together)"; oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@sha256:ddd ci/${component}-quay:c quay-proxy.ci.openshift.org/openshift/ci@sha256:bbb ci/ci-quay:${component} && break; :; done
-      for r in {1..3}; do echo "Tag attempt $r (individual)"; oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@sha256:ddd ci/${component}-quay:c && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before retry; sleep $backoff; done
-      for r in {1..3}; do echo "Tag attempt $r (individual)"; oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@sha256:bbb ci/ci-quay:${component} && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before retry; sleep $backoff; done
-      set -e
+    - "function mirror {\nfor r in $(seq 1 $1); do\n  echo Mirror attempt $r\n  if
+      oc image mirror --loglevel=$2 --keep-manifest-list --registry-config=$3 --max-per-registry=10
+      $4; then break; fi\n  if [ \"${r}\" -eq $1 ]; then\n    exit 1\n  fi\n  backoff=$(($RANDOM
+      % 120))s\n  echo Sleeping randomized $backoff before retry\n  sleep $backoff\ndone\n}\nmirror
+      5 2 /etc/push-secret/.dockerconfigjson registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb=quay.io/openshift/ci:ci_a_latest_incoming\nmirror
+      5 2 /etc/push-secret/.dockerconfigjson registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:ddd=quay.io/openshift/ci:ci_c_latest_incoming\n_OLD_EXISTS=false\nif
+      oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_a_latest
+      >/dev/null 2>&1; then _OLD_EXISTS=true; fi\nif [ \"${_OLD_EXISTS}\" = \"true\"
+      ]; then\n  mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_a_latest=quay.io/openshift/ci:20240603235401_prune_ci_a_latest\n
+      \ mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_a_latest=quay.io/openshift/ci:ci_a_latest__pre\nfi\nmirror
+      5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_a_latest_incoming=quay.io/openshift/ci:ci_a_latest\nif
+      [ \"${_OLD_EXISTS}\" = \"true\" ]; then\n  mirror 5 2 /etc/push-secret/.dockerconfigjson
+      quay.io/openshift/ci:ci_a_latest=quay.io/openshift/ci:ci_a_latest__post1\nfi\n_OLD_EXISTS=false\nif
+      oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_c_latest
+      >/dev/null 2>&1; then _OLD_EXISTS=true; fi\nif [ \"${_OLD_EXISTS}\" = \"true\"
+      ]; then\n  mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_c_latest=quay.io/openshift/ci:20240603235401_prune_ci_c_latest\n
+      \ mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_c_latest=quay.io/openshift/ci:ci_c_latest__pre\nfi\nmirror
+      5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_c_latest_incoming=quay.io/openshift/ci:ci_c_latest\nif
+      [ \"${_OLD_EXISTS}\" = \"true\" ]; then\n  mirror 5 2 /etc/push-secret/.dockerconfigjson
+      quay.io/openshift/ci:ci_c_latest=quay.io/openshift/ci:ci_c_latest__post1\nfi\nfor
+      r in {1..2}; do \necho \"Tag attempt $r\"\n\nwhile read tag; do\noc tag --source=docker
+      --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference
+      $tag || break\ndone <<EOF\nquay-proxy.ci.openshift.org/openshift/ci@sha256:ddd
+      ci/${component}-quay:c\nquay-proxy.ci.openshift.org/openshift/ci@sha256:bbb
+      ci/ci-quay:${component}\nEOF\n[[ $? -ne 0 ]] && break\n:\ndone"
     command:
     - /bin/sh
     - -c

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_4.12.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_4.12.yaml
@@ -8,107 +8,39 @@ spec:
   containers:
   - args:
     - |
-      for r in {1..5}; do
+      function mirror {
+      for r in $(seq 1 $1); do
         echo Mirror attempt $r
-        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:aaa=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes_incoming registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base_incoming; then break; fi
-        if [ "${r}" -eq 5 ]; then
+        if oc image mirror --loglevel=$2 --keep-manifest-list --registry-config=$3 --max-per-registry=10 $4; then break; fi
+        if [ "${r}" -eq $1 ]; then
           exit 1
         fi
         backoff=$(($RANDOM % 120))s
         echo Sleeping randomized $backoff before retry
         sleep $backoff
       done
+      }
+      mirror 5 2 /etc/push-secret/.dockerconfigjson registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:aaa=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes_incoming
+      mirror 5 2 /etc/push-secret/.dockerconfigjson registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base_incoming
       _OLD_EXISTS=false
       if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.12_ovn-kubernetes >/dev/null 2>&1; then _OLD_EXISTS=true; fi
       if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes__pre; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
+        mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.12_ovn-kubernetes=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes
+        mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.12_ovn-kubernetes=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes__pre
       fi
-      for r in {1..5}; do
-        echo Mirror attempt $r
-        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes_incoming=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes; then break; fi
-        if [ "${r}" -eq 5 ]; then
-          exit 1
-        fi
-        backoff=$(($RANDOM % 120))s
-        echo Sleeping randomized $backoff before retry
-        sleep $backoff
-      done
+      mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.12_ovn-kubernetes_incoming=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes
       if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes__post1; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
+        mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.12_ovn-kubernetes=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes__post1
       fi
       _OLD_EXISTS=false
       if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base >/dev/null 2>&1; then _OLD_EXISTS=true; fi
       if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes-base; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base__pre; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
+        mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes-base
+        mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base__pre
       fi
-      for r in {1..5}; do
-        echo Mirror attempt $r
-        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base_incoming=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base; then break; fi
-        if [ "${r}" -eq 5 ]; then
-          exit 1
-        fi
-        backoff=$(($RANDOM % 120))s
-        echo Sleeping randomized $backoff before retry
-        sleep $backoff
-      done
+      mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base_incoming=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base
       if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base__post1; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
+        mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base__post1
       fi
       for r in {1..5}; do
         _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_multiple_tags.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_multiple_tags.yaml
@@ -8,153 +8,50 @@ spec:
   containers:
   - args:
     - |
-      for r in {1..5}; do
+      function mirror {
+      for r in $(seq 1 $1); do
         echo Mirror attempt $r
-        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:aaa=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes_incoming registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base_incoming registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:ccc=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift_incoming; then break; fi
-        if [ "${r}" -eq 5 ]; then
+        if oc image mirror --loglevel=$2 --keep-manifest-list --registry-config=$3 --max-per-registry=10 $4; then break; fi
+        if [ "${r}" -eq $1 ]; then
           exit 1
         fi
         backoff=$(($RANDOM % 120))s
         echo Sleeping randomized $backoff before retry
         sleep $backoff
       done
+      }
+      mirror 5 2 /etc/push-secret/.dockerconfigjson registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:aaa=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes_incoming
+      mirror 5 2 /etc/push-secret/.dockerconfigjson registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base_incoming
+      mirror 5 2 /etc/push-secret/.dockerconfigjson registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:ccc=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift_incoming
       _OLD_EXISTS=false
       if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes >/dev/null 2>&1; then _OLD_EXISTS=true; fi
       if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes__pre; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
+        mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes
+        mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes__pre
       fi
-      for r in {1..5}; do
-        echo Mirror attempt $r
-        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes_incoming=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes; then break; fi
-        if [ "${r}" -eq 5 ]; then
-          exit 1
-        fi
-        backoff=$(($RANDOM % 120))s
-        echo Sleeping randomized $backoff before retry
-        sleep $backoff
-      done
+      mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes_incoming=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes
       if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes__post1; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
+        mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes__post1
       fi
       _OLD_EXISTS=false
       if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base >/dev/null 2>&1; then _OLD_EXISTS=true; fi
       if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes-base; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base__pre; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
+        mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes-base
+        mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base__pre
       fi
-      for r in {1..5}; do
-        echo Mirror attempt $r
-        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base_incoming=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base; then break; fi
-        if [ "${r}" -eq 5 ]; then
-          exit 1
-        fi
-        backoff=$(($RANDOM % 120))s
-        echo Sleeping randomized $backoff before retry
-        sleep $backoff
-      done
+      mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base_incoming=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base
       if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base__post1; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
+        mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base__post1
       fi
       _OLD_EXISTS=false
       if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift >/dev/null 2>&1; then _OLD_EXISTS=true; fi
       if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes-microshift; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift__pre; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
+        mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes-microshift
+        mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift__pre
       fi
-      for r in {1..5}; do
-        echo Mirror attempt $r
-        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift_incoming=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift; then break; fi
-        if [ "${r}" -eq 5 ]; then
-          exit 1
-        fi
-        backoff=$(($RANDOM % 120))s
-        echo Sleeping randomized $backoff before retry
-        sleep $backoff
-      done
+      mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift_incoming=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift
       if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift__post1; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
+        mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift__post1
       fi
       for r in {1..5}; do
         _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_non_release_namespace.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_non_release_namespace.yaml
@@ -7,107 +7,38 @@ metadata:
 spec:
   containers:
   - args:
-    - |-
-      for r in {1..5}; do
-        echo Mirror attempt $r
-        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb=quay.io/openshift/ci:ci_ci_sanitize-prow-jobs_incoming registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:aaa=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes_incoming; then break; fi
-        if [ "${r}" -eq 5 ]; then
-          exit 1
-        fi
-        backoff=$(($RANDOM % 120))s
-        echo Sleeping randomized $backoff before retry
-        sleep $backoff
-      done
-      _OLD_EXISTS=false
-      if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_ci_sanitize-prow-jobs >/dev/null 2>&1; then _OLD_EXISTS=true; fi
-      if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ci_ci_sanitize-prow-jobs=quay.io/openshift/ci:ci_ci_sanitize-prow-jobs__pre; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-      fi
-      for r in {1..5}; do
-        echo Mirror attempt $r
-        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ci_ci_sanitize-prow-jobs_incoming=quay.io/openshift/ci:ci_ci_sanitize-prow-jobs; then break; fi
-        if [ "${r}" -eq 5 ]; then
-          exit 1
-        fi
-        backoff=$(($RANDOM % 120))s
-        echo Sleeping randomized $backoff before retry
-        sleep $backoff
-      done
-      if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ci_ci_sanitize-prow-jobs=quay.io/openshift/ci:ci_ci_sanitize-prow-jobs__post1; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-      fi
-      _OLD_EXISTS=false
-      if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes >/dev/null 2>&1; then _OLD_EXISTS=true; fi
-      if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes__pre; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-      fi
-      for r in {1..5}; do
-        echo Mirror attempt $r
-        if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes_incoming=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes; then break; fi
-        if [ "${r}" -eq 5 ]; then
-          exit 1
-        fi
-        backoff=$(($RANDOM % 120))s
-        echo Sleeping randomized $backoff before retry
-        sleep $backoff
-      done
-      if [ "${_OLD_EXISTS}" = "true" ]; then
-        for r in {1..5}; do
-          echo Mirror attempt $r
-          if oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes__post1; then break; fi
-          if [ "${r}" -eq 5 ]; then
-            exit 1
-          fi
-          backoff=$(($RANDOM % 120))s
-          echo Sleeping randomized $backoff before retry
-          sleep $backoff
-        done
-      fi
-      for r in {1..5}; do
-        _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
-        if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.21:ovn-kubernetes; then
-          break
-        fi
-        echo "promotion-quay: digest-tag failed for ocp/4.21:ovn-kubernetes attempt ${r}/5 (QCI digest may have moved after mirror)" >&2
-        if [ "${r}" -eq 5 ]; then
-          exit 1
-        fi
-        echo "promotion-quay: retrying digest-tag for ocp/4.21:ovn-kubernetes (attempt $((r+1))/5 after randomized backoff)" >&2
-        backoff=$(($RANDOM % 120))s
-        sleep "${backoff}"
-      done
-
-      set +e
-      for r in {1..2}; do echo "Tag attempt $r (all together)"; oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@sha256:bbb ci/ci-quay:sanitize-prow-jobs && break; :; done
-      for r in {1..3}; do echo "Tag attempt $r (individual)"; oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@sha256:bbb ci/ci-quay:sanitize-prow-jobs && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before retry; sleep $backoff; done
-      set -e
+    - "function mirror {\nfor r in $(seq 1 $1); do\n  echo Mirror attempt $r\n  if
+      oc image mirror --loglevel=$2 --keep-manifest-list --registry-config=$3 --max-per-registry=10
+      $4; then break; fi\n  if [ \"${r}\" -eq $1 ]; then\n    exit 1\n  fi\n  backoff=$(($RANDOM
+      % 120))s\n  echo Sleeping randomized $backoff before retry\n  sleep $backoff\ndone\n}\nmirror
+      5 2 /etc/push-secret/.dockerconfigjson registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb=quay.io/openshift/ci:ci_ci_sanitize-prow-jobs_incoming\nmirror
+      5 2 /etc/push-secret/.dockerconfigjson registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:aaa=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes_incoming\n_OLD_EXISTS=false\nif
+      oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_ci_sanitize-prow-jobs
+      >/dev/null 2>&1; then _OLD_EXISTS=true; fi\nif [ \"${_OLD_EXISTS}\" = \"true\"
+      ]; then\n  mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_ci_sanitize-prow-jobs=quay.io/openshift/ci:ci_ci_sanitize-prow-jobs__pre\nfi\nmirror
+      5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_ci_sanitize-prow-jobs_incoming=quay.io/openshift/ci:ci_ci_sanitize-prow-jobs\nif
+      [ \"${_OLD_EXISTS}\" = \"true\" ]; then\n  mirror 5 2 /etc/push-secret/.dockerconfigjson
+      quay.io/openshift/ci:ci_ci_sanitize-prow-jobs=quay.io/openshift/ci:ci_ci_sanitize-prow-jobs__post1\nfi\n_OLD_EXISTS=false\nif
+      oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes
+      >/dev/null 2>&1; then _OLD_EXISTS=true; fi\nif [ \"${_OLD_EXISTS}\" = \"true\"
+      ]; then\n  mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes__pre\nfi\nmirror
+      5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes_incoming=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes\nif
+      [ \"${_OLD_EXISTS}\" = \"true\" ]; then\n  mirror 5 2 /etc/push-secret/.dockerconfigjson
+      quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes__post1\nfi\nfor
+      r in {1..5}; do\n  _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson
+      --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes | sed
+      -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)\n  if [ -n \"${_digest}\"
+      ] && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal'
+      --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.21:ovn-kubernetes;
+      then\n    break\n  fi\n  echo \"promotion-quay: digest-tag failed for ocp/4.21:ovn-kubernetes
+      attempt ${r}/5 (QCI digest may have moved after mirror)\" >&2\n  if [ \"${r}\"
+      -eq 5 ]; then\n    exit 1\n  fi\n  echo \"promotion-quay: retrying digest-tag
+      for ocp/4.21:ovn-kubernetes (attempt $((r+1))/5 after randomized backoff)\"
+      >&2\n  backoff=$(($RANDOM % 120))s\n  sleep \"${backoff}\"\ndone\n\nfor r in
+      {1..2}; do \necho \"Tag attempt $r\"\n\nwhile read tag; do\noc tag --source=docker
+      --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference
+      $tag || break\ndone <<EOF\nquay-proxy.ci.openshift.org/openshift/ci@sha256:bbb
+      ci/ci-quay:sanitize-prow-jobs\nEOF\n[[ $? -ne 0 ]] && break\n:\ndone"
     command:
     - /bin/sh
     - -c


### PR DESCRIPTION
The objective of these modifications is to reduce the total size of shell arguments and environment variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Promotion Step Shell Script Refactoring

This PR refactors how `ci-operator` generates the release promotion Pod’s inline `/bin/sh -c` script (`pkg/steps/release`) to reduce duplicated shell/command text by centralizing mirroring and tag operations into reusable shell helpers.

### What changed in practical terms
- **Component affected:** `ci-operator` release promotion step (`pkg/steps/release/promote.go`).
- **Mirroring now uses a shared shell helper + per-mapping calls:**
  - The generated script injects a `mirror()` shell function (`mirrorShellFunction`) that wraps `oc image mirror` with randomized backoff and fails the Pod only after exhausting retries.
  - `getMirrorRetryShell(registryConfig, images)` now generates **smaller fragments** that invoke `mirror <attempts> <loglevel> <registry-config> <src=dst>` **once per image mapping**, rather than embedding repeated retry loops for multiple mappings.
- **Quay promotion retry behavior is now per-image/per-mapping:**
  - Quay mirroring retries were rewritten so each mirror mapping performs its own retry/backoff sequence, improving consistency of retry logging and failure behavior.
- **Non-official ImageStream tag promotion is now loop-based:**
  - Added `getTagLoopCommand(tagSpecs, loglevel)`, which emits a heredoc-fed `while read tag; do oc tag ...; done` loop.
  - For quay non-official IS tag retries, tagging is executed via `retryLoopTemplate` with a **2-attempt wrapper** around that per-tag loop.
  - For non-quay (regular promotion), tagging uses `retryLoopTemplate` with the prior **5-attempt retry-with-backoff** behavior, but with tagging driven by the same loop-based `getTagLoopCommand(...)`.
  - The generated `retryLoopTemplate` was reformatted to explicitly check `$?` and `break` on success.

### Behavioral/operational impact for CI users/operators
- **Smaller, more maintainable promotion Pod scripts** (less duplicated inline shell content), reducing risk of hitting command/arg length limits.
- **More predictable retry semantics**: mirroring retries are applied per mapping via the shared `mirror()` helper, and tag operations are executed through a deterministic heredoc loop with bounded retry behavior.

### Tests and fixtures
- Updated `pkg/steps/release/promote_test.go` (`TestGetMirrorRetryShell`) to assert the exact generated `mirror` invocation format.
- Updated promotion Pod script fixtures in `pkg/steps/release/testdata/*` to reflect the new helper-driven mirroring and heredoc-based tag loop logic for the relevant quay/non-official scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->