### PR TITLE
Register libvirt-s390x-vpn-ssp cluster profile

### DIFF
--- a/pkg/api/clusterprofile.go
+++ b/pkg/api/clusterprofile.go
@@ -123,6 +123,7 @@ const (
 	ClusterProfileLibvirtS390xAmd64          ClusterProfile = "libvirt-s390x-amd64"
 	ClusterProfileLibvirtS390xVPN            ClusterProfile = "libvirt-s390x-vpn"
 	ClusterProfileLibvirtS390xVPNOZ          ClusterProfile = "libvirt-s390x-vpn-oz"
+	ClusterProfileLibvirtS390xVPNVirt        ClusterProfile = "libvirt-s390x-vpn-virt"
 	ClusterProfileMetalPerfscaleBMCPT        ClusterProfile = "metal-perfscale-cpt"
 	ClusterProfileMetalPerfscaleJetlag       ClusterProfile = "metal-perfscale-jetlag"
 	ClusterProfileMetalPerfscaleOSP          ClusterProfile = "metal-perfscale-osp"
@@ -345,6 +346,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileLibvirtS390xAmd64,
 		ClusterProfileLibvirtS390xVPN,
 		ClusterProfileLibvirtS390xVPNOZ,
+		ClusterProfileLibvirtS390xVPNVirt,
 		ClusterProfileMetalPerfscaleBMCPT,
 		ClusterProfileMetalPerfscaleJetlag,
 		ClusterProfileMetalPerfscaleOSP,
@@ -624,6 +626,8 @@ func (p ClusterProfile) ClusterType() string {
 		return "libvirt-s390x-vpn"
 	case ClusterProfileLibvirtS390xVPNOZ:
 		return "libvirt-s390x-vpn-oz"
+	case ClusterProfileLibvirtS390xVPNVirt:
+		return "libvirt-s390x-vpn-virt"
 	case ClusterProfileMetalRHgs:
 		return "metal-redhat-gs"
 	case ClusterProfileMetalPerfscaleBMCPT:
@@ -971,6 +975,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "libvirt-s390x-vpn-quota-slice"
 	case ClusterProfileLibvirtS390xVPNOZ:
 		return "libvirt-s390x-vpn-oz-quota-slice"
+	case ClusterProfileLibvirtS390xVPNVirt:
+		return "libvirt-s390x-vpn-virt-quota-slice"
 	case ClusterProfileMetalPerfscaleBMCPT:
 		return "metal-perfscale-cpt-quota-slice"
 	case ClusterProfileMetalPerfscaleJetlag:
@@ -1190,7 +1196,7 @@ func LeaseTypeFromClusterType(t string) (string, error) {
 		"aws", "aws-us-east-1", "aws-c2s", "aws-china", "aws-usgov", "aws-sc2s", "aws-eusc", "aws-osd-msp", "aws-opendatahub",
 		"alibaba", "azure-2", "azure4", "azure-arm64", "azurestack", "azuremag", "equinix-ocp-metal",
 		"gcp", "gcp-arm64", "gcp-opendatahub", "libvirt-ppc64le", "libvirt-ppc64le-s2s", "libvirt-s390x",
-		"libvirt-s390x-1", "libvirt-s390x-2", "libvirt-s390x-amd64", "libvirt-s390x-vpn", "libvirt-s390x-vpn-oz", "ibmcloud-multi-ppc64le",
+		"libvirt-s390x-1", "libvirt-s390x-2", "libvirt-s390x-amd64", "libvirt-s390x-vpn", "libvirt-s390x-vpn-oz", "libvirt-s390x-vpn-virt", "ibmcloud-multi-ppc64le",
 		"ibmcloud-multi-s390x", "nutanix", "nutanix-qe", "nutanix-qe-dis", "nutanix-qe-zone", "nutanix-qe-gpu",
 		"nutanix-qe-flow", "openstack", "openstack-osuosl", "openstack-vexxhost", "openstack-ppc64le",
 		"openstack-nerc-dev", "vsphere", "ovirt", "packet", "packet-edge", "powervc-1", "powervs-multi-1",


### PR DESCRIPTION
Add a new cluster profile `libvirt-s390x-vpn-ssp` for running SSP e2e functional tests on s390x architecture in the orange zone VPN environment

This provides a dedicated profile for the SSP operator CI lane, using its own host and Boskos leases, will be added in a follow-up PR
Signed-off-by: Thomas-David Griedel griedel911@gmail.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request extends the OpenShift CI tools cluster profile API to add a new s390x “orange zone” VPN libvirt cluster profile for SSP e2e functional testing. It introduces the `libvirt-s390x-vpn-virt` profile so CI jobs and infrastructure resolution can consistently derive the expected cluster type and Boskos quota-slice lease name for this SSP-focused lane.

## Changes

**pkg/api/clusterprofile.go**
- Added a new exported `ClusterProfile` constant:
  - `ClusterProfileLibvirtS390xVPNVirt ClusterProfile = "libvirt-s390x-vpn-virt"`
- Registered the new profile in `ClusterProfiles()` so it’s accepted as a valid input.
- Updated the conversion helpers to support this profile end-to-end:
  - `ClusterType()` now maps `ClusterProfileLibvirtS390xVPNVirt` → `"libvirt-s390x-vpn-virt"`.
  - `LeaseType()` now maps `ClusterProfileLibvirtS390xVPNVirt` → `"libvirt-s390x-vpn-virt-quota-slice"`.
  - `LeaseTypeFromClusterType()` now accepts `"libvirt-s390x-vpn-virt"` and converts it to the corresponding `-quota-slice` lease type.

## Impact

CI configuration can reference `libvirt-s390x-vpn-virt` to ensure SSP e2e jobs resolve the correct cluster type and Boskos lease/quota-slice naming for the orange zone VPN environment (with host and Boskos lease resource details planned in a follow-up).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->