### PR TITLE
ci-operator-configresolver: Add upstream config resolver

### DIFF
--- a/cmd/ci-operator-configresolver/main.go
+++ b/cmd/ci-operator-configresolver/main.go
@@ -40,18 +40,19 @@ import (
 )
 
 type options struct {
-	configPath             string
-	registryPath           string
-	logLevel               string
-	address                string
-	releaseRepoGitSyncPath string
-	port                   int
-	uiAddress              string
-	uiPort                 int
-	gracePeriod            time.Duration
-	validateOnly           bool
-	flatRegistry           bool
-	instrumentationOptions flagutil.InstrumentationOptions
+	configPath              string
+	registryPath            string
+	logLevel                string
+	address                 string
+	releaseRepoGitSyncPath  string
+	port                    int
+	uiAddress               string
+	uiPort                  int
+	gracePeriod             time.Duration
+	validateOnly            bool
+	flatRegistry            bool
+	instrumentationOptions  flagutil.InstrumentationOptions
+	upstreamResolverAddress string
 }
 
 var (
@@ -73,6 +74,7 @@ func gatherOptions() (options, error) {
 	_ = fs.Duration("cycle", time.Minute*2, "Legacy flag kept for compatibility. Does nothing")
 	fs.BoolVar(&o.validateOnly, "validate-only", false, "Load the config and registry, validate them and exit.")
 	fs.BoolVar(&o.flatRegistry, "flat-registry", false, "Disable directory structure based registry validation")
+	fs.StringVar(&o.upstreamResolverAddress, "upstream-resolver-address", "", "Address of an upstream resolver")
 	o.instrumentationOptions.AddFlags(fs)
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		return o, fmt.Errorf("failed to parse flags: %w", err)
@@ -144,32 +146,48 @@ func getRegistryGeneration(agent agents.RegistryAgent) http.HandlerFunc {
 	}
 }
 
-type memoryCache struct {
-	Client                 ctrlruntimeclient.Client
-	IntegratedStreamsMutex sync.Mutex
-	IntegratedStreams      map[string]integratedStreamRecord
-	CacheDuration          time.Duration
+type streamCache struct {
+	integratedStreams         *sync.Map
+	cacheDuration             time.Duration
+	integrationStreamResolver func(ctx context.Context, namespace, name string) (*configresolver.IntegratedStream, error)
 }
 
-func (c *memoryCache) Get(ctx context.Context, ns, name string) (*configresolver.IntegratedStream, error) {
+func (c *streamCache) Get(ctx context.Context, ns, name string) (*configresolver.IntegratedStream, error) {
 	key := fmt.Sprintf("%s/%s", ns, name)
-	if c.IntegratedStreams == nil {
-		c.IntegratedStreams = map[string]integratedStreamRecord{}
-	}
-	if r, ok := c.IntegratedStreams[key]; ok {
-		if time.Now().Before(r.LastUpdatedAt.Add(c.CacheDuration)) {
+
+	if anyR, ok := c.integratedStreams.Load(key); ok {
+		r := anyR.(integratedStreamRecord)
+		if time.Now().Before(r.LastUpdatedAt.Add(c.cacheDuration)) {
 			logrus.WithField("namespace", ns).WithField("name", name).Debug("Getting info for integrated stream from cache")
 			return r.Stream, nil
 		}
 	}
-	c.IntegratedStreamsMutex.Lock()
-	defer c.IntegratedStreamsMutex.Unlock()
-	s, err := configresolver.LocalIntegratedStream(ctx, c.Client, ns, name)
+
+	s, err := c.integrationStreamResolver(ctx, ns, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get information on image stream %s/%s: %w", ns, name, err)
 	}
-	c.IntegratedStreams[key] = integratedStreamRecord{Stream: s, LastUpdatedAt: time.Now()}
+
+	c.integratedStreams.Store(key, integratedStreamRecord{Stream: s, LastUpdatedAt: time.Now()})
 	return s, nil
+}
+
+func integrationStreamCache(kubeClient ctrlruntimeclient.Client, ResolverClient registryserver.ResolverClient, cacheDuration time.Duration) *streamCache {
+	streamResolver := func(ctx context.Context, namespace, name string) (*configresolver.IntegratedStream, error) {
+		return configresolver.LocalIntegratedStream(ctx, kubeClient, namespace, name)
+	}
+
+	if ResolverClient != nil {
+		streamResolver = func(_ context.Context, namespace, name string) (*configresolver.IntegratedStream, error) {
+			return ResolverClient.IntegratedStream(namespace, name)
+		}
+	}
+
+	return &streamCache{
+		integratedStreams:         &sync.Map{},
+		cacheDuration:             cacheDuration,
+		integrationStreamResolver: streamResolver,
+	}
 }
 
 type integratedStreamRecord struct {
@@ -302,7 +320,7 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to load in-cluster config")
 	}
-	ocClient, err := ctrlruntimeclient.New(inClusterConfig, ctrlruntimeclient.Options{})
+	kubeClient, err := ctrlruntimeclient.New(inClusterConfig, ctrlruntimeclient.Options{})
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to create oc client")
 	}
@@ -333,6 +351,13 @@ func main() {
 		l("chain"),
 		l("workflow"),
 	))
+
+	var upstreamResolver registryserver.ResolverClient
+	if o.upstreamResolverAddress != "" {
+		upstreamResolver = registryserver.NewResolverClient(o.upstreamResolverAddress)
+	}
+	integrationStreamCache := integrationStreamCache(kubeClient, upstreamResolver, time.Minute)
+
 	handler := metrics.TraceHandler(simplifier, configresolverMetrics.HTTPRequestDuration, configresolverMetrics.HTTPResponseSize)
 	uihandler := metrics.TraceHandler(uisimplifier, configresolverMetrics.HTTPRequestDuration, configresolverMetrics.HTTPResponseSize)
 	// add handler func for incorrect paths as well; can help with identifying errors/404s caused by incorrect paths
@@ -343,8 +368,7 @@ func main() {
 	http.HandleFunc("/clusterProfile", handler(registryserver.ResolveClusterProfile(registryAgent, configresolverMetrics)).ServeHTTP)
 	http.HandleFunc("/configGeneration", handler(getConfigGeneration(configAgent)).ServeHTTP)
 	http.HandleFunc("/registryGeneration", handler(getRegistryGeneration(registryAgent)).ServeHTTP)
-	cache := memoryCache{Client: ocClient, CacheDuration: time.Minute}
-	http.HandleFunc("/integratedStream", handler(getIntegratedStream(context.Background(), &cache)).ServeHTTP)
+	http.HandleFunc("/integratedStream", handler(getIntegratedStream(context.Background(), integrationStreamCache)).ServeHTTP)
 	http.HandleFunc("/readyz", func(_ http.ResponseWriter, _ *http.Request) {})
 	interrupts.ListenAndServe(&http.Server{Addr: ":" + strconv.Itoa(o.port)}, o.gracePeriod)
 	uiMux := http.NewServeMux()

--- a/cmd/ci-operator-configresolver/main_test.go
+++ b/cmd/ci-operator-configresolver/main_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -18,6 +19,7 @@ import (
 	imagev1 "github.com/openshift/api/image/v1"
 
 	"github.com/openshift/ci-tools/pkg/api/configresolver"
+	registryserver "github.com/openshift/ci-tools/pkg/registry/server"
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
@@ -123,38 +125,46 @@ func TestValidateStream(t *testing.T) {
 	}
 }
 
-var streams = []ctrlruntimeclient.Object{
-	&imagev1.ImageStream{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "4.15",
-			Namespace: "ocp",
-			Annotations: map[string]string{
-				"release.openshift.io/config": `{"name":"4.15.0-0.ci","to":"release","message":"This release contains CI image builds of all code in release-4.15 (master) branches, and is updated each time someone merges.","mirrorPrefix":"4.15","expires":"72h","maxUnreadyReleases":1,"minCreationIntervalSeconds":21600,"pullSecretName":"source","check":{},"publish":{"tag":{"tagRef":{"name":"4.15-ci"}}},"verify":{"aws-sdn-serial":{"maxRetries":3,"prowJob":{"name":"periodic-ci-openshift-release-master-ci-4.15-e2e-aws-sdn-serial"}},"gcp-sdn":{"optional":true,"prowJob":{"name":"periodic-ci-openshift-release-master-ci-4.15-e2e-gcp-sdn"}},"hypershift-e2e":{"maxRetries":3,"prowJob":{"name":"periodic-ci-openshift-hypershift-release-4.15-periodics-e2e-aws-ovn"},"upgrade":true},"upgrade":{"optional":true,"prowJob":{"name":"periodic-ci-openshift-release-master-ci-4.15-e2e-gcp-sdn-upgrade"},"disabled":true,"upgrade":true},"upgrade-minor-aws-ovn":{"optional":true,"prowJob":{"name":"periodic-ci-openshift-release-master-ci-4.15-upgrade-from-stable-4.14-e2e-aws-ovn-upgrade"},"disabled":true,"upgrade":true,"upgradeFromRelease":{"candidate":{"stream":"ci","version":"4.14"}}},"upgrade-minor-sdn":{"optional":true,"prowJob":{"name":"periodic-ci-openshift-release-master-ci-4.15-upgrade-from-stable-4.14-e2e-aws-sdn-upgrade"},"upgrade":true,"upgradeFromRelease":{"candidate":{"stream":"ci","version":"4.14"}}},"aws-ovn-upgrade-4.15-minor":{"maxRetries":3,"prowJob":{"name":"periodic-ci-openshift-release-master-ci-4.15-upgrade-from-stable-4.14-e2e-aws-ovn-upgrade"},"upgrade":true,"upgradeFromRelease":{"candidate":{"stream":"ci","version":"4.14"}}},"azure-sdn-upgrade-4.15-minor":{"maxRetries":3,"prowJob":{"name":"periodic-ci-openshift-release-master-ci-4.15-upgrade-from-stable-4.14-e2e-azure-sdn-upgrade"},"upgrade":true,"upgradeFromRelease":{"candidate":{"stream":"ci","version":"4.14"}}},"gcp-ovn-upgrade-4.15-micro":{"maxRetries":3,"prowJob":{"name":"periodic-ci-openshift-release-master-ci-4.15-e2e-gcp-ovn-upgrade"},"upgrade":true}}}`,
+var (
+	streams = []ctrlruntimeclient.Object{
+		&imagev1.ImageStream{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "4.15",
+				Namespace: "ocp",
+				Annotations: map[string]string{
+					"release.openshift.io/config": `{"name":"4.15.0-0.ci","to":"release","message":"This release contains CI image builds of all code in release-4.15 (master) branches, and is updated each time someone merges.","mirrorPrefix":"4.15","expires":"72h","maxUnreadyReleases":1,"minCreationIntervalSeconds":21600,"pullSecretName":"source","check":{},"publish":{"tag":{"tagRef":{"name":"4.15-ci"}}},"verify":{"aws-sdn-serial":{"maxRetries":3,"prowJob":{"name":"periodic-ci-openshift-release-master-ci-4.15-e2e-aws-sdn-serial"}},"gcp-sdn":{"optional":true,"prowJob":{"name":"periodic-ci-openshift-release-master-ci-4.15-e2e-gcp-sdn"}},"hypershift-e2e":{"maxRetries":3,"prowJob":{"name":"periodic-ci-openshift-hypershift-release-4.15-periodics-e2e-aws-ovn"},"upgrade":true},"upgrade":{"optional":true,"prowJob":{"name":"periodic-ci-openshift-release-master-ci-4.15-e2e-gcp-sdn-upgrade"},"disabled":true,"upgrade":true},"upgrade-minor-aws-ovn":{"optional":true,"prowJob":{"name":"periodic-ci-openshift-release-master-ci-4.15-upgrade-from-stable-4.14-e2e-aws-ovn-upgrade"},"disabled":true,"upgrade":true,"upgradeFromRelease":{"candidate":{"stream":"ci","version":"4.14"}}},"upgrade-minor-sdn":{"optional":true,"prowJob":{"name":"periodic-ci-openshift-release-master-ci-4.15-upgrade-from-stable-4.14-e2e-aws-sdn-upgrade"},"upgrade":true,"upgradeFromRelease":{"candidate":{"stream":"ci","version":"4.14"}}},"aws-ovn-upgrade-4.15-minor":{"maxRetries":3,"prowJob":{"name":"periodic-ci-openshift-release-master-ci-4.15-upgrade-from-stable-4.14-e2e-aws-ovn-upgrade"},"upgrade":true,"upgradeFromRelease":{"candidate":{"stream":"ci","version":"4.14"}}},"azure-sdn-upgrade-4.15-minor":{"maxRetries":3,"prowJob":{"name":"periodic-ci-openshift-release-master-ci-4.15-upgrade-from-stable-4.14-e2e-azure-sdn-upgrade"},"upgrade":true,"upgradeFromRelease":{"candidate":{"stream":"ci","version":"4.14"}}},"gcp-ovn-upgrade-4.15-micro":{"maxRetries":3,"prowJob":{"name":"periodic-ci-openshift-release-master-ci-4.15-e2e-gcp-ovn-upgrade"},"upgrade":true}}}`,
+				},
+			},
+			Status: imagev1.ImageStreamStatus{
+				Tags: []imagev1.NamedTagEventList{
+					{Tag: "bar"},
+					{Tag: "foo"},
+				},
 			},
 		},
-		Status: imagev1.ImageStreamStatus{
-			Tags: []imagev1.NamedTagEventList{
-				{Tag: "bar"},
-				{Tag: "foo"},
+		&imagev1.ImageStream{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "5.0",
+				Namespace: "ocp",
+				Annotations: map[string]string{
+					"release.openshift.io/config": `{"name":"5.0.0-0.ci","to":"release-5","message":"This release contains CI image builds of all code in release-5.0 (main) branches, and is updated each time someone merges.","mirrorPrefix":"5.0","expires":"72h","maxUnreadyReleases":1,"minCreationIntervalSeconds":21600,"pullSecretName":"source","alternateImageRepository":"quay.io/openshift-release-dev/dev-release","alternateImageRepositorySecretName":"release-controller-quay-mirror-secret","check":{},"publish":{"tag":{"tagRef":{"name":"5.0-ci"}}},"verify":{}}`,
+				},
+			},
+			Status: imagev1.ImageStreamStatus{
+				Tags: []imagev1.NamedTagEventList{
+					{Tag: "bar"},
+					{Tag: "foo"},
+				},
 			},
 		},
-	},
-	&imagev1.ImageStream{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "5.0",
-			Namespace: "ocp",
-			Annotations: map[string]string{
-				"release.openshift.io/config": `{"name":"5.0.0-0.ci","to":"release-5","message":"This release contains CI image builds of all code in release-5.0 (main) branches, and is updated each time someone merges.","mirrorPrefix":"5.0","expires":"72h","maxUnreadyReleases":1,"minCreationIntervalSeconds":21600,"pullSecretName":"source","alternateImageRepository":"quay.io/openshift-release-dev/dev-release","alternateImageRepositorySecretName":"release-controller-quay-mirror-secret","check":{},"publish":{"tag":{"tagRef":{"name":"5.0-ci"}}},"verify":{}}`,
-			},
+	}
+	upstreamStreams = map[string]*configresolver.IntegratedStream{
+		"ocp/4.22": {
+			Tags:                        []string{"installer"},
+			ReleaseControllerConfigName: "4.22.0-0.ci",
 		},
-		Status: imagev1.ImageStreamStatus{
-			Tags: []imagev1.NamedTagEventList{
-				{Tag: "bar"},
-				{Tag: "foo"},
-			},
-		},
-	},
-}
+	}
+)
 
 func init() {
 	if err := imagev1.AddToScheme(scheme.Scheme); err != nil {
@@ -162,23 +172,30 @@ func init() {
 	}
 }
 
-type fakeCache struct {
-	Client ctrlruntimeclient.Client
+type fakeResolverClient struct {
+	registryserver.ResolverClient
 }
 
-func (c *fakeCache) Get(ctx context.Context, ns, name string) (*configresolver.IntegratedStream, error) {
-	return configresolver.LocalIntegratedStream(ctx, c.Client, ns, name)
+func (f *fakeResolverClient) IntegratedStream(namespace, name string) (*configresolver.IntegratedStream, error) {
+	nn := namespace + "/" + name
+	s, ok := upstreamStreams[nn]
+	if !ok {
+		return nil, fmt.Errorf("stream %s not found", nn)
+	}
+	return s, nil
 }
 
 func TestGetIntegratedStream(t *testing.T) {
+	t.Parallel()
 	fakeclient.NewClientBuilder().WithObjects(&imagev1.ImageStream{})
 
 	testCases := []struct {
-		name         string
-		client       ctrlruntimeclient.Client
-		url          string
-		expectedCode int
-		expectedBody string
+		name           string
+		client         ctrlruntimeclient.Client
+		resolverClient *fakeResolverClient
+		url            string
+		expectedCode   int
+		expectedBody   string
 	}{
 		{
 			name:         "4.x stream is valid",
@@ -201,16 +218,35 @@ func TestGetIntegratedStream(t *testing.T) {
 			expectedCode: 400,
 			expectedBody: "not a valid integrated stream: ocp/10.0\n",
 		},
+		{
+			name:           "4.x stream from upstream resolver",
+			resolverClient: &fakeResolverClient{},
+			url:            "/url?namespace=ocp&name=4.22",
+			expectedCode:   200,
+			expectedBody:   "{\"tags\":[\"installer\"],\"releaseControllerConfigName\":\"4.22.0-0.ci\"}\n",
+		}, {
+			name:           "5.x stream from upstream not found",
+			resolverClient: &fakeResolverClient{},
+			url:            "/url?namespace=ocp&name=6.22",
+			expectedCode:   400,
+			expectedBody:   "not a valid integrated stream: ocp/6.22\n",
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			req, err := http.NewRequest("GET", tc.url, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
 			rr := httptest.NewRecorder()
-			handlerFunc := getIntegratedStream(context.Background(), &fakeCache{Client: tc.client})
+			var resolver registryserver.ResolverClient
+			if tc.resolverClient != nil {
+				resolver = tc.resolverClient
+			}
+			cache := integrationStreamCache(tc.client, resolver, time.Minute)
+			handlerFunc := getIntegratedStream(context.Background(), cache)
 			handlerFunc.ServeHTTP(rr, req)
 			if diff := cmp.Diff(tc.expectedCode, rr.Code); diff != "" {
 				t.Errorf("%s: actual does not match expected, diff: %s", tc.name, diff)

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -191,9 +191,10 @@ func Boskos(opt BoskosOptions) *Accessory {
 
 // ConfigResolverOptions are options for running the config server
 type ConfigResolverOptions struct {
-	ConfigPath   string
-	RegistryPath string
-	FlatRegistry bool
+	ConfigPath              string
+	RegistryPath            string
+	FlatRegistry            bool
+	UpstreamResolverAddress string
 }
 
 // ConfigResolver begins the configresolver server and makes sure it is ready
@@ -201,11 +202,12 @@ type ConfigResolverOptions struct {
 func ConfigResolver(opt ConfigResolverOptions) *Accessory {
 	return testhelper.NewAccessory("ci-operator-configresolver",
 		flags(map[string]string{
-			"config":        opt.ConfigPath,
-			"registry":      opt.RegistryPath,
-			"flat-registry": strconv.FormatBool(opt.FlatRegistry),
-			"log-level":     "debug",
-			"cycle":         "2m",
+			"config":                    opt.ConfigPath,
+			"registry":                  opt.RegistryPath,
+			"flat-registry":             strconv.FormatBool(opt.FlatRegistry),
+			"log-level":                 "debug",
+			"cycle":                     "2m",
+			"upstream-resolver-address": opt.UpstreamResolverAddress,
 		}),
 		func(port, healthPort string) []string {
 			return flags(map[string]string{

--- a/test/e2e/multi-stage/e2e_test.go
+++ b/test/e2e/multi-stage/e2e_test.go
@@ -10,6 +10,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/uuid"
 
+	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/test/e2e/framework"
 )
 
@@ -229,7 +230,6 @@ func TestMultiStage(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		framework.Run(t, testCase.name, func(t *framework.T, cmd *framework.CiOperatorCommand) {
 			cmd.AddArgs(framework.LocalPullSecretFlag(t), framework.RemotePullSecretFlag(t))
 			cmd.AddArgs(testCase.args...)
@@ -246,9 +246,10 @@ func TestMultiStage(t *testing.T) {
 			}
 			cmd.VerboseOutputContains(t, testCase.name, testCase.output...)
 		}, framework.ConfigResolver(framework.ConfigResolverOptions{
-			ConfigPath:   "configs",
-			RegistryPath: "registry",
-			FlatRegistry: true,
+			ConfigPath:              "configs",
+			RegistryPath:            "registry",
+			FlatRegistry:            true,
+			UpstreamResolverAddress: api.URLForService("config"),
 		}))
 	}
 }

--- a/test/e2e/multi-stage/integration-releases.yaml
+++ b/test/e2e/multi-stage/integration-releases.yaml
@@ -36,14 +36,16 @@ tests:
               cpu: 10m
               memory: 10Mi
         - as: latest
-          commands: grep -q '4.18' <<<"$( cluster-version-operator version )"
+          commands: |
+            cat /release-manifests/release-metadata
+            grep -q '4.18' /release-manifests/release-metadata
           from: "release:latest"
           resources:
             requests:
               cpu: 10m
               memory: 10Mi
         - as: latest-cli
-          commands: grep -q '4.18' <<<"$( oc version )"
+          commands: grep -q '4.18' <<<"$OS_GIT_VERSION"
           from: "stable:cli"
           resources:
             requests:

--- a/test/e2e/observer/e2e_test.go
+++ b/test/e2e/observer/e2e_test.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/test/e2e/framework"
 )
 
@@ -74,7 +75,6 @@ func TestObservers(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		framework.Run(t, testCase.name, func(t *framework.T, cmd *framework.CiOperatorCommand) {
 			cmd.AddArgs(framework.LocalPullSecretFlag(t), framework.RemotePullSecretFlag(t))
 			cmd.AddArgs(testCase.args...)
@@ -102,9 +102,10 @@ func TestObservers(t *testing.T) {
 			expectedJunit := path.Join("artifacts", testCase.junitOperator)
 			framework.CompareWithFixture(t, expectedJunit, filepath.Join(cmd.ArtifactDir(), "junit_operator.xml"))
 		}, framework.ConfigResolver(framework.ConfigResolverOptions{
-			ConfigPath:   "configs",
-			RegistryPath: "registry",
-			FlatRegistry: true,
+			ConfigPath:              "configs",
+			RegistryPath:            "registry",
+			FlatRegistry:            true,
+			UpstreamResolverAddress: api.URLForService("config"),
 		}))
 	}
 }


### PR DESCRIPTION
`e2e` tests use a real `ci-operator-configresolver` that is expected to find IS `ocp/X.Y` within the cluster the test is running on, but these streams exist on `app.ci` only.

As a consequence of that, we experience failures like [this](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_ci-tools/5247/pull-ci-openshift-ci-tools-main-e2e/2066457872044134400).
This PR overcomes the problem by adding a new parameter on `ci-operator-configresolver`:
```
--upstream-resolver-address=...
```
that `e2e`s set to the production endpoint `https://config.ci.openshift.org/`.

The upstream resolver is used to retrieve information about the integrated streams.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Upstream Resolver Support for `ci-operator-configresolver`

This PR adds an **optional upstream resolver** path for resolving OpenShift “integrated streams” so **e2e tests in isolated clusters** don’t fail when the test cluster lacks `ocp/X.Y` ImageStreams (those exist only on `app.ci`). When configured, `ci-operator-configresolver` delegates integrated-stream lookups to the **production config service**.

### What changed

**`ci-operator-configresolver` (`cmd/ci-operator-configresolver/main.go`)**
- Added a new CLI flag: `--upstream-resolver-address`.
- Implemented a new TTL-backed cache for integrated stream resolution:
  - Uses **local** resolution when no upstream is configured.
  - Uses an **upstream resolver client** when `--upstream-resolver-address` is set.
- Updated the server wiring so the `/integratedStream` endpoint serves from the new integration cache (replacing the prior in-memory/mutex cache approach).

**Unit tests (`cmd/ci-operator-configresolver/main_test.go`)**
- Refactored integrated-stream tests to exercise the TTL cache for both:
  - **Local** integrated stream resolution
  - **Upstream** integrated stream resolution, including an **upstream miss** case with the expected HTTP 400 error.

**E2E framework + tests**
- Extended `test/e2e/framework/framework.go`:
  - Added `ConfigResolverOptions.UpstreamResolverAddress`
  - Passed it through to `ci-operator-configresolver` as `--upstream-resolver-address`.
- Updated e2e callers to set the upstream resolver address using the CI API config service endpoint (`api.URLForService("config")`):
  - `test/e2e/multi-stage/e2e_test.go`
  - `test/e2e/observer/e2e_test.go`
- Also removed per-iteration loop-variable shadowing in the e2e tests to ensure the intended `testCase` is used.
- `test/e2e/multi-stage/integration-releases.yaml`: adjusted the **4.18 “latest”** checks to read `/release-manifests/release-metadata` instead of grepping `cluster-version-operator version` / `oc version`.

### Practical impact
- **Default behavior is unchanged**: if the flag is not set, integrated streams are resolved locally as before.
- **Opt-in behavior**: e2e environments can point `ci-operator-configresolver` to `https://config.ci.openshift.org/` (via the framework wiring) to resolve integrated streams even when `ocp/X.Y` ImageStreams are missing from the test cluster.

### Test/validation notes
- The PR author requested e2e runs and reruns via PR commands (`/test e2e`, `/hold`, `/retest-required`) while validating the change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->