### PR TITLE
fix: pull reference-only ocp tags from quay-proxy spec

### DIFF
--- a/pkg/api/promotion.go
+++ b/pkg/api/promotion.go
@@ -130,6 +130,23 @@ func ConsolidatedQuayPromotionVersion(name string) bool {
 	return major == 4 && minor >= 11 && minor <= 22
 }
 
+// UsesOfficialImageTagResolution reports whether an official OCP input should resolve via
+// spec/status on the source imagestream before falling back to computed quay-proxy.
+// Versioned streams at 4.23+ use computed quay only; non-versioned streams (e.g. builder) use spec-first.
+func UsesOfficialImageTagResolution(tag ImageStreamTagReference) bool {
+	if !RefersToOfficialImage(tag.Namespace, WithoutOKD) {
+		return false
+	}
+	if ConsolidatedQuayPromotionVersion(tag.Name) {
+		return true
+	}
+	var major, minor int
+	if _, err := fmt.Sscanf(tag.Name, "%d.%d", &major, &minor); err == nil {
+		return false
+	}
+	return true
+}
+
 func quayProxyStreamSuffix(tag ImageStreamTagReference) string {
 	if ConsolidatedQuayPromotionVersion(tag.Name) {
 		return ""

--- a/pkg/api/promotion_test.go
+++ b/pkg/api/promotion_test.go
@@ -63,6 +63,26 @@ func TestPromotesOfficialImages(t *testing.T) {
 	}
 }
 
+func TestUsesOfficialImageTagResolution(t *testing.T) {
+	tests := []struct {
+		tag  ImageStreamTagReference
+		want bool
+	}{
+		{tag: ImageStreamTagReference{Namespace: "ocp", Name: "4.22", Tag: "cli"}, want: true},
+		{tag: ImageStreamTagReference{Namespace: "ocp", Name: "4.23", Tag: "cli"}, want: false},
+		{tag: ImageStreamTagReference{Namespace: "ocp", Name: "5.0", Tag: "cli"}, want: false},
+		{tag: ImageStreamTagReference{Namespace: "ocp", Name: "builder", Tag: "rhel-9-golang-1.22-openshift-4.17"}, want: true},
+		{tag: ImageStreamTagReference{Namespace: "ci", Name: "tools", Tag: "latest"}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.tag.ISTagName(), func(t *testing.T) {
+			if diff := cmp.Diff(tt.want, UsesOfficialImageTagResolution(tt.tag)); diff != "" {
+				t.Fatalf("UsesOfficialImageTagResolution() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestTargetName(t *testing.T) {
 	var testCases = []struct {
 		name     string

--- a/pkg/controller/test-images-distributor/test_images_distributor.go
+++ b/pkg/controller/test-images-distributor/test_images_distributor.go
@@ -29,6 +29,7 @@ import (
 	testimagestreamtagimportv1 "github.com/openshift/ci-tools/pkg/api/testimagestreamtagimport/v1"
 	controllerutil "github.com/openshift/ci-tools/pkg/controller/util"
 	"github.com/openshift/ci-tools/pkg/load/agents"
+	steputils "github.com/openshift/ci-tools/pkg/steps/utils"
 	"github.com/openshift/ci-tools/pkg/util/imagestreamtagmapper"
 	"github.com/openshift/ci-tools/pkg/util/imagestreamtagwrapper"
 )
@@ -317,9 +318,9 @@ func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, log *
 	if err != nil {
 		return fmt.Errorf("failed to get registry domain for cluster %s: %w", r.registryClusterName, err)
 	}
-	pullSpec := pullSpecFromImageStreamTag(registryDomain, sourceImageStreamTag)
+	pullSpec := steputils.PullSpecForImageStreamTag(registryDomain, sourceImageStream, sourceImageStreamTag)
 	*log = *log.WithField("docker_image_reference", pullSpec)
-	if isImportForbidden(sourceImageStreamTag.Image.DockerImageReference, r.forbiddenRegistries) {
+	if isImportForbidden(pullSpec, r.forbiddenRegistries) || isImportForbidden(sourceImageStreamTag.Image.DockerImageReference, r.forbiddenRegistries) {
 		log.Debugf("Import from any cluster in %s is forbidden, ignoring", r.forbiddenRegistries)
 		return nil
 	}
@@ -376,7 +377,7 @@ func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, log *
 				},
 				To: &corev1.LocalObjectReference{Name: imageTag},
 				ReferencePolicy: imagev1.TagReferencePolicy{
-					Type: imagev1.LocalTagReferencePolicy,
+					Type: steputils.TagImportReferencePolicy(&corev1.ObjectReference{Kind: "DockerImage", Name: pullSpec}),
 				},
 			}},
 		},
@@ -636,8 +637,4 @@ func isImportForbidden(pullSpec string, forbiddenRegistries sets.Set[string]) bo
 		}
 	}
 	return false
-}
-
-func pullSpecFromImageStreamTag(registryURL string, isTag *imagev1.ImageStreamTag) string {
-	return registryURL + "/" + isTag.Namespace + "/" + strings.Split(isTag.Name, ":")[0] + "@" + isTag.Image.ObjectMeta.Name
 }

--- a/pkg/steps/input_image_tag.go
+++ b/pkg/steps/input_image_tag.go
@@ -164,7 +164,7 @@ func (s *inputImageTagStep) resolveOfficialImport(ctx context.Context) (*coreapi
 	if from.Kind != "DockerImage" && from.Namespace != "" {
 		pullSpec = fmt.Sprintf("%s/%s", from.Namespace, from.Name)
 	}
-	return from, imagev1.LocalTagReferencePolicy, pullSpec, nil
+	return from, utils.TagImportReferencePolicy(from), pullSpec, nil
 }
 
 // waitForTagInSpec waits for the tag on the image stream are to show in spec

--- a/pkg/steps/input_image_tag_test.go
+++ b/pkg/steps/input_image_tag_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,6 +18,7 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/steps/loggingclient"
+	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
 func TestInputImageTagStep(t *testing.T) {
@@ -192,15 +195,78 @@ func TestInputImageTagStepOfficialSpec(t *testing.T) {
 		Tag: &imagev1.TagReference{
 			From:            &corev1.ObjectReference{Kind: "DockerImage", Name: specPullSpec},
 			ImportPolicy:    imagev1.TagImportPolicy{ImportMode: imagev1.ImportModePreserveOriginal},
-			ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.LocalTagReferencePolicy},
+			ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.SourceTagReferencePolicy},
 		},
 	}
 	targetImageStreamTag := &imagev1.ImageStreamTag{}
 	if err := client.Get(context.Background(), ctrlruntimeclient.ObjectKey{Namespace: jobspec.Namespace(), Name: "pipeline:ocp_4_22_hyperkube"}, targetImageStreamTag); err != nil {
 		t.Fatalf("failed to get pipeline tag: %v", err)
 	}
-	if !equality.Semantic.DeepEqual(expectedImageStreamTag, targetImageStreamTag) {
-		t.Errorf("unexpected pipeline tag:\n%s", diff.ObjectReflectDiff(expectedImageStreamTag, targetImageStreamTag))
+	if diff := cmp.Diff(expectedImageStreamTag, targetImageStreamTag, testhelper.RuntimeObjectIgnoreRvTypeMeta); diff != "" {
+		t.Errorf("unexpected pipeline tag (-want +got):\n%s", diff)
+	}
+}
+
+func TestInputImageTagStepOCPBuilderReference(t *testing.T) {
+	specPullSpec := "quay-proxy.ci.openshift.org/openshift/ci@sha256:47f4267a177f47b7a1cf44d652a452d668ee1fc72ed0490560db4292449eebfe"
+	baseImage := api.ImageStreamTagReference{
+		Namespace: "ocp",
+		Name:      "builder",
+		Tag:       "rhel-9-golang-1.22-openshift-4.17",
+	}
+	config := api.InputImageTagStepConfiguration{
+		InputImage: api.InputImage{To: "builder", BaseImage: baseImage},
+	}
+	client := loggingclient.New(fakectrlruntimeclient.NewClientBuilder().WithRuntimeObjects(
+		&imagev1.ImageStream{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ocp", Name: "builder"},
+			Spec: imagev1.ImageStreamSpec{Tags: []imagev1.TagReference{{
+				Name:      "rhel-9-golang-1.22-openshift-4.17",
+				Reference: true,
+				From:      &corev1.ObjectReference{Kind: "DockerImage", Name: specPullSpec},
+			}}},
+			Status: imagev1.ImageStreamStatus{Tags: []imagev1.NamedTagEventList{{
+				Tag: "rhel-9-golang-1.22-openshift-4.17",
+				Items: []imagev1.TagEvent{{
+					Image:                "",
+					DockerImageReference: specPullSpec,
+				}},
+			}}},
+		},
+		&imagev1.ImageStream{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "target-namespace", Name: api.PipelineImageStream},
+			Spec: imagev1.ImageStreamSpec{
+				LookupPolicy: imagev1.ImageLookupPolicy{Local: true},
+				Tags:         []imagev1.TagReference{{Name: "builder"}},
+			},
+			Status: imagev1.ImageStreamStatus{
+				PublicDockerImageRepository: "some-reg/target-namespace/pipeline",
+				Tags: []imagev1.NamedTagEventList{{
+					Tag:   "builder",
+					Items: []imagev1.TagEvent{{Image: "sha256:47e2f82dbede8ff990e6e240f82d78830e7558f7b30df7bd8c0693992018b1e3"}},
+				}},
+			},
+		}).Build(), nil)
+	jobspec := &api.JobSpec{}
+	jobspec.SetNamespace("target-namespace")
+	iits := InputImageTagStep(&config, client, jobspec)
+	executeStep(t, iits, executionExpectation{
+		prerun: doneExpectation{value: false, err: false}, runError: false, postrun: doneExpectation{value: true, err: false},
+	})
+	expected := &imagev1.ImageStreamTag{
+		ObjectMeta: metav1.ObjectMeta{Name: "pipeline:builder", Namespace: jobspec.Namespace(), ResourceVersion: "1"},
+		Tag: &imagev1.TagReference{
+			From:            &corev1.ObjectReference{Kind: "DockerImage", Name: specPullSpec},
+			ImportPolicy:    imagev1.TagImportPolicy{ImportMode: imagev1.ImportModePreserveOriginal},
+			ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.SourceTagReferencePolicy},
+		},
+	}
+	got := &imagev1.ImageStreamTag{}
+	if err := client.Get(context.Background(), ctrlruntimeclient.ObjectKey{Namespace: jobspec.Namespace(), Name: "pipeline:builder"}, got); err != nil {
+		t.Fatalf("get pipeline tag: %v", err)
+	}
+	if diff := cmp.Diff(expected, got, testhelper.RuntimeObjectIgnoreRvTypeMeta); diff != "" {
+		t.Errorf("unexpected tag (-want +got):\n%s", diff)
 	}
 }
 

--- a/pkg/steps/release/snapshot.go
+++ b/pkg/steps/release/snapshot.go
@@ -141,13 +141,8 @@ func snapshotImportSource(sourceNamespace, sourceName, tag string, source *image
 		}
 		return nil, false
 	}
-	if api.ConsolidatedQuayPromotionVersion(sourceName) {
+	if api.UsesOfficialImageTagResolution(base) {
 		return utils.OfficialImageTagFrom(source, base), true
-	}
-	if source != nil {
-		if ref := utils.FindSpecTag(source, tag); ref != nil && ref.Kind == "DockerImage" && ref.Name != "" {
-			from.Name = ref.Name
-		}
 	}
 	return from, true
 }

--- a/pkg/steps/release/snapshot_test.go
+++ b/pkg/steps/release/snapshot_test.go
@@ -3,6 +3,8 @@ package release
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	coreapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -53,7 +55,7 @@ func TestSnapshotImportSource(t *testing.T) {
 			wantFrom: &coreapi.ObjectReference{Kind: "DockerImage", Name: api.QuayImageReference(api.ImageStreamTagReference{Namespace: "ocp", Name: "4.22", Tag: base.Tag})},
 		},
 		{
-			name:   "non-consolidated spec docker",
+			name:   "non-consolidated uses computed quay",
 			stream: "4.23",
 			tag:    "cli",
 			source: &imagev1.ImageStream{
@@ -64,7 +66,7 @@ func TestSnapshotImportSource(t *testing.T) {
 				}}},
 			},
 			wantOK:   true,
-			wantFrom: &coreapi.ObjectReference{Kind: "DockerImage", Name: specPull},
+			wantFrom: &coreapi.ObjectReference{Kind: "DockerImage", Name: api.QuayImageReference(api.ImageStreamTagReference{Namespace: "ocp", Name: "4.23", Tag: "cli"})},
 		},
 		{
 			name:     "default quay float",
@@ -88,8 +90,8 @@ func TestSnapshotImportSource(t *testing.T) {
 			if !ok {
 				return
 			}
-			if from.Kind != tt.wantFrom.Kind || from.Name != tt.wantFrom.Name {
-				t.Fatalf("from = %+v, want %+v", from, tt.wantFrom)
+			if diff := cmp.Diff(tt.wantFrom, from); diff != "" {
+				t.Fatalf("from mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/steps/utils/image.go
+++ b/pkg/steps/utils/image.go
@@ -83,10 +83,53 @@ func OfficialImageTagFrom(source *imagev1.ImageStream, base api.ImageStreamTagRe
 	return &coreapi.ObjectReference{Kind: "DockerImage", Name: api.QuayImageReference(base)}
 }
 
-// ResolveOfficialInputFrom resolves consolidated ocp inputs: stable in job ns, then spec/status/quay on source IS.
+// TagImportReferencePolicy returns Source for external DockerImage refs, Local for in-cluster tags.
+func TagImportReferencePolicy(from *coreapi.ObjectReference) imagev1.TagReferencePolicyType {
+	if from != nil && from.Kind == "DockerImage" {
+		name := from.Name
+		if strings.HasPrefix(name, api.QCIAPPCIDomain) || strings.HasPrefix(name, api.QuayOpenShiftCIRepo) || strings.HasPrefix(name, "quay.io/") {
+			return imagev1.SourceTagReferencePolicy
+		}
+	}
+	return imagev1.LocalTagReferencePolicy
+}
+
+// PullSpecForImageStreamTag returns a pull spec for an imagestream tag, resolving reference-only
+// tags via spec/status/quay-proxy when the tag has no local image content.
+func PullSpecForImageStreamTag(registryURL string, source *imagev1.ImageStream, isTag *imagev1.ImageStreamTag) string {
+	nameParts := strings.SplitN(isTag.Name, ":", 2)
+	if len(nameParts) == 2 && source != nil {
+		for _, t := range source.Spec.Tags {
+			if t.Name == nameParts[1] && t.Reference && t.From != nil && t.From.Kind == "DockerImage" && t.From.Name != "" {
+				return t.From.Name
+			}
+		}
+	}
+	if isTag.Image.ObjectMeta.Name != "" {
+		return registryURL + "/" + isTag.Namespace + "/" + strings.Split(isTag.Name, ":")[0] + "@" + isTag.Image.ObjectMeta.Name
+	}
+	if len(nameParts) != 2 {
+		return ""
+	}
+	base := api.ImageStreamTagReference{Namespace: isTag.Namespace, Name: nameParts[0], Tag: nameParts[1]}
+	ref := OfficialImageTagFrom(source, base)
+	switch ref.Kind {
+	case "DockerImage":
+		return ref.Name
+	case "ImageStreamImage":
+		if ref.Namespace != "" {
+			return registryURL + "/" + ref.Namespace + "/" + ref.Name
+		}
+		return registryURL + "/" + isTag.Namespace + "/" + ref.Name
+	default:
+		return ref.Name
+	}
+}
+
+// ResolveOfficialInputFrom resolves official ocp inputs: stable in job ns, then spec/status/quay on source IS.
 // When ok is false, callers use QuayImageReference with Source policy (e.g. 4.23, 5.0).
 func ResolveOfficialInputFrom(ctx context.Context, client ctrlruntimeclient.Client, jobNamespace string, base api.ImageStreamTagReference) (*coreapi.ObjectReference, bool, error) {
-	if !api.ConsolidatedQuayPromotionVersion(base.Name) || !api.RefersToOfficialImage(base.Namespace, api.WithoutOKD) {
+	if !api.UsesOfficialImageTagResolution(base) {
 		return nil, false, nil
 	}
 	stable := &imagev1.ImageStream{}

--- a/pkg/steps/utils/image_test.go
+++ b/pkg/steps/utils/image_test.go
@@ -40,6 +40,33 @@ func TestResolveOfficialInputFrom(t *testing.T) {
 		wantFrom *coreapi.ObjectReference
 	}{
 		{name: "non-consolidated", base: api.ImageStreamTagReference{Namespace: "ocp", Name: "5.0", Tag: "cli"}, wantOK: false},
+		{name: "4.23 uses computed quay", base: api.ImageStreamTagReference{Namespace: "ocp", Name: "4.23", Tag: "cli"}, wantOK: false},
+		{
+			name: "ocp builder spec quay-proxy digest",
+			base: api.ImageStreamTagReference{Namespace: "ocp", Name: "builder", Tag: "rhel-9-golang-1.22-openshift-4.17"},
+			objects: []runtime.Object{&imagev1.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ocp", Name: "builder"},
+				Spec: imagev1.ImageStreamSpec{Tags: []imagev1.TagReference{{
+					Name:      "rhel-9-golang-1.22-openshift-4.17",
+					Reference: true,
+					From: &coreapi.ObjectReference{
+						Kind: "DockerImage",
+						Name: "quay-proxy.ci.openshift.org/openshift/ci@sha256:47f4267a177f47b7a1cf44d652a452d668ee1fc72ed0490560db4292449eebfe",
+					},
+				}}},
+				Status: imagev1.ImageStreamStatus{Tags: []imagev1.NamedTagEventList{{
+					Tag: "rhel-9-golang-1.22-openshift-4.17",
+					Items: []imagev1.TagEvent{{
+						DockerImageReference: "quay-proxy.ci.openshift.org/openshift/ci@sha256:47f4267a177f47b7a1cf44d652a452d668ee1fc72ed0490560db4292449eebfe",
+					}},
+				}}},
+			}},
+			wantOK: true,
+			wantFrom: &coreapi.ObjectReference{
+				Kind: "DockerImage",
+				Name: "quay-proxy.ci.openshift.org/openshift/ci@sha256:47f4267a177f47b7a1cf44d652a452d668ee1fc72ed0490560db4292449eebfe",
+			},
+		},
 		{
 			name: "spec docker",
 			base: base,
@@ -113,8 +140,52 @@ func TestResolveOfficialInputFrom(t *testing.T) {
 			if !ok {
 				return
 			}
-			if from.Kind != tt.wantFrom.Kind || from.Name != tt.wantFrom.Name || from.Namespace != tt.wantFrom.Namespace {
-				t.Fatalf("from = %+v, want %+v", from, tt.wantFrom)
+			if diff := cmp.Diff(tt.wantFrom, from); diff != "" {
+				t.Fatalf("from mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPullSpecForImageStreamTag(t *testing.T) {
+	specDigest := "quay-proxy.ci.openshift.org/openshift/ci@sha256:47f4267a177f47b7a1cf44d652a452d668ee1fc72ed0490560db4292449eebfe"
+	is := &imagev1.ImageStream{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ocp", Name: "builder"},
+		Spec: imagev1.ImageStreamSpec{Tags: []imagev1.TagReference{{
+			Name:      "rhel-9-golang-1.22-openshift-4.17",
+			Reference: true,
+			From:      &coreapi.ObjectReference{Kind: "DockerImage", Name: specDigest},
+		}}},
+		Status: imagev1.ImageStreamStatus{Tags: []imagev1.NamedTagEventList{{
+			Tag:   "rhel-9-golang-1.22-openshift-4.17",
+			Items: []imagev1.TagEvent{{DockerImageReference: specDigest}},
+		}}},
+	}
+	tests := []struct {
+		name  string
+		isTag *imagev1.ImageStreamTag
+		want  string
+	}{
+		{
+			name: "reference tag",
+			isTag: &imagev1.ImageStreamTag{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ocp", Name: "builder:rhel-9-golang-1.22-openshift-4.17"},
+			},
+			want: specDigest,
+		},
+		{
+			name: "stale local image",
+			isTag: &imagev1.ImageStreamTag{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ocp", Name: "builder:rhel-9-golang-1.22-openshift-4.17"},
+				Image:      imagev1.Image{ObjectMeta: metav1.ObjectMeta{Name: "sha256:950393761142fa66698e9ba1d679643c88194d78a99308aa814fef6de92a8bfe"}},
+			},
+			want: specDigest,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := cmp.Diff(tt.want, PullSpecForImageStreamTag("registry.ci.openshift.org", is, tt.isTag)); diff != "" {
+				t.Fatalf("pull spec mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Resolve reference-only ocp tags (e.g. ocp/builder) from spec.tags.from.name on quay-proxy with Source policy so PRPQR builds pull directly instead of failing on empty registry.ci imports.

https://redhat-internal.slack.com/archives/CBN38N3MW/p1781621737997829



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes the handling of reference-only OCP image tags in CI builds by introducing differentiated resolution logic for official OCP image inputs. The key change enables the CI system to successfully pull non-versioned OCP images (like `ocp/builder`) from the quay-proxy container registry using source-based resolution, while maintaining the existing computed Quay approach for versioned releases (4.23+).

## Changes

**New Resolution Decision Logic:**
A new function `UsesOfficialImageTagResolution` in `pkg/api/promotion.go` implements a versioning strategy:
- **Consolidated versions (4.11-4.22)**: Use computed quay-proxy references
- **Versioned releases (4.23+, 5.0+)**: Use computed quay-proxy references  
- **Non-versioned streams (builder, etc.)**: Use spec-first resolution to pull from source ImageStream

**New Pull Spec and Reference Policy Helpers:**
Two new functions in `pkg/steps/utils/image.go`:
- `TagImportReferencePolicy`: Determines whether to use Source (for external registries like quay.io) or Local tag reference policies
- `PullSpecForImageStreamTag`: Computes pull specs for ImageStreamTags, with special handling for reference-only tags by resolving Docker image references from the ImageStream spec

**Component Updates:**
- **Release Snapshot controller** (`pkg/steps/release/snapshot.go`): Uses the new `UsesOfficialImageTagResolution` logic to decide when to resolve imports via the official channels
- **Input Image Tag step** (`pkg/steps/input_image_tag.go`): Uses `TagImportReferencePolicy` to dynamically set reference policies based on resolved sources
- **Test Images Distributor controller** (`pkg/controller/test-images-distributor/test_images_distributor.go`): Extended to filter forbidden registries based on computed pull specs and use the new reference policy logic

## Practical Impact

This enables PRPQR (Promotion with Reference-based Pull Request) builds to correctly pull reference-only OCP tags specified in imagestream `spec.tags.from` fields. Previously, these builds would fail because the CI system would try to use empty `registry.ci` imports. Now they successfully resolve from the quay-proxy by reading the reference-only tag definition from the source ImageStream's specification, improving build reliability for builder images and other non-versioned OCP resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->