### PR TITLE
fix: accept legacy cluster_profile in resolved configs

### DIFF
--- a/pkg/api/leases.go
+++ b/pkg/api/leases.go
@@ -10,7 +10,7 @@ import (
 // unique values.
 func LeasesForTest(test *TestStepConfiguration) (ret []StepLease) {
 	multiStageTest := test.MultiStageTestConfigurationLiteral
-	if p := multiStageTest.ClusterProfileLiteral; p != nil {
+	if p := multiStageTest.ClusterProfileLiteralOrLegacy(); p != nil {
 		ret = append(ret, StepLease{
 			ResourceType:   p.LeaseType,
 			Env:            DefaultLeaseEnv,

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -928,15 +928,15 @@ func (config TestStepConfiguration) IsPeriodic() bool {
 
 // GetClusterProfileName returns the cluster profile name if it's set
 func (config TestStepConfiguration) GetClusterProfileName() string {
-	switch {
-	case config.MultiStageTestConfigurationLiteral != nil &&
-		config.MultiStageTestConfigurationLiteral.ClusterProfileLiteral != nil:
-		return config.MultiStageTestConfigurationLiteral.ClusterProfileLiteral.Name
-	case config.MultiStageTestConfiguration != nil:
-		return config.MultiStageTestConfiguration.ClusterProfile.Name()
-	default:
-		return ""
+	if config.MultiStageTestConfigurationLiteral != nil {
+		if p := config.MultiStageTestConfigurationLiteral.ClusterProfileLiteralOrLegacy(); p != nil {
+			return p.Name
+		}
 	}
+	if config.MultiStageTestConfiguration != nil {
+		return config.MultiStageTestConfiguration.ClusterProfile.Name()
+	}
+	return ""
 }
 
 // Cloud is the name of a cloud provider, e.g., aws cluster topology, etc.
@@ -962,6 +962,27 @@ func FromClusterProfileDetails(profileDetails *ClusterProfileDetails) *ClusterPr
 		LeaseType:   profileDetails.LeaseType,
 		ClusterType: profileDetails.ClusterType,
 		Secret:      profileDetails.Secret,
+	}
+}
+
+// ClusterProfileLiteralOrLegacy returns the resolved cluster profile literal, falling back to
+// the deprecated cluster_profile string emitted by older configresolver builds.
+func (m *MultiStageTestConfigurationLiteral) ClusterProfileLiteralOrLegacy() *ClusterProfileLiteral {
+	if m == nil {
+		return nil
+	}
+	if m.ClusterProfileLiteral != nil {
+		return m.ClusterProfileLiteral
+	}
+	if m.ClusterProfile == "" {
+		return nil
+	}
+	profile := m.ClusterProfile
+	return &ClusterProfileLiteral{
+		Name:        string(profile),
+		LeaseType:   profile.LeaseType(),
+		ClusterType: profile.ClusterType(),
+		Secret:      GetDefaultClusterProfileSecretName(profile),
 	}
 }
 
@@ -1327,6 +1348,8 @@ type DependencyOverrides map[string]string
 type MultiStageTestConfigurationLiteral struct {
 	// ClusterProfileLiteral defines the profile/cloud provider for end-to-end test steps.
 	ClusterProfileLiteral *ClusterProfileLiteral `json:"cluster_profile_literal,omitempty"`
+	// ClusterProfile is deprecated; retained for configs resolved by older configresolver builds.
+	ClusterProfile ClusterProfile `json:"cluster_profile,omitempty"`
 	// Pre is the array of test steps run to set up the environment for the test.
 	Pre []LiteralTestStep `json:"pre,omitempty"`
 	// Test is the array of test steps that define the actual test.

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -368,7 +368,7 @@ func stepForTest(cfg *Config, inputImages inputImageSet, c *api.TestStepConfigur
 		step := multi_stage.MultiStageTestStep(*c, cfg.CIConfig, params, cfg.podClient, cfg.JobSpec, leases, cfg.NodeName, cfg.TargetAdditionalSuffix, nil, cfg.GSMConfig != nil, cfg.GSMConfig, isLeaseProxyServerAvailable(cfg), retry.DefaultRetry)
 
 		if len(leases) != 0 {
-			step = steps.IPPoolStep(cfg.LeaseClient, cfg.podClient, step, params, cfg.JobSpec.Namespace, cfg.MetricsAgent, test.ClusterProfileLiteral, cfg.CIConfig.Metadata.Branch)
+			step = steps.IPPoolStep(cfg.LeaseClient, cfg.podClient, step, params, cfg.JobSpec.Namespace, cfg.MetricsAgent, test.ClusterProfileLiteralOrLegacy(), cfg.CIConfig.Metadata.Branch)
 			step = steps.LeaseStep(cfg.LeaseClient, leases, step, cfg.JobSpec.Namespace, cfg.MetricsAgent, cfg.kubeClient, cfg.ClusterProfileGetter)
 		}
 

--- a/pkg/prowgen/jobbase.go
+++ b/pkg/prowgen/jobbase.go
@@ -171,7 +171,7 @@ func NewProwJobBaseBuilderForTest(configSpec *cioperatorapi.ReleaseBuildConfigur
 	switch {
 	case test.MultiStageTestConfigurationLiteral != nil:
 		p.PodSpec.Add(LeaseClient())
-		if clusterProfile := test.MultiStageTestConfigurationLiteral.ClusterProfileLiteral; clusterProfile != nil {
+		if clusterProfile := test.MultiStageTestConfigurationLiteral.ClusterProfileLiteralOrLegacy(); clusterProfile != nil {
 			p.WithLabel(cioperatorapi.CloudClusterProfileLabel, clusterProfile.Name)
 			p.WithLabel(cioperatorapi.CloudLabel, clusterProfile.ClusterType)
 		}

--- a/pkg/steps/multi_stage/multi_stage.go
+++ b/pkg/steps/multi_stage/multi_stage.go
@@ -184,7 +184,7 @@ func newMultiStageTestStep(
 		name:                             testConfig.As,
 		additionalSuffix:                 targetAdditionalSuffix,
 		nodeName:                         nodeName,
-		profile:                          ms.ClusterProfileLiteral,
+		profile:                          ms.ClusterProfileLiteralOrLegacy(),
 		config:                           config,
 		params:                           params,
 		env:                              ms.Environment,

--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -636,9 +636,9 @@ func (v *Validator) validateTestConfigurationType(
 	if testConfig := test.MultiStageTestConfigurationLiteral; testConfig != nil {
 		typeCount++
 		context := newContext(fieldPath(fieldRoot).addField("steps"), testConfig.Environment, releases, inputImagesSeen)
-		if testConfig.ClusterProfileLiteral != nil {
+		if clusterProfile := testConfig.ClusterProfileLiteralOrLegacy(); clusterProfile != nil {
 			clusterCount++
-			validationErrors = append(validationErrors, v.validateClusterProfile(fieldRoot, testConfig.ClusterProfileLiteral.Name, test.As, metadata)...)
+			validationErrors = append(validationErrors, v.validateClusterProfile(fieldRoot, clusterProfile.Name, test.As, metadata)...)
 		}
 		validationErrors = append(validationErrors, validateLeases(context.addField("leases"), testConfig.Leases)...)
 		for i, s := range testConfig.Pre {

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -672,6 +672,8 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"            # all previous `pre` and `test` steps were successful. The given step must explicitly\n" +
 	"            # ask for being skipped by setting the OptionalOnSuccess flag to true.\n" +
 	"            allow_skip_on_success: false\n" +
+	"            # ClusterProfile is deprecated; retained for configs resolved by older configresolver builds.\n" +
+	"            cluster_profile: ' '\n" +
 	"            # ClusterProfileLiteral defines the profile/cloud provider for end-to-end test steps.\n" +
 	"            cluster_profile_literal:\n" +
 	"                cluster_type: ' '\n" +
@@ -1610,6 +1612,8 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"        # all previous `pre` and `test` steps were successful. The given step must explicitly\n" +
 	"        # ask for being skipped by setting the OptionalOnSuccess flag to true.\n" +
 	"        allow_skip_on_success: false\n" +
+	"        # ClusterProfile is deprecated; retained for configs resolved by older configresolver builds.\n" +
+	"        cluster_profile: ' '\n" +
 	"        # ClusterProfileLiteral defines the profile/cloud provider for end-to-end test steps.\n" +
 	"        cluster_profile_literal:\n" +
 	"            cluster_type: ' '\n" +


### PR DESCRIPTION
/cc @danilo-gemoli 

Too many [affected](https://search.dptools.openshift.org/?search=%2Fbin%2Fbash%3A+line+11%3A+CLUSTER_PROFILE_DIR%3A+unbound+variable&maxAge=6h&context=1&type=all&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job) jobs related to https://github.com/openshift/ci-tools/pull/5247 

Accept legacy cluster_profile in resolved multi-stage configs when cluster_profile_literal is missing, restoring cluster profile secret mounts and CLUSTER_PROFILE_DIR during configresolver/ci-operator rollout skew.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix for Job Failures from PR 5247

This PR restores backward compatibility for legacy `cluster_profile` configuration in multi-stage tests, fixing widespread job failures that occurred after PR 5247. The issue arose during the rollout period when older configurations from configresolver still emitted the legacy `cluster_profile` format, but the code had been updated to only recognize the new `cluster_profile_literal` format.

## Key Changes

A new helper method `ClusterProfileLiteralOrLegacy()` is introduced to the `MultiStageTestConfigurationLiteral` type that intelligently resolves cluster profile configuration by:
- First checking for the new `ClusterProfileLiteral` format
- Falling back to translating legacy `ClusterProfile` (string-based) data into the new format
- Automatically applying the default cluster profile secret name when converting legacy configs

The method is now used consistently across the codebase in:
- **Configuration API** (`pkg/api/types.go`): Core resolution logic for cluster profile names
- **Job generation** (`pkg/prowgen/jobbase.go`): Properly labeling jobs with cluster profile and cluster type information
- **CI operator** (`pkg/steps/multi_stage/multi_stage.go`, `pkg/defaults/defaults.go`): Building multi-stage test steps with correct cluster profile data
- **Resource allocation** (`pkg/api/leases.go`): Selecting the correct cluster profile when computing step leases
- **Configuration validation** (`pkg/validation/test.go`): Validating cluster profile ownership for both formats

## Impact

This change ensures that jobs using legacy cluster profile configuration will continue to work correctly, restoring both cluster profile secret mounts and the `CLUSTER_PROFILE_DIR` environment variable. The fix maintains compatibility during the configresolver and ci-operator rollout period, allowing older configurations to coexist with the new format without causing job failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->