### PR TITLE
fix: read dockerfiles from extra-ref clone paths

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -872,14 +872,11 @@ func runtimeStepConfigsForBuild(
 			if root.FromRepository {
 				path := "."        // By default, the path will be the working directory
 				if len(refs) > 1 { // If we are getting the build root image for a specific ref we must determine the absolute path
-					var matchingRefs []prowapi.Refs
-					for _, r := range refs {
-						if ref == fmt.Sprintf("%s.%s", r.Org, r.Repo) {
-							matchingRefs = append(matchingRefs, r)
+					matchingRefs := matchingRefsForImage(ref, jobSpec)
+					if len(matchingRefs) == 0 {
+						if primaryRef := determinePrimaryRef(jobSpec, injectedTest); primaryRef != nil {
+							matchingRefs = append(matchingRefs, *primaryRef)
 						}
-					}
-					if len(matchingRefs) == 0 { // If we didn't find anything, use the primary refs
-						matchingRefs = append(matchingRefs, *determinePrimaryRef(jobSpec, injectedTest))
 					}
 					path = decorate.DetermineWorkDir(codeMountPath, matchingRefs)
 				}
@@ -920,7 +917,7 @@ func runtimeStepConfigsForBuild(
 	buildSteps = append(buildSteps, getSourceStepsForJobSpec(jobSpec, injectedTest)...)
 
 	// Detect Dockerfile inputs for project images and add InputImageTagStepConfiguration entries
-	dockerfileInputSteps, images := detectDockerfileInputs(config.Images.Items, config.BaseImages, readFile)
+	dockerfileInputSteps, images := detectDockerfileInputs(config.Images.Items, config.BaseImages, readFile, jobSpec)
 	config.Images.Items = images
 	buildSteps = append(buildSteps, dockerfileInputSteps...)
 
@@ -936,10 +933,10 @@ type dockerfileDetails struct {
 // detectDockerfileInputs reads Dockerfiles for project images and detects registry.ci.openshift.org
 // references that should be added as base images. It returns any required InputImageTagStepConfiguration steps to
 // import the detected base images, as well as an updated list of image configurations with the detected inputs added
-func detectDockerfileInputs(images []api.ProjectDirectoryImageBuildStepConfiguration, baseImages map[string]api.ImageStreamTagReference, readFile readFile) ([]api.StepConfiguration, []api.ProjectDirectoryImageBuildStepConfiguration) {
+func detectDockerfileInputs(images []api.ProjectDirectoryImageBuildStepConfiguration, baseImages map[string]api.ImageStreamTagReference, readFile readFile, jobSpec *api.JobSpec) ([]api.StepConfiguration, []api.ProjectDirectoryImageBuildStepConfiguration) {
 	var steps []api.StepConfiguration
 	for i, image := range images {
-		dockerfileDetails, err := readDockerfileForImage(image, readFile)
+		dockerfileDetails, err := readDockerfileForImage(image, readFile, jobSpec)
 		if err != nil {
 			logrus.WithError(err).WithField("image", image.To).Debug("Failed to read Dockerfile for input detection, skipping")
 			continue
@@ -952,9 +949,23 @@ func detectDockerfileInputs(images []api.ProjectDirectoryImageBuildStepConfigura
 	return steps, images
 }
 
+// matchingRefsForImage returns prowapi.Refs from jobSpec whose org.repo identifier matches imageRef.
+func matchingRefsForImage(imageRef string, jobSpec *api.JobSpec) []prowapi.Refs {
+	var refs []prowapi.Refs
+	if jobSpec.Refs != nil && imageRef == fmt.Sprintf("%s.%s", jobSpec.Refs.Org, jobSpec.Refs.Repo) {
+		refs = append(refs, *jobSpec.Refs)
+	}
+	for _, ref := range jobSpec.ExtraRefs {
+		if imageRef == fmt.Sprintf("%s.%s", ref.Org, ref.Repo) {
+			refs = append(refs, ref)
+		}
+	}
+	return refs
+}
+
 // readDockerfileForImage reads the Dockerfile content for a given image configuration
 // Returns the dockerfileDetails and any error encountered
-func readDockerfileForImage(image api.ProjectDirectoryImageBuildStepConfiguration, readFile readFile) (dockerfileDetails, error) {
+func readDockerfileForImage(image api.ProjectDirectoryImageBuildStepConfiguration, readFile readFile, jobSpec *api.JobSpec) (dockerfileDetails, error) {
 	if image.DockerfileLiteral != nil {
 		return dockerfileDetails{content: []byte(*image.DockerfileLiteral), path: "dockerfile_literal"}, nil
 	}
@@ -965,6 +976,16 @@ func readDockerfileForImage(image api.ProjectDirectoryImageBuildStepConfiguratio
 	dockerfilePath := fmt.Sprintf("./%s", details.path)
 	if image.ContextDir != "" {
 		dockerfilePath = fmt.Sprintf("%s/%s", image.ContextDir, details.path)
+	}
+	if image.Ref != "" {
+		if matchingRefs := matchingRefsForImage(image.Ref, jobSpec); len(matchingRefs) > 0 {
+			basePath := decorate.DetermineWorkDir(codeMountPath, matchingRefs)
+			if image.ContextDir != "" {
+				dockerfilePath = filepath.Join(basePath, image.ContextDir, details.path)
+			} else {
+				dockerfilePath = filepath.Join(basePath, details.path)
+			}
+		}
 	}
 	details.path = dockerfilePath
 

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -2323,6 +2323,7 @@ func TestReadDockerfileForImage(t *testing.T) {
 	testCases := []struct {
 		name            string
 		image           api.ProjectDirectoryImageBuildStepConfiguration
+		jobSpec         *api.JobSpec
 		readFile        readFile
 		expectedContent string
 		expectedPath    string
@@ -2396,6 +2397,38 @@ func TestReadDockerfileForImage(t *testing.T) {
 			expectError:     false,
 		},
 		{
+			name: "extra ref dockerfile path",
+			image: api.ProjectDirectoryImageBuildStepConfiguration{
+				To:  "hello-openshift-openshift.origin",
+				Ref: "openshift.origin",
+				ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
+					DockerfilePath: "Dockerfile.rhel",
+					ContextDir:     "images/hello-openshift",
+				},
+			},
+			jobSpec: &api.JobSpec{
+				JobSpec: downwardapi.JobSpec{
+					Refs: &prowapi.Refs{Org: "openshift", Repo: "cluster-cloud-controller-manager-operator", BaseRef: "release-4.22"},
+					ExtraRefs: []prowapi.Refs{{
+						Org:       "openshift",
+						Repo:      "origin",
+						BaseRef:   "release-4.22",
+						PathAlias: "github.com/openshift/origin",
+					}},
+				},
+			},
+			readFile: func(path string) ([]byte, error) {
+				want := "/home/prow/go/src/github.com/openshift/origin/images/hello-openshift/Dockerfile.rhel"
+				if path == want {
+					return []byte("FROM registry.ci.openshift.org/ocp/4.16:base-rhel9"), nil
+				}
+				return nil, fmt.Errorf("file not found: %s", path)
+			},
+			expectedContent: "FROM registry.ci.openshift.org/ocp/4.16:base-rhel9",
+			expectedPath:    "/home/prow/go/src/github.com/openshift/origin/images/hello-openshift/Dockerfile.rhel",
+			expectError:     false,
+		},
+		{
 			name: "file not found",
 			image: api.ProjectDirectoryImageBuildStepConfiguration{
 				To: "test-image",
@@ -2409,7 +2442,7 @@ func TestReadDockerfileForImage(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			details, err := readDockerfileForImage(tc.image, tc.readFile)
+			details, err := readDockerfileForImage(tc.image, tc.readFile, tc.jobSpec)
 
 			if tc.expectError {
 				if err == nil {


### PR DESCRIPTION
PRPQR builds hello-openshift from extra ref openshift.origin, but Dockerfile auto-detection reads from wrong working directory and silently skips input wiring and the build pulls hardcoded [registry.ci](http://registry.ci/) URLs that are now reference only.

https://redhat-internal.slack.com/archives/CBN38N3MW/p1781697111353389?thread_ts=1781621737.997829&cid=CBN38N3MW

https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-origin-31303-openshift-cluster-cloud-controller-manager-operator-471-nightly-4.22-e2e-vsphere-ovn-hybrid-env-techpreview/2067199635323097088



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes Dockerfile auto-detection for ci-operator builds that fetch sources from additional reference clone paths (PRPQR builds). Previously, Dockerfile detection could look in the wrong working directory for ref-specific image builds, causing the ci-operator to silently skip wiring detected inputs and fall back to hardcoded `registry.ci.openshift.org` references (which can now be reference-only and fail). The change is motivated by a Slack discussion and corroborated by a failing Prow build log.

## Changes

### Reference-aware workdir/Dockerfile resolution
- `pkg/defaults/defaults.go`
  - Makes Dockerfile input detection ref-aware by threading `JobSpec` through:
    - `runtimeStepConfigsForBuild(...)` now passes `jobSpec` into `detectDockerfileInputs(...)`.
    - `detectDockerfileInputs(...)` now calls `readDockerfileForImage(image, readFile, jobSpec)` while iterating project images.
    - `readDockerfileForImage(...)` now:
      - Computes which `prowapi.Refs` apply to the image via a new `matchingRefsForImage(image.Ref, jobSpec)` helper (matches `org.repo` against `jobSpec.Refs` and `jobSpec.ExtraRefs`).
      - Uses `decorate.DetermineWorkDir(codeMountPath, matchingRefs)` to resolve the correct ref clone working directory.
      - Builds the final Dockerfile path by joining the resolved workdir with `image.ContextDir` (if set) and the Dockerfile path.

### Related behavior for build-root workdir selection
- `runtimeStepConfigsForBuild(...)` also uses `matchingRefsForImage(...)` when determining the workdir for ref-specific build roots, falling back to `determinePrimaryRef(...)` when no matching refs are found.

## Tests

- `pkg/defaults/defaults_test.go`
  - Updates `TestReadDockerfileForImage` to pass `jobSpec` into `readDockerfileForImage`.
  - Adds coverage for the “extra ref dockerfile path” case, validating Dockerfile reads from the computed filesystem path based on `jobSpec.ExtraRefs` (including `PathAlias`).

## Impact for CI Operators

CI jobs that build with multiple repositories (primary + `ExtraRefs`) will now reliably detect and wire Dockerfile inputs from the correct cloned ref directory, avoiding the silent skip that previously led to hardcoded registry fallbacks.

## Validation note

The author requested running end-to-end testing using `/test e2e` to validate the fix in PRPQR contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->