### PR TITLE
Add cluster profile for powervs-hcp

### DIFF
--- a/pkg/api/clusterprofile.go
+++ b/pkg/api/clusterprofile.go
@@ -115,6 +115,7 @@ const (
 	ClusterProfilePOWERVS7                   ClusterProfile = "powervs-7"
 	ClusterProfilePOWERVS8                   ClusterProfile = "powervs-8"
 	ClusterProfilePOWERVS9                   ClusterProfile = "powervs-9"
+        ClusterProfilePOWERVSHCP                 ClusterProfile = "powervs-hcp"
 	ClusterProfileLibvirtPpc64le             ClusterProfile = "libvirt-ppc64le"
 	ClusterProfileLibvirtPpc64leS2S          ClusterProfile = "libvirt-ppc64le-s2s"
 	ClusterProfileLibvirtS390x               ClusterProfile = "libvirt-s390x"
@@ -336,6 +337,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfilePOWERVS7,
 		ClusterProfilePOWERVS8,
 		ClusterProfilePOWERVS9,
+                ClusterProfilePOWERVSHCP,
 		ClusterProfileKubevirt,
 		ClusterProfileLibvirtPpc64le,
 		ClusterProfileLibvirtPpc64leS2S,
@@ -608,6 +610,8 @@ func (p ClusterProfile) ClusterType() string {
 		return "powervs-8"
 	case ClusterProfilePOWERVS9:
 		return "powervs-9"
+        case ClusterProfilePOWERVSHCP:
+                return "powervs-hcp"
 	case ClusterProfileLibvirtPpc64le:
 		return "libvirt-ppc64le"
 	case ClusterProfileLibvirtPpc64leS2S:
@@ -955,6 +959,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "powervs-8-quota-slice"
 	case ClusterProfilePOWERVS9:
 		return "powervs-9-quota-slice"
+        case ClusterProfilePOWERVSHCP:
+                return "powervs-hcp-quota-slice"
 	case ClusterProfileLibvirtPpc64le:
 		return "libvirt-ppc64le-quota-slice"
 	case ClusterProfileLibvirtPpc64leS2S:
@@ -1194,7 +1200,7 @@ func LeaseTypeFromClusterType(t string) (string, error) {
 		"ibmcloud-multi-s390x", "nutanix", "nutanix-qe", "nutanix-qe-dis", "nutanix-qe-zone", "nutanix-qe-gpu",
 		"nutanix-qe-flow", "openstack", "openstack-osuosl", "openstack-vexxhost", "openstack-ppc64le",
 		"openstack-nerc-dev", "vsphere", "ovirt", "packet", "packet-edge", "powervc-1", "powervs-multi-1",
-		"powervs-1", "powervs-2", "powervs-3", "powervs-4", "powervs-5", "powervs-6", "powervs-7", "powervs-8", "powervs-9",
+		"powervs-1", "powervs-2", "powervs-3", "powervs-4", "powervs-5", "powervs-6", "powervs-7", "powervs-8", "powervs-9", "powervs-hcp",
 		"kubevirt", "aws-cpaas", "osd-ephemeral", "gcp-virtualization", "aws-virtualization",
 		"azure-virtualization", "hypershift-aws", "hypershift-aks", "hypershift-azure",
 		"hypershift-powervs", "hypershift-powervs-cb", "hypershift-gcp", "aws-mco-qe",

--- a/pkg/api/clusterprofile.go
+++ b/pkg/api/clusterprofile.go
@@ -115,7 +115,7 @@ const (
 	ClusterProfilePOWERVS7                   ClusterProfile = "powervs-7"
 	ClusterProfilePOWERVS8                   ClusterProfile = "powervs-8"
 	ClusterProfilePOWERVS9                   ClusterProfile = "powervs-9"
-        ClusterProfilePOWERVSHCP                 ClusterProfile = "powervs-hcp"
+    ClusterProfilePOWERVSHCP                 ClusterProfile = "powervs-hcp"
 	ClusterProfileLibvirtPpc64le             ClusterProfile = "libvirt-ppc64le"
 	ClusterProfileLibvirtPpc64leS2S          ClusterProfile = "libvirt-ppc64le-s2s"
 	ClusterProfileLibvirtS390x               ClusterProfile = "libvirt-s390x"
@@ -337,7 +337,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfilePOWERVS7,
 		ClusterProfilePOWERVS8,
 		ClusterProfilePOWERVS9,
-                ClusterProfilePOWERVSHCP,
+        ClusterProfilePOWERVSHCP,
 		ClusterProfileKubevirt,
 		ClusterProfileLibvirtPpc64le,
 		ClusterProfileLibvirtPpc64leS2S,
@@ -610,8 +610,8 @@ func (p ClusterProfile) ClusterType() string {
 		return "powervs-8"
 	case ClusterProfilePOWERVS9:
 		return "powervs-9"
-        case ClusterProfilePOWERVSHCP:
-                return "powervs-hcp"
+    case ClusterProfilePOWERVSHCP:
+        return "powervs-hcp"
 	case ClusterProfileLibvirtPpc64le:
 		return "libvirt-ppc64le"
 	case ClusterProfileLibvirtPpc64leS2S:
@@ -959,8 +959,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "powervs-8-quota-slice"
 	case ClusterProfilePOWERVS9:
 		return "powervs-9-quota-slice"
-        case ClusterProfilePOWERVSHCP:
-                return "powervs-hcp-quota-slice"
+    case ClusterProfilePOWERVSHCP:
+        return "powervs-hcp-quota-slice"
 	case ClusterProfileLibvirtPpc64le:
 		return "libvirt-ppc64le-quota-slice"
 	case ClusterProfileLibvirtPpc64leS2S:


### PR DESCRIPTION
Add cluster profile for powervs-hcp

**Changes:

Added ClusterProfilePOWERVSHCP constant with value "powervs-hcp"
Added profile to ClusterProfiles() function
Added quota slice case for powervs-hcp-quota-slice
Added powervs-hcp to LeaseTypeFromClusterType function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

A detailed high-level summary could not be generated for this review. Here is an overview derived from the analyzed file changes:

- **pkg/api/clusterprofile.go**: ## AI-generated summary of changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->