### PR TITLE
CORS-4510: Add GCD cluster profile

### DIFF
--- a/pkg/api/clusterprofile.go
+++ b/pkg/api/clusterprofile.go
@@ -84,6 +84,7 @@ const (
 	ClusterProfileEquinixOcpMetalQE          ClusterProfile = "equinix-ocp-metal-qe"
 	ClusterProfileEquinixOcpHCP              ClusterProfile = "equinix-ocp-hcp"
 	ClusterProfileFleetManagerQE             ClusterProfile = "fleet-manager-qe"
+	ClusterProfileGCD                        ClusterProfile = "gcd"
 	ClusterProfileGCPQE                      ClusterProfile = "gcp-qe"
 	ClusterProfileGCPQEC3Metal               ClusterProfile = "gcp-qe-c3-metal"
 	ClusterProfileGCPAutoReleaseQE           ClusterProfile = "gcp-autorelease-qe"
@@ -302,6 +303,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileEquinixOcpMetalQE,
 		ClusterProfileEquinixOcpHCP,
 		ClusterProfileFleetManagerQE,
+		ClusterProfileGCD,
 		ClusterProfileGCP,
 		ClusterProfileGCP2,
 		ClusterProfileGCP3,
@@ -558,6 +560,7 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileEquinixOcpHCP:
 		return "equinix-ocp-metal"
 	case
+		ClusterProfileGCD,
 		ClusterProfileGCPQE,
 		ClusterProfileGCPQEC3Metal,
 		ClusterProfileGCPAutoReleaseQE,
@@ -896,6 +899,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "equinix-ocp-hcp-quota-slice"
 	case ClusterProfileFleetManagerQE:
 		return "fleet-manager-qe-quota-slice"
+	case ClusterProfileGCD:
+		return "gcd-quota-slice"
 	case ClusterProfileGCPQE:
 		return "gcp-qe-quota-slice"
 	case ClusterProfileGCPQEC3Metal:
@@ -1195,7 +1200,7 @@ func LeaseTypeFromClusterType(t string) (string, error) {
 	case
 		"aws", "aws-us-east-1", "aws-c2s", "aws-china", "aws-usgov", "aws-sc2s", "aws-eusc", "aws-osd-msp", "aws-opendatahub",
 		"alibaba", "azure-2", "azure4", "azure-arm64", "azurestack", "azuremag", "equinix-ocp-metal",
-		"gcp", "gcp-arm64", "gcp-opendatahub", "libvirt-ppc64le", "libvirt-ppc64le-s2s", "libvirt-s390x",
+		"gcd", "gcp", "gcp-arm64", "gcp-opendatahub", "libvirt-ppc64le", "libvirt-ppc64le-s2s", "libvirt-s390x",
 		"libvirt-s390x-1", "libvirt-s390x-2", "libvirt-s390x-amd64", "libvirt-s390x-vpn", "libvirt-s390x-vpn-oz", "libvirt-s390x-vpn-virt", "ibmcloud-multi-ppc64le",
 		"ibmcloud-multi-s390x", "nutanix", "nutanix-qe", "nutanix-qe-dis", "nutanix-qe-zone", "nutanix-qe-gpu",
 		"nutanix-qe-flow", "openstack", "openstack-osuosl", "openstack-vexxhost", "openstack-ppc64le",


### PR DESCRIPTION
## Summary
- Register `ClusterProfileGCD` ("gcd") for Google Cloud Dedicated
- Maps to cluster type "gcp" (reuses existing GCP cloud type)
- Lease type: "gcd-quota-slice"
- Added to `LeaseTypeFromClusterType` for template-based test compatibility

## Context
This is part of [CORS-4508](https://redhat.atlassian.net/browse/CORS-4508): setting up Workload Identity Federation authentication for the OpenShift installer on Google Cloud Dedicated (Berlin environment).

The corresponding openshift/release PR will add the cluster profile config, Boskos quota slices, secret bootstrap entry, and installer CI job configuration.


Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR extends OpenShift CI’s cluster profile support to include Google Cloud Dedicated (GCD) by introducing a new `gcd` cluster profile in the CI API layer. CI jobs can now reference `gcd` as a first-class target, while the tooling reuses the existing Google Cloud (GCP) provider implementation under the hood.

## Changes

**pkg/api/clusterprofile.go**
- Added a new exported cluster profile constant: `ClusterProfileGCD` (`"gcd"`).
- Registered `gcd` in the list of supported cluster profiles (`ClusterProfiles()`).
- Updated profile-to-cloud-type mapping so `gcd` is treated like the existing GCP-based cloud type.
- Added `gcd` to `LeaseTypeFromClusterType` and wired the profile to a dedicated lease type: `gcd-quota-slice`.
  - This keeps template-based CI tests compatible by ensuring the lease-type resolution logic understands the new `gcd` cluster type.

## Impact

CI operators and job authors can configure and run tests against Google Cloud Dedicated clusters by selecting the new `gcd` profile, without duplicating provider logic. The implementation also ensures quota-slice lease handling works correctly for GCD (`gcd-quota-slice`), which is a prerequisite for the Berlin environment setup related to Workload Identity Federation authentication for the OpenShift installer ([CORS-4508](https://redhat.atlassian.net/browse/CORS-4508)).

## Test/validation notes

The PR triggered end-to-end testing and retesting requests (`/test e2e` and `/retest e2e`) and included coordination on CI overrides for e2e execution. An approval was provided after review and naming verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->