### PR TITLE
DPTP-2938: pod-scaler limit-only decrease with configurable escalation

### DIFF
--- a/cmd/pod-scaler/admission.go
+++ b/cmd/pod-scaler/admission.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"math/rand"
 	"net/http"
 	"sort"
@@ -37,7 +38,7 @@ import (
 	"github.com/openshift/ci-tools/pkg/steps"
 )
 
-func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Interface, kubeClient kubernetes.Interface, loaders map[string][]*cacheReloader, mutateResourceLimits bool, cpuCap int64, memoryCap string, cpuPriorityScheduling int64, percentageMeasured float64, measuredPodCPUIncrease float64, systemReservedCPU int64, authoritativeCPU, authoritativeMemory, authoritativeCPUDryRun, authoritativeMemoryDryRun bool, authoritativeCPUMaxReductionPercent, authoritativeMemoryMaxReductionPercent float64, reporter results.PodScalerReporter) {
+func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Interface, kubeClient kubernetes.Interface, loaders map[string][]*cacheReloader, mutateResourceLimits bool, cpuCap int64, memoryCap string, cpuPriorityScheduling int64, percentageMeasured float64, measuredPodCPUIncrease float64, systemReservedCPU int64, authoritativeCPU, authoritativeMemory, authoritativeCPUDryRun, authoritativeMemoryDryRun bool, authoritativeCPUMaxReductionPercent, authoritativeMemoryMaxReductionPercent float64, escalations *escalationServer, reporter results.PodScalerReporter) {
 	logger := logrus.WithField("component", "pod-scaler admission")
 	logger.Infof("Initializing admission webhook server with %d loaders.", len(loaders))
 	if authoritativeCPUDryRun || authoritativeMemoryDryRun {
@@ -57,7 +58,7 @@ func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Int
 		Port:    port,
 		CertDir: certDir,
 	})
-	server.Register("/pods", &webhook.Admission{Handler: &podMutator{logger: logger, client: client, decoder: decoder, resources: resources, mutateResourceLimits: mutateResourceLimits, cpuCap: cpuCap, memoryCap: memoryCap, cpuPriorityScheduling: cpuPriorityScheduling, percentageMeasured: percentageMeasured, measuredPodCPUIncrease: measuredPodCPUIncrease, nodeCache: nodeCache, authoritativeCPU: authoritativeCPU, authoritativeMemory: authoritativeMemory, authoritativeCPUDryRun: authoritativeCPUDryRun, authoritativeMemoryDryRun: authoritativeMemoryDryRun, authoritativeCPUMaxReductionPercent: authoritativeCPUMaxReductionPercent, authoritativeMemoryMaxReductionPercent: authoritativeMemoryMaxReductionPercent, reporter: reporter}})
+	server.Register("/pods", &webhook.Admission{Handler: &podMutator{logger: logger, client: client, decoder: decoder, resources: resources, mutateResourceLimits: mutateResourceLimits, cpuCap: cpuCap, memoryCap: memoryCap, cpuPriorityScheduling: cpuPriorityScheduling, percentageMeasured: percentageMeasured, measuredPodCPUIncrease: measuredPodCPUIncrease, nodeCache: nodeCache, authoritativeCPU: authoritativeCPU, authoritativeMemory: authoritativeMemory, authoritativeCPUDryRun: authoritativeCPUDryRun, authoritativeMemoryDryRun: authoritativeMemoryDryRun, authoritativeCPUMaxReductionPercent: authoritativeCPUMaxReductionPercent, authoritativeMemoryMaxReductionPercent: authoritativeMemoryMaxReductionPercent, escalations: escalations, reporter: reporter}})
 	logger.Info("Serving admission webhooks.")
 	if err := server.Start(interrupts.Context()); err != nil {
 		logrus.WithError(err).Fatal("Failed to serve webhooks.")
@@ -82,6 +83,7 @@ type podMutator struct {
 	authoritativeMemoryDryRun              bool
 	authoritativeCPUMaxReductionPercent    float64
 	authoritativeMemoryMaxReductionPercent float64
+	escalations                            *escalationServer
 	reporter                               results.PodScalerReporter
 }
 
@@ -131,7 +133,7 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 		m.setMeasuredLabel(pod, false, logger)
 	}
 
-	mutatePodResources(pod, m.resources, m.mutateResourceLimits, m.cpuCap, m.memoryCap, isMeasured, m.nodeCache, m.measuredPodCPUIncrease, m.authoritativeCPU, m.authoritativeMemory, m.authoritativeCPUDryRun, m.authoritativeMemoryDryRun, m.authoritativeCPUMaxReductionPercent, m.authoritativeMemoryMaxReductionPercent, m.reporter, logger)
+	mutatePodResources(pod, m.resources, m.mutateResourceLimits, m.cpuCap, m.memoryCap, isMeasured, m.nodeCache, m.measuredPodCPUIncrease, m.authoritativeCPU, m.authoritativeMemory, m.authoritativeCPUDryRun, m.authoritativeMemoryDryRun, m.authoritativeCPUMaxReductionPercent, m.authoritativeMemoryMaxReductionPercent, m.escalations, m.reporter, logger)
 	m.addPriorityClass(pod)
 
 	marshaledPod, err := json.Marshal(pod)
@@ -232,8 +234,8 @@ func mutatePodLabels(pod *corev1.Pod, build *buildv1.Build) {
 
 var authoritativeMinCPURequest = resource.MustParse("10m")
 
-// useOursIfLarger updates fields in theirs when ours are larger, or lowers them when authoritative mode allows.
-func useOursIfLarger(allOfOurs, allOfTheirs *corev1.ResourceRequirements, workloadName, workloadType string, isMeasured bool, workloadClass string, authoritativeCPU, authoritativeMemory, authoritativeCPUDryRun, authoritativeMemoryDryRun bool, authoritativeCPUMaxReductionPercent, authoritativeMemoryMaxReductionPercent float64, reporter results.PodScalerReporter, logger *logrus.Entry) {
+// useOursIfLarger updates fields in theirs when ours are larger.
+func useOursIfLarger(allOfOurs, allOfTheirs *corev1.ResourceRequirements, workloadName, workloadType string, isMeasured bool, workloadClass string, reporter results.PodScalerReporter, logger *logrus.Entry) {
 	for _, item := range []*corev1.ResourceRequirements{allOfOurs, allOfTheirs} {
 		if item.Requests == nil {
 			item.Requests = corev1.ResourceList{}
@@ -281,76 +283,7 @@ func useOursIfLarger(allOfOurs, allOfTheirs *corev1.ResourceRequirements, worklo
 				}
 			} else if cmp < 0 {
 				fieldLogger.Debug("determined amount smaller than configured")
-				if isMeasured {
-					continue
-				}
-				authoritative := authoritativeMemory
-				dryRun := authoritativeMemoryDryRun
-				maxReductionPercent := authoritativeMemoryMaxReductionPercent
-				if field == corev1.ResourceCPU {
-					authoritative = authoritativeCPU
-					dryRun = authoritativeCPUDryRun
-					maxReductionPercent = authoritativeCPUMaxReductionPercent
-				}
-				if !authoritative && !dryRun {
-					continue
-				}
-				theirValue := their.AsApproximateFloat64()
-				if theirValue == 0 {
-					if field == corev1.ResourceCPU {
-						if our.Cmp(authoritativeMinCPURequest) < 0 {
-							our = authoritativeMinCPURequest
-						}
-						if our.Cmp(their) >= 0 {
-							continue
-						}
-					}
-					if dryRun {
-						fieldLogger.WithFields(logrus.Fields{
-							"event":         "authoritative_decrease_dry_run",
-							"workloadClass": workloadClass,
-							"would_set":     our.String(),
-							"authoritative": authoritative,
-						}).Info("authoritative decrease dry-run")
-						continue
-					}
-					(*pair.theirs)[field] = our
-					continue
-				}
-				ourValue := our.AsApproximateFloat64()
-				if 1.0-(ourValue/theirValue) < 0.05 {
-					continue
-				}
-				reductionCapped := false
-				if 1.0-(ourValue/theirValue) > maxReductionPercent {
-					switch field {
-					case corev1.ResourceCPU:
-						our.SetMilli(int64(float64(their.MilliValue()) * (1.0 - maxReductionPercent)))
-					case corev1.ResourceMemory:
-						our.Set(int64(theirValue * (1.0 - maxReductionPercent)))
-					}
-					reductionCapped = true
-				}
-				if field == corev1.ResourceCPU {
-					if our.Cmp(authoritativeMinCPURequest) < 0 {
-						our = authoritativeMinCPURequest
-					}
-					if our.Cmp(their) >= 0 {
-						continue
-					}
-				}
-				if dryRun {
-					fieldLogger.WithFields(logrus.Fields{
-						"event":            "authoritative_decrease_dry_run",
-						"workloadClass":    workloadClass,
-						"would_set":        our.String(),
-						"authoritative":    authoritative,
-						"reduction_pct":    (1.0 - our.AsApproximateFloat64()/theirValue) * 100,
-						"reduction_capped": reductionCapped,
-					}).Info("authoritative decrease dry-run")
-					continue
-				}
-				(*pair.theirs)[field] = our
+				continue
 			} else {
 				fieldLogger.Debug("determined amount equal to configured")
 			}
@@ -411,7 +344,7 @@ func preventUnschedulableWithCaps(resources *corev1.ResourceRequirements, cpuCap
 	}
 }
 
-func mutatePodResources(pod *corev1.Pod, server *resourceServer, mutateResourceLimits bool, cpuCap int64, memoryCap string, isMeasured bool, nodeCache *nodeAllocatableCache, measuredPodCPUIncrease float64, authoritativeCPU, authoritativeMemory, authoritativeCPUDryRun, authoritativeMemoryDryRun bool, authoritativeCPUMaxReductionPercent, authoritativeMemoryMaxReductionPercent float64, reporter results.PodScalerReporter, logger *logrus.Entry) {
+func mutatePodResources(pod *corev1.Pod, server *resourceServer, mutateResourceLimits bool, cpuCap int64, memoryCap string, isMeasured bool, nodeCache *nodeAllocatableCache, measuredPodCPUIncrease float64, authoritativeCPU, authoritativeMemory, authoritativeCPUDryRun, authoritativeMemoryDryRun bool, authoritativeCPUMaxReductionPercent, authoritativeMemoryMaxReductionPercent float64, escalations *escalationServer, reporter results.PodScalerReporter, logger *logrus.Entry) {
 	workloadClass := pod.Labels[ciWorkloadLabel]
 
 	mutateResources := func(containers []corev1.Container) {
@@ -463,10 +396,13 @@ func mutatePodResources(pod *corev1.Pod, server *resourceServer, mutateResourceL
 				logger.Debugf("recommendation exists for: %s (using max of measured and unmeasured)", containers[i].Name)
 				workloadType := determineWorkloadType(pod.Annotations, pod.Labels)
 				workloadName := determineWorkloadName(pod.Name, containers[i].Name, workloadType, pod.Labels)
-				useOursIfLarger(&resources, &containers[i].Resources, workloadName, workloadType, isMeasured, workloadClass, authoritativeCPU, authoritativeMemory, authoritativeCPUDryRun, authoritativeMemoryDryRun, authoritativeCPUMaxReductionPercent, authoritativeMemoryMaxReductionPercent, reporter, logger)
+				useOursIfLarger(&resources, &containers[i].Resources, workloadName, workloadType, isMeasured, workloadClass, reporter, logger)
 				if mutateResourceLimits {
 					reconcileLimits(&containers[i].Resources)
 				}
+				applyFailureEscalation(&containers[i].Resources, workloadType, workloadName, escalations, logger)
+				applyAuthoritativeLimitDecrease(&resources, &containers[i].Resources, workloadName, workloadType, isMeasured, workloadClass, authoritativeCPU, authoritativeMemory, authoritativeCPUDryRun, authoritativeMemoryDryRun, authoritativeCPUMaxReductionPercent, authoritativeMemoryMaxReductionPercent, escalations, logger)
+				clampRequestsToLimits(&containers[i].Resources)
 			}
 			preventUnschedulable(&containers[i].Resources, cpuCap, memoryCap, logger)
 		}
@@ -792,4 +728,238 @@ func (c *nodeAllocatableCache) getMaxCPUForWorkload(workloadType string) int64 {
 	}
 
 	return maxMeasuredCPUCores
+}
+
+type escalationServer struct {
+	cache  Cache
+	logger *logrus.Entry
+	lock   sync.RWMutex
+	index  podscaler.EscalationIndex
+	factor float64
+}
+
+func newEscalationServer(cache Cache, factor float64) *escalationServer {
+	s := &escalationServer{
+		cache:  cache,
+		logger: logrus.WithField("component", "pod-scaler escalation"),
+		index:  podscaler.EscalationIndex{},
+		factor: factor,
+	}
+	s.reload()
+	interrupts.TickLiteral(s.reload, time.Hour)
+	return s
+}
+
+func loadEscalationIndex(cache Cache, logger *logrus.Entry) podscaler.EscalationIndex {
+	data, err := loadFrom(cache, podscaler.EscalationsCacheName)
+	if err != nil {
+		if _, ok := err.(notExist); ok {
+			return podscaler.EscalationIndex{}
+		}
+		logger.WithError(err).Warn("Failed to load escalation index, starting fresh.")
+		return podscaler.EscalationIndex{}
+	}
+	index := podscaler.EscalationIndex{}
+	if err := json.Unmarshal(data, &index); err != nil {
+		logger.WithError(err).Warn("Failed to parse escalation index, starting fresh.")
+		return podscaler.EscalationIndex{}
+	}
+	return index
+}
+
+func (s *escalationServer) reload() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.index = loadEscalationIndex(s.cache, s.logger)
+}
+
+func (s *escalationServer) levels(workloadType, workloadName string) (memoryLevel, cpuLevel int) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	state, ok := s.index[podscaler.WorkloadKey(workloadType, workloadName)]
+	if !ok {
+		return 0, 0
+	}
+	return state.MemoryLevel, state.CPULevel
+}
+
+func (s *escalationServer) scaleQuantity(q resource.Quantity, level int) resource.Quantity {
+	if level <= 0 {
+		return q
+	}
+	multiplier := math.Pow(s.factor, float64(level))
+	scaled := q.AsApproximateFloat64() * multiplier
+	if q.Format == resource.DecimalSI {
+		return *resource.NewMilliQuantity(int64(scaled*1000), resource.DecimalSI)
+	}
+	return *resource.NewQuantity(int64(scaled), q.Format)
+}
+
+func applyFailureEscalation(resources *corev1.ResourceRequirements, workloadType, workloadName string, server *escalationServer, logger *logrus.Entry) {
+	if server == nil || resources == nil {
+		return
+	}
+	memoryLevel, cpuLevel := server.levels(workloadType, workloadName)
+	if memoryLevel == 0 && cpuLevel == 0 {
+		return
+	}
+	if resources.Requests == nil {
+		resources.Requests = corev1.ResourceList{}
+	}
+	if resources.Limits == nil {
+		resources.Limits = corev1.ResourceList{}
+	}
+	if cpuLevel > 0 {
+		if q, ok := resources.Requests[corev1.ResourceCPU]; ok {
+			resources.Requests[corev1.ResourceCPU] = server.scaleQuantity(q, cpuLevel)
+		}
+		if q, ok := resources.Limits[corev1.ResourceCPU]; ok {
+			resources.Limits[corev1.ResourceCPU] = server.scaleQuantity(q, cpuLevel)
+		}
+	}
+	if memoryLevel > 0 {
+		if q, ok := resources.Requests[corev1.ResourceMemory]; ok {
+			resources.Requests[corev1.ResourceMemory] = server.scaleQuantity(q, memoryLevel)
+		}
+		if q, ok := resources.Limits[corev1.ResourceMemory]; ok {
+			resources.Limits[corev1.ResourceMemory] = server.scaleQuantity(q, memoryLevel)
+		}
+	}
+	logger.WithFields(logrus.Fields{
+		"workloadType": workloadType,
+		"workloadName": workloadName,
+		"memory_level": memoryLevel,
+		"cpu_level":    cpuLevel,
+	}).Debug("applied failure escalation multiplier")
+}
+
+func storeEscalationIndex(cache Cache, index podscaler.EscalationIndex) error {
+	raw, err := json.Marshal(index)
+	if err != nil {
+		return err
+	}
+	var lastErr error
+	for i := 0; i < 5; i++ {
+		storeErr := storeTo(cache, podscaler.EscalationsCacheName, raw)
+		if storeErr == nil {
+			return nil
+		}
+		if errors.Is(storeErr, context.DeadlineExceeded) {
+			lastErr = storeErr
+			continue
+		}
+		return storeErr
+	}
+	if lastErr != nil {
+		return lastErr
+	}
+	return context.DeadlineExceeded
+}
+
+func applyAuthoritativeLimitDecrease(recommended, configured *corev1.ResourceRequirements, workloadName, workloadType string, isMeasured bool, workloadClass string, authoritativeCPU, authoritativeMemory, authoritativeCPUDryRun, authoritativeMemoryDryRun bool, authoritativeCPUMaxReductionPercent, authoritativeMemoryMaxReductionPercent float64, escalations *escalationServer, logger *logrus.Entry) {
+	if isMeasured || configured.Limits == nil {
+		return
+	}
+	memoryLevel, cpuLevel := 0, 0
+	if escalations != nil {
+		memoryLevel, cpuLevel = escalations.levels(workloadType, workloadName)
+	}
+	for _, field := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+		if field == corev1.ResourceCPU && cpuLevel > 0 {
+			continue
+		}
+		if field == corev1.ResourceMemory && memoryLevel > 0 {
+			continue
+		}
+		our := recommended.Requests[field]
+		if our.IsZero() {
+			continue
+		}
+		if field == corev1.ResourceCPU {
+			our.SetMilli(int64(float64(our.MilliValue()) * 1.2))
+		} else {
+			increased := our.AsApproximateFloat64() * 1.2
+			our.Set(int64(increased))
+		}
+		their, ok := configured.Limits[field]
+		if !ok || their.IsZero() {
+			continue
+		}
+		authoritative := authoritativeMemory
+		dryRun := authoritativeMemoryDryRun
+		maxReductionPercent := authoritativeMemoryMaxReductionPercent
+		if field == corev1.ResourceCPU {
+			authoritative = authoritativeCPU
+			dryRun = authoritativeCPUDryRun
+			maxReductionPercent = authoritativeCPUMaxReductionPercent
+		}
+		if !authoritative && !dryRun {
+			continue
+		}
+		fieldLogger := logger.WithFields(logrus.Fields{
+			"workloadName": workloadName,
+			"workloadType": workloadType,
+			"field":        field,
+			"resource":     "limit",
+			"determined":   our.String(),
+			"configured":   their.String(),
+		})
+		if our.Cmp(their) >= 0 {
+			continue
+		}
+		theirValue := their.AsApproximateFloat64()
+		ourValue := our.AsApproximateFloat64()
+		if 1.0-(ourValue/theirValue) < 0.05 {
+			continue
+		}
+		reductionCapped := false
+		if 1.0-(ourValue/theirValue) > maxReductionPercent {
+			switch field {
+			case corev1.ResourceCPU:
+				our.SetMilli(int64(float64(their.MilliValue()) * (1.0 - maxReductionPercent)))
+			case corev1.ResourceMemory:
+				our.Set(int64(theirValue * (1.0 - maxReductionPercent)))
+			}
+			reductionCapped = true
+		}
+		if field == corev1.ResourceCPU {
+			if our.Cmp(authoritativeMinCPURequest) < 0 {
+				our = authoritativeMinCPURequest
+			}
+			if our.Cmp(their) >= 0 {
+				continue
+			}
+		}
+		if dryRun {
+			fieldLogger.WithFields(logrus.Fields{
+				"event":            "authoritative_decrease_dry_run",
+				"workloadClass":    workloadClass,
+				"would_set":        our.String(),
+				"authoritative":    authoritative,
+				"reduction_pct":    (1.0 - our.AsApproximateFloat64()/theirValue) * 100,
+				"reduction_capped": reductionCapped,
+			}).Info("authoritative decrease dry-run")
+			continue
+		}
+		configured.Limits[field] = our
+	}
+}
+
+func clampRequestsToLimits(resources *corev1.ResourceRequirements) {
+	if resources == nil || resources.Limits == nil || resources.Requests == nil {
+		return
+	}
+	for _, field := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+		limit, ok := resources.Limits[field]
+		if !ok || limit.IsZero() {
+			continue
+		}
+		request, ok := resources.Requests[field]
+		if !ok || request.IsZero() {
+			continue
+		}
+		if request.Cmp(limit) > 0 {
+			resources.Requests[field] = limit.DeepCopy()
+		}
+	}
 }

--- a/cmd/pod-scaler/admission_test.go
+++ b/cmd/pod-scaler/admission_test.go
@@ -554,7 +554,7 @@ func TestMutatePodResources(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			original := testCase.pod.DeepCopy()
-			mutatePodResources(testCase.pod, testCase.server, testCase.mutateResourceLimits, 10, "20Gi", false, nil, 50.0, false, false, false, false, 0.25, 0.25, &defaultReporter, logrus.WithField("test", testCase.name))
+			mutatePodResources(testCase.pod, testCase.server, testCase.mutateResourceLimits, 10, "20Gi", false, nil, 50.0, false, false, false, false, 0.25, 0.25, nil, &defaultReporter, logrus.WithField("test", testCase.name))
 			diff := cmp.Diff(original, testCase.pod)
 			// In some cases, cmp.Diff decides to use non-breaking spaces, and it's not
 			// particularly deterministic about this. We don't care.
@@ -619,7 +619,7 @@ func TestMutatePodResources_ciWorkloadLabelDoesNotBreakCacheLookup(t *testing.T)
 		},
 	}
 
-	mutatePodResources(pod, server, false, 10, "20Gi", false, nil, 50.0, false, false, false, false, 0.25, 0.25, &defaultReporter, logger)
+	mutatePodResources(pod, server, false, 10, "20Gi", false, nil, 50.0, false, false, false, false, 0.25, 0.25, nil, &defaultReporter, logger)
 
 	got := pod.Spec.Containers[0].Resources.Requests.Cpu().MilliValue()
 	const want = 6000 // 5000m recommendation inflated by 1.2 in useOursIfLarger
@@ -788,7 +788,7 @@ func TestUseOursIfLarger(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			useOursIfLarger(&testCase.ours, &testCase.theirs, "test", "build", false, "", false, false, false, false, 0.25, 0.25, &defaultReporter, logrus.WithField("test", testCase.name))
+			useOursIfLarger(&testCase.ours, &testCase.theirs, "test", "build", false, "", &defaultReporter, logrus.WithField("test", testCase.name))
 			if diff := cmp.Diff(testCase.theirs, testCase.expected); diff != "" {
 				t.Errorf("%s: got incorrect resources after mutation: %v", testCase.name, diff)
 			}
@@ -798,10 +798,9 @@ func TestUseOursIfLarger(t *testing.T) {
 
 func TestUseOursIfLarger_authoritative(t *testing.T) {
 	testCases := []struct {
-		name                                  string
-		authoritativeCPU, authoritativeMemory bool
-		isMeasured                            bool
-		ours, theirs, expected                corev1.ResourceRequirements
+		name                   string
+		isMeasured             bool
+		ours, theirs, expected corev1.ResourceRequirements
 	}{
 		{
 			name: "authoritative disabled",
@@ -826,9 +825,7 @@ func TestUseOursIfLarger_authoritative(t *testing.T) {
 			},
 		},
 		{
-			name:                "capped reduction",
-			authoritativeCPU:    true,
-			authoritativeMemory: true,
+			name: "smaller recommendation does not decrease requests",
 			ours: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    *resource.NewQuantity(10, resource.DecimalSI),
@@ -844,14 +841,13 @@ func TestUseOursIfLarger_authoritative(t *testing.T) {
 			expected: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{},
 				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    *resource.NewQuantity(75, resource.DecimalSI),
-					corev1.ResourceMemory: *resource.NewQuantity(15e9, resource.BinarySI),
+					corev1.ResourceCPU:    *resource.NewQuantity(100, resource.DecimalSI),
+					corev1.ResourceMemory: *resource.NewQuantity(2e10, resource.BinarySI),
 				},
 			},
 		},
 		{
-			name:             "cpu decrease never below 10m",
-			authoritativeCPU: true,
+			name: "cpu decrease never below 10m",
 			ours: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU: resource.MustParse("1m"),
@@ -865,13 +861,12 @@ func TestUseOursIfLarger_authoritative(t *testing.T) {
 			expected: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{},
 				Requests: corev1.ResourceList{
-					corev1.ResourceCPU: resource.MustParse("10m"),
+					corev1.ResourceCPU: resource.MustParse("12m"),
 				},
 			},
 		},
 		{
-			name:             "zero cpu recommendation ignored",
-			authoritativeCPU: true,
+			name: "zero cpu recommendation ignored",
 			ours: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU: resource.Quantity{},
@@ -890,9 +885,8 @@ func TestUseOursIfLarger_authoritative(t *testing.T) {
 			},
 		},
 		{
-			name:             "measured pod skips reduction",
-			authoritativeCPU: true,
-			isMeasured:       true,
+			name:       "measured pod skips reduction",
+			isMeasured: true,
 			ours: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU: *resource.NewQuantity(10, resource.DecimalSI),
@@ -913,7 +907,7 @@ func TestUseOursIfLarger_authoritative(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			useOursIfLarger(&tc.ours, &tc.theirs, "test", "build", tc.isMeasured, "", tc.authoritativeCPU, tc.authoritativeMemory, false, false, 0.25, 0.25, &defaultReporter, logrus.WithField("test", tc.name))
+			useOursIfLarger(&tc.ours, &tc.theirs, "test", "build", tc.isMeasured, "", &defaultReporter, logrus.WithField("test", tc.name))
 			if diff := cmp.Diff(tc.theirs, tc.expected); diff != "" {
 				t.Errorf("unexpected resources: %s", diff)
 			}
@@ -921,7 +915,116 @@ func TestUseOursIfLarger_authoritative(t *testing.T) {
 	}
 }
 
-func TestUseOursIfLarger_authoritativeUncappedMemory(t *testing.T) {
+func TestApplyAuthoritativeLimitDecrease(t *testing.T) {
+	testCases := []struct {
+		name                                  string
+		authoritativeCPU, authoritativeMemory bool
+		isMeasured                            bool
+		ours, theirs, expected                corev1.ResourceRequirements
+	}{
+		{
+			name: "authoritative disabled",
+			ours: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    *resource.NewQuantity(10, resource.DecimalSI),
+					corev1.ResourceMemory: *resource.NewQuantity(1e1, resource.BinarySI),
+				},
+			},
+			theirs: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    *resource.NewQuantity(100, resource.DecimalSI),
+					corev1.ResourceMemory: *resource.NewQuantity(2e10, resource.BinarySI),
+				},
+			},
+			expected: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    *resource.NewQuantity(100, resource.DecimalSI),
+					corev1.ResourceMemory: *resource.NewQuantity(2e10, resource.BinarySI),
+				},
+			},
+		},
+		{
+			name:                "capped reduction on limits only",
+			authoritativeCPU:    true,
+			authoritativeMemory: true,
+			ours: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    *resource.NewQuantity(10, resource.DecimalSI),
+					corev1.ResourceMemory: *resource.NewQuantity(1e1, resource.BinarySI),
+				},
+			},
+			theirs: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    *resource.NewQuantity(100, resource.DecimalSI),
+					corev1.ResourceMemory: *resource.NewQuantity(2e10, resource.BinarySI),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    *resource.NewQuantity(100, resource.DecimalSI),
+					corev1.ResourceMemory: *resource.NewQuantity(2e10, resource.BinarySI),
+				},
+			},
+			expected: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    *resource.NewQuantity(75, resource.DecimalSI),
+					corev1.ResourceMemory: *resource.NewQuantity(15e9, resource.BinarySI),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    *resource.NewQuantity(100, resource.DecimalSI),
+					corev1.ResourceMemory: *resource.NewQuantity(2e10, resource.BinarySI),
+				},
+			},
+		},
+		{
+			name:             "cpu limit decrease never below 10m",
+			authoritativeCPU: true,
+			ours: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1m"),
+				},
+			},
+			theirs: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("12m"),
+				},
+			},
+			expected: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("10m"),
+				},
+			},
+		},
+		{
+			name:             "measured pod skips limit reduction",
+			authoritativeCPU: true,
+			isMeasured:       true,
+			ours: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: *resource.NewQuantity(10, resource.DecimalSI),
+				},
+			},
+			theirs: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: *resource.NewQuantity(100, resource.DecimalSI),
+				},
+			},
+			expected: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: *resource.NewQuantity(100, resource.DecimalSI),
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			applyAuthoritativeLimitDecrease(&tc.ours, &tc.theirs, "test", "build", tc.isMeasured, "", tc.authoritativeCPU, tc.authoritativeMemory, false, false, 0.25, 0.25, nil, logrus.WithField("test", tc.name))
+			if diff := cmp.Diff(tc.theirs, tc.expected); diff != "" {
+				t.Errorf("unexpected resources: %s", diff)
+			}
+		})
+	}
+}
+
+func TestApplyAuthoritativeLimitDecrease_uncappedMemory(t *testing.T) {
 	ours := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    *resource.NewQuantity(10, resource.DecimalSI),
@@ -929,23 +1032,161 @@ func TestUseOursIfLarger_authoritativeUncappedMemory(t *testing.T) {
 		},
 	}
 	theirs := corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
+		Limits: corev1.ResourceList{
 			corev1.ResourceCPU:    *resource.NewQuantity(100, resource.DecimalSI),
 			corev1.ResourceMemory: *resource.NewQuantity(2e10, resource.BinarySI),
 		},
 	}
 	expected := corev1.ResourceRequirements{
-		Limits: corev1.ResourceList{},
-		Requests: corev1.ResourceList{
+		Limits: corev1.ResourceList{
 			corev1.ResourceCPU:    *resource.NewQuantity(75, resource.DecimalSI),
 			corev1.ResourceMemory: *resource.NewQuantity(12, resource.BinarySI),
 		},
 	}
 
-	useOursIfLarger(&ours, &theirs, "test", "build", false, "", true, true, false, false, 0.25, 1.0, &defaultReporter, logrus.WithField("test", t.Name()))
+	applyAuthoritativeLimitDecrease(&ours, &theirs, "test", "build", false, "", true, true, false, false, 0.25, 1.0, nil, logrus.WithField("test", t.Name()))
 	if diff := cmp.Diff(theirs, expected); diff != "" {
 		t.Errorf("unexpected resources: %s", diff)
 	}
+}
+
+func TestApplyAuthoritativeLimitDecrease_dryRun(t *testing.T) {
+	ours := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU: *resource.NewQuantity(10, resource.DecimalSI),
+		},
+	}
+	theirs := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU: *resource.NewQuantity(100, resource.DecimalSI),
+		},
+	}
+	expected := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU: *resource.NewQuantity(100, resource.DecimalSI),
+		},
+	}
+
+	applyAuthoritativeLimitDecrease(&ours, &theirs, "test", "build", false, "", true, false, true, false, 0.25, 0.25, nil, logrus.WithField("test", t.Name()))
+	if diff := cmp.Diff(theirs, expected); diff != "" {
+		t.Errorf("dry-run should not mutate resources: %s", diff)
+	}
+}
+
+func TestClampRequestsToLimits(t *testing.T) {
+	resources := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("2"),
+			corev1.ResourceMemory: resource.MustParse("4Gi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1"),
+			corev1.ResourceMemory: resource.MustParse("2Gi"),
+		},
+	}
+	expected := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1"),
+			corev1.ResourceMemory: resource.MustParse("2Gi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1"),
+			corev1.ResourceMemory: resource.MustParse("2Gi"),
+		},
+	}
+	clampRequestsToLimits(&resources)
+	if diff := cmp.Diff(resources, expected); diff != "" {
+		t.Errorf("unexpected resources: %s", diff)
+	}
+}
+
+func TestApplyAuthoritativeLimitDecrease_skipsDuringEscalation(t *testing.T) {
+	ours := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: *resource.NewQuantity(1e1, resource.BinarySI),
+		},
+	}
+	theirs := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: *resource.NewQuantity(2e10, resource.BinarySI),
+		},
+	}
+	server := &escalationServer{
+		index: podscaler.EscalationIndex{
+			podscaler.WorkloadKey("build", "test"): {MemoryLevel: 1},
+		},
+	}
+
+	applyAuthoritativeLimitDecrease(&ours, &theirs, "test", "build", false, "", false, true, false, false, 0.25, 0.25, server, logrus.WithField("test", t.Name()))
+	want := *resource.NewQuantity(2e10, resource.BinarySI)
+	if diff := cmp.Diff(theirs.Limits, corev1.ResourceList{corev1.ResourceMemory: want}); diff != "" {
+		t.Errorf("expected memory limit unchanged during escalation: %s", diff)
+	}
+}
+
+func TestApplyFailureEscalation(t *testing.T) {
+	var testCases = []struct {
+		name      string
+		index     podscaler.EscalationIndex
+		resources corev1.ResourceRequirements
+	}{
+		{
+			name: "no escalation",
+			resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+		},
+		{
+			name: "cpu and memory escalation",
+			index: podscaler.EscalationIndex{
+				podscaler.WorkloadKey("build", "test"): {CPULevel: 1, MemoryLevel: 2},
+			},
+			resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := &escalationServer{index: tc.index, factor: 1.5}
+			resources := copyResourceRequirements(tc.resources)
+			expected := copyResourceRequirements(tc.resources)
+			if tc.index != nil {
+				state := tc.index[podscaler.WorkloadKey("build", "test")]
+				if state.CPULevel > 0 {
+					expected.Requests[corev1.ResourceCPU] = server.scaleQuantity(expected.Requests[corev1.ResourceCPU], state.CPULevel)
+				}
+				if state.MemoryLevel > 0 {
+					expected.Requests[corev1.ResourceMemory] = server.scaleQuantity(expected.Requests[corev1.ResourceMemory], state.MemoryLevel)
+					expected.Limits[corev1.ResourceMemory] = server.scaleQuantity(expected.Limits[corev1.ResourceMemory], state.MemoryLevel)
+				}
+			}
+			applyFailureEscalation(&resources, "build", "test", server, logrus.WithField("test", tc.name))
+			if diff := cmp.Diff(resources, expected); diff != "" {
+				t.Errorf("unexpected resources: %s", diff)
+			}
+		})
+	}
+}
+
+func copyResourceRequirements(in corev1.ResourceRequirements) corev1.ResourceRequirements {
+	out := in
+	if in.Requests != nil {
+		out.Requests = in.Requests.DeepCopy()
+	}
+	if in.Limits != nil {
+		out.Limits = in.Limits.DeepCopy()
+	}
+	return out
 }
 
 func TestUseOursIfLarger_authoritativeDryRun(t *testing.T) {
@@ -966,7 +1207,7 @@ func TestUseOursIfLarger_authoritativeDryRun(t *testing.T) {
 		},
 	}
 
-	useOursIfLarger(&ours, &theirs, "test", "build", false, "", true, false, true, false, 0.25, 0.25, &defaultReporter, logrus.WithField("test", t.Name()))
+	useOursIfLarger(&ours, &theirs, "test", "build", false, "", &defaultReporter, logrus.WithField("test", t.Name()))
 	if diff := cmp.Diff(theirs, expected); diff != "" {
 		t.Errorf("dry-run should not mutate resources: %s", diff)
 	}
@@ -1049,7 +1290,7 @@ func TestUseOursIsLarger_ReporterReports(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			useOursIfLarger(&tc.ours, &tc.theirs, "test", "build", false, "", false, false, false, false, 0.25, 0.25, &tc.reporter, logrus.WithField("test", tc.name))
+			useOursIfLarger(&tc.ours, &tc.theirs, "test", "build", false, "", &tc.reporter, logrus.WithField("test", tc.name))
 
 			if diff := cmp.Diff(tc.reporter.called, tc.expected); diff != "" {
 				t.Errorf("actual and expected reporter states don't match, : %v", diff)

--- a/cmd/pod-scaler/main.go
+++ b/cmd/pod-scaler/main.go
@@ -49,6 +49,10 @@ type options struct {
 	cacheBucket        string
 	gcsCredentialsFile string
 
+	failureEscalationFactor   float64
+	failureEscalationMaxLevel int
+	cpuThrottleThreshold      float64
+
 	resultsOptions results.Options
 }
 
@@ -108,8 +112,11 @@ func bindOptions(fs *flag.FlagSet) *options {
 	fs.BoolVar(&o.authoritativeMemory, "authoritative-memory", false, "Allow admission to decrease memory requests and limits based on measured usage.")
 	fs.BoolVar(&o.authoritativeCPUDryRun, "authoritative-cpu-dry-run", false, "Log CPU decreases that authoritative mode would apply without mutating pods.")
 	fs.BoolVar(&o.authoritativeMemoryDryRun, "authoritative-memory-dry-run", false, "Log memory decreases that authoritative mode would apply without mutating pods.")
-	fs.Float64Var(&o.authoritativeCPUMaxReductionPercent, "authoritative-cpu-max-reduction-percent", 1.0, "Maximum CPU request reduction per admission in authoritative mode, as a fraction (0.25 = 25%, 1.0 = no cap).")
-	fs.Float64Var(&o.authoritativeMemoryMaxReductionPercent, "authoritative-memory-max-reduction-percent", 1.0, "Maximum memory request reduction per admission in authoritative mode, as a fraction (0.25 = 25%, 1.0 = no cap).")
+	fs.Float64Var(&o.authoritativeCPUMaxReductionPercent, "authoritative-cpu-max-reduction-percent", 1.0, "Maximum CPU limit reduction per admission in authoritative mode, as a fraction (0.25 = 25%, 1.0 = no cap).")
+	fs.Float64Var(&o.authoritativeMemoryMaxReductionPercent, "authoritative-memory-max-reduction-percent", 1.0, "Maximum memory limit reduction per admission in authoritative mode, as a fraction (0.25 = 25%, 1.0 = no cap).")
+	fs.Float64Var(&o.failureEscalationFactor, "failure-escalation-factor", 1.5, "Multiplier applied per escalation level after OOM or CPU throttle (1.5 = 50% increase per level).")
+	fs.IntVar(&o.failureEscalationMaxLevel, "failure-escalation-max-level", 10, "Maximum escalation level tracked for a workload.")
+	fs.Float64Var(&o.cpuThrottleThreshold, "cpu-throttle-threshold", 0.25, "Minimum throttled/total CPU CFS period ratio to count as CPU deprived.")
 	o.resultsOptions.Bind(fs)
 	return &o
 }
@@ -177,6 +184,15 @@ func (o *options) validate() error {
 	}
 	if o.logStyle != logStyleJson && o.logStyle != logStyleText {
 		return fmt.Errorf("--log-style must be one of %s or %s, not %s", logStyleText, logStyleJson, o.logStyle)
+	}
+	if o.failureEscalationFactor <= 1 {
+		return errors.New("--failure-escalation-factor must be greater than 1")
+	}
+	if o.failureEscalationMaxLevel < 0 {
+		return errors.New("--failure-escalation-max-level must be >= 0")
+	}
+	if o.cpuThrottleThreshold <= 0 || o.cpuThrottleThreshold > 1 {
+		return errors.New("--cpu-throttle-threshold must be between 0 and 1")
 	}
 
 	return o.instrumentationOptions.Validate(false)
@@ -277,7 +293,7 @@ func mainProduce(opts *options, cache Cache) {
 		logger.Debugf("Loaded Prometheus client.")
 	}
 
-	produce(clients, cache, opts.ignoreLatest, opts.maxDataAge, opts.once)
+	produce(clients, cache, opts.ignoreLatest, opts.maxDataAge, opts.once, opts.failureEscalationMaxLevel, opts.cpuThrottleThreshold)
 
 }
 
@@ -305,7 +321,9 @@ func mainAdmission(opts *options, cache Cache) {
 		logrus.WithError(err).Fatal("Failed to create pod-scaler reporter.")
 	}
 
-	go admit(opts.port, opts.instrumentationOptions.HealthPort, opts.certDir, client, kubeClient, loaders(cache), opts.mutateResourceLimits, opts.cpuCap, opts.memoryCap, opts.cpuPriorityScheduling, opts.percentageMeasured, opts.measuredPodCPUIncrease, opts.systemReservedCPU, opts.authoritativeCPU, opts.authoritativeMemory, opts.authoritativeCPUDryRun, opts.authoritativeMemoryDryRun, opts.authoritativeCPUMaxReductionPercent, opts.authoritativeMemoryMaxReductionPercent, reporter)
+	escalations := newEscalationServer(cache, opts.failureEscalationFactor)
+
+	go admit(opts.port, opts.instrumentationOptions.HealthPort, opts.certDir, client, kubeClient, loaders(cache), opts.mutateResourceLimits, opts.cpuCap, opts.memoryCap, opts.cpuPriorityScheduling, opts.percentageMeasured, opts.measuredPodCPUIncrease, opts.systemReservedCPU, opts.authoritativeCPU, opts.authoritativeMemory, opts.authoritativeCPUDryRun, opts.authoritativeMemoryDryRun, opts.authoritativeCPUMaxReductionPercent, opts.authoritativeMemoryMaxReductionPercent, escalations, reporter)
 }
 
 func loaders(cache Cache) map[string][]*cacheReloader {

--- a/cmd/pod-scaler/producer.go
+++ b/cmd/pod-scaler/producer.go
@@ -34,16 +34,20 @@ const (
 	ProwjobsCachePrefix = "prowjobs"
 	PodsCachePrefix     = "pods"
 	StepsCachePrefix    = "steps"
+
+	metricOOMKilled    = `kube_pod_container_status_last_terminated_reason`
+	metricCPUThrottled = `container_cpu_cfs_throttled_periods_total`
+	metricCPUPeriods   = `container_cpu_cfs_periods_total`
 )
 
-// queriesByMetric returns a mapping of Prometheus query by metric name for all queries we want to execute
-func queriesByMetric() map[string]string {
-	queries := map[string]string{}
-	for _, info := range []struct {
-		prefix   string
-		selector string
-		labels   []string
-	}{
+type metricQueryConfig struct {
+	prefix   string
+	selector string
+	labels   []string
+}
+
+func metricQueryConfigs() []metricQueryConfig {
+	return []metricQueryConfig{
 		{
 			prefix:   ProwjobsCachePrefix,
 			selector: `{` + string(podscaler.ProwLabelNameCreated) + `="true",` + string(podscaler.ProwLabelNameJob) + `!="",` + string(podscaler.LabelNameRehearsal) + `=""}`,
@@ -59,7 +63,12 @@ func queriesByMetric() map[string]string {
 			selector: `{` + string(podscaler.LabelNameCreated) + `="true",` + string(podscaler.LabelNameStep) + `!=""}`,
 			labels:   []string{string(podscaler.LabelNameOrg), string(podscaler.LabelNameRepo), string(podscaler.LabelNameBranch), string(podscaler.LabelNameVariant), string(podscaler.LabelNameTarget), string(podscaler.LabelNameStep), string(podscaler.LabelNameMeasured)},
 		},
-	} {
+	}
+}
+
+func queriesByMetric() map[string]string {
+	queries := map[string]string{}
+	for _, info := range metricQueryConfigs() {
 		for name, metric := range map[string]string{
 			MetricNameCPUUsage:         `rate(` + MetricNameCPUUsage + containerFilter + `[3m])`,
 			MetricNameMemoryWorkingSet: MetricNameMemoryWorkingSet + containerFilter,
@@ -70,7 +79,7 @@ func queriesByMetric() map[string]string {
 	return queries
 }
 
-func produce(clients map[string]prometheusapi.API, dataCache Cache, ignoreLatest, maxDataAge time.Duration, once bool) {
+func produce(clients map[string]prometheusapi.API, dataCache Cache, ignoreLatest, maxDataAge time.Duration, once bool, failureEscalationMaxLevel int, cpuThrottleThreshold float64) {
 	var execute func(func())
 	if once {
 		execute = func(f func()) {
@@ -157,6 +166,7 @@ func produce(clients map[string]prometheusapi.API, dataCache Cache, ignoreLatest
 				logger.WithError(err).Error("Failed to write cached data.")
 			}
 		}
+		refreshEscalationIndex(clients, dataCache, failureEscalationMaxLevel, cpuThrottleThreshold)
 	})
 }
 
@@ -394,4 +404,132 @@ func (q *querier) executeOverRange(ctx context.Context, c *clusterMetadata, r pr
 	q.data.Record(c.name, rangeFrom(r), matrix, logger)
 	q.lock.Unlock()
 	logger.Debugf("Saved Prometheus response after %s.", time.Since(saveStart).Round(time.Second))
+}
+
+func refreshEscalationIndex(clients map[string]prometheusapi.API, dataCache Cache, maxLevel int, cpuThrottleThreshold float64) {
+	logger := logrus.WithField("component", "pod-scaler escalation producer")
+	index := loadEscalationIndex(dataCache, logger)
+	oomWorkloads := map[string]struct{}{}
+	throttledWorkloads := map[string]struct{}{}
+	usageWorkloads := map[string]struct{}{}
+
+	for clusterName, client := range clients {
+		clusterLogger := logger.WithField("cluster", clusterName)
+		for _, info := range metricQueryConfigs() {
+			oomQuery := queryFor(
+				metricOOMKilled+`{reason="OOMKilled",container!="POD",container!=""}`,
+				info.selector,
+				info.labels,
+			)
+			if err := queryInstantVector(clusterLogger.WithField("query", "oom"), client, oomQuery, func(metric model.Metric, value model.SampleValue) {
+				if value > 0 {
+					oomWorkloads[podscaler.WorkloadKeyFromMetric(metric)] = struct{}{}
+				}
+			}); err != nil {
+				clusterLogger.WithError(err).WithField("query", "oom").Warn("Failed to query OOM signal.")
+			}
+
+			throttleQuery := queryFor(
+				`sum by (namespace,pod,container) (rate(`+metricCPUThrottled+containerFilter+`[1h])) / sum by (namespace,pod,container) (rate(`+metricCPUPeriods+containerFilter+`[1h]))`,
+				info.selector,
+				info.labels,
+			)
+			if err := queryInstantVector(clusterLogger.WithField("query", "cpu_throttle"), client, throttleQuery, func(metric model.Metric, value model.SampleValue) {
+				if value >= model.SampleValue(cpuThrottleThreshold) {
+					throttledWorkloads[podscaler.WorkloadKeyFromMetric(metric)] = struct{}{}
+				}
+			}); err != nil {
+				clusterLogger.WithError(err).WithField("query", "cpu_throttle").Warn("Failed to query CPU throttle signal.")
+			}
+
+			usageQuery := queriesByMetric()[info.prefix+"/"+MetricNameMemoryWorkingSet]
+			if err := queryInstantVector(clusterLogger.WithField("query", "usage"), client, usageQuery, func(metric model.Metric, value model.SampleValue) {
+				if value > 0 {
+					usageWorkloads[podscaler.WorkloadKeyFromMetric(metric)] = struct{}{}
+				}
+			}); err != nil {
+				clusterLogger.WithError(err).WithField("query", "usage").Warn("Failed to query usage signal.")
+			}
+		}
+	}
+
+	for key := range oomWorkloads {
+		state := index[key]
+		if state.MemoryLevel < maxLevel {
+			state.MemoryLevel++
+		}
+		index[key] = state
+	}
+	for key := range throttledWorkloads {
+		state := index[key]
+		if state.CPULevel < maxLevel {
+			state.CPULevel++
+		}
+		index[key] = state
+	}
+	decayEscalation := func(key string) {
+		state, ok := index[key]
+		if !ok {
+			return
+		}
+		if state.MemoryLevel > 0 {
+			state.MemoryLevel--
+		}
+		if state.CPULevel > 0 {
+			state.CPULevel--
+		}
+		if state.MemoryLevel == 0 && state.CPULevel == 0 {
+			delete(index, key)
+			return
+		}
+		index[key] = state
+	}
+	for key := range usageWorkloads {
+		if _, oom := oomWorkloads[key]; oom {
+			continue
+		}
+		if _, throttled := throttledWorkloads[key]; throttled {
+			continue
+		}
+		decayEscalation(key)
+	}
+	for key := range index {
+		if _, oom := oomWorkloads[key]; oom {
+			continue
+		}
+		if _, throttled := throttledWorkloads[key]; throttled {
+			continue
+		}
+		if _, active := usageWorkloads[key]; active {
+			continue
+		}
+		decayEscalation(key)
+	}
+
+	if err := storeEscalationIndex(dataCache, index); err != nil {
+		logger.WithError(err).Error("Failed to store workload escalation index.")
+	}
+}
+
+func queryInstantVector(logger *logrus.Entry, client prometheusapi.API, query string, apply func(model.Metric, model.SampleValue)) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	value, warnings, err := client.Query(ctx, query, time.Now())
+	if err != nil {
+		return err
+	}
+	if len(warnings) > 0 {
+		logger.WithField("warnings", warnings).Warn("Got warnings from Prometheus.")
+	}
+	vector, ok := value.(model.Vector)
+	if !ok {
+		return nil
+	}
+	for _, sample := range vector {
+		if sample.Metric == nil {
+			continue
+		}
+		apply(sample.Metric, sample.Value)
+	}
+	return nil
 }

--- a/pkg/pod-scaler/types.go
+++ b/pkg/pod-scaler/types.go
@@ -469,3 +469,36 @@ func (m *StepMetadata) LogFields() logrus.Fields {
 		"container": m.Container,
 	}
 }
+
+// ResourceEscalation tracks per-workload escalation levels after resource pressure failures.
+type ResourceEscalation struct {
+	MemoryLevel int `json:"memory_level,omitempty"`
+	CPULevel    int `json:"cpu_level,omitempty"`
+}
+
+// EscalationIndex maps workload keys to escalation state persisted by the producer.
+type EscalationIndex map[string]ResourceEscalation
+
+// WorkloadKey returns the canonical key for a workload type and name.
+func WorkloadKey(workloadType, workloadName string) string {
+	return fmt.Sprintf("%s/%s", workloadType, workloadName)
+}
+
+// WorkloadKeyFromMetric derives a WorkloadKey from Prometheus metric labels.
+func WorkloadKeyFromMetric(metric model.Metric) string {
+	if _, ok := metric[ProwLabelNameCreated]; ok {
+		return WorkloadKey("prowjob", string(metric[ProwLabelNameJob]))
+	}
+	meta := metadataFromMetric(metric)
+	name := fmt.Sprintf("%s-%s", meta.Pod, meta.Container)
+	if meta.Step != "" {
+		return WorkloadKey("step", name)
+	}
+	if _, ok := metric[LabelNameBuild]; ok {
+		return WorkloadKey("build", name)
+	}
+	return WorkloadKey("undefined", name)
+}
+
+// EscalationsCacheName is the GCS object prefix for the persisted escalation index.
+const EscalationsCacheName = "escalations/v1"

--- a/pkg/pod-scaler/types_test.go
+++ b/pkg/pod-scaler/types_test.go
@@ -1037,3 +1037,45 @@ func TestMetadataFor(t *testing.T) {
 		})
 	}
 }
+
+func TestWorkloadKeyFromMetric(t *testing.T) {
+	var testCases = []struct {
+		name   string
+		metric model.Metric
+		want   string
+	}{
+		{
+			name: "prowjob",
+			metric: model.Metric{
+				ProwLabelNameCreated: "true",
+				ProwLabelNameJob:     "periodic-test",
+			},
+			want: "prowjob/periodic-test",
+		},
+		{
+			name: "build pod",
+			metric: model.Metric{
+				LabelNameBuild:     "true",
+				LabelNamePod:       "build-1",
+				LabelNameContainer: "test",
+			},
+			want: "build/build-1-test",
+		},
+		{
+			name: "step",
+			metric: model.Metric{
+				LabelNameStep:      "unit",
+				LabelNamePod:       "pod-1",
+				LabelNameContainer: "test",
+			},
+			want: "step/pod-1-test",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := WorkloadKeyFromMetric(tc.metric); got != tc.want {
+				t.Errorf("WorkloadKeyFromMetric() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
/cc @bear-redhat 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Pod-Scaler: limit-only decrease with failure-based escalation ([DPTP-2938](https://redhat.atlassian.net/browse/DPTP-2938))

This PR updates the **pod-scaler** admission/mutation logic used by OpenShift CI to be safer under failure-prone workloads by combining:
1) **failure-driven escalation** (scales resources up), and
2) **limit-only decrease** (reduces configured limits only in the intended mode).

### Practical behavior changes (for CI operators)
- **Escalation is now based on workload failure signals.** The pod-scaler producer periodically refreshes an escalation index in cached storage using Prometheus instant-vector signals:
  - **OOMKilled** terminations (`reason="OOMKilled"`)
  - **CPU throttling** ratio (`rate(throttled)/rate(periods)`), compared against `cpu-throttle-threshold`
  - **Memory working set** activity
- **While escalation is active for a workload**, the admission webhook multiplies that workload’s **requests and limits** using an exponential factor:  
  `multiplier = failure-escalation-factor^level`, where level is tracked up to `failure-escalation-max-level`.
- **Authoritative “limit-only decrease” is applied conservatively:**
  - It runs only when the pod is **not measured** (`percentage-measured` mode).
  - It updates **configured limits** (from the incoming pod) based on the computed recommendation, with safeguards including:
    - **CPU minimum request enforcement** (`10m`)
    - **optional dry-run logging** (`--authoritative-*-dry-run`)
    - **max per-admission reduction capping** (`--authoritative-*-max-reduction-percent`)
  - If escalation is active for a given resource type (CPU or memory), **decreases are skipped** for that resource.
  - After escalation/decrease decisions, **requests are clamped to not exceed limits**.

### How it’s implemented
- **Admission path (`cmd/pod-scaler/admission.go`)**
  - The admission server now carries an `escalationServer` dependency through `admit → podMutator → mutatePodResources`.
  - Per container mutation order when a recommendation exists:
    1. `useOursIfLarger` updates the workload’s requests/limits from recommendations (only when ours > theirs)
    2. `applyFailureEscalation` scales requests+limits using the cached escalation levels
    3. `applyAuthoritativeLimitDecrease` applies configured-limit decreases (subject to measured/escalation/dry-run/max-reduction gating)
    4. `clampRequestsToLimits` ensures requests do not exceed limits
- **Producer path (`cmd/pod-scaler/producer.go`)**
  - Adds `refreshEscalationIndex` which:
    - loads the persisted escalation index
    - increments memory/cpu levels (bounded by `failureEscalationMaxLevel`) for workloads observed via OOM, throttling, and usage
    - decays levels by 1 for workloads not currently observed (eventually deleting entries at level 0/0)
    - persists the updated index back to the cache

### Configuration knobs added (CLI)
New flags:
- `--failure-escalation-factor` (must be > 1)
- `--failure-escalation-max-level` (must be >= 0)
- `--cpu-throttle-threshold` (must be between 0 and 1)

### Tests
Admission and helper logic were updated and extended to cover:
- escalation application and clamping
- authoritative limit decrease behavior, including measured-skip, dry-run, max-reduction/capping paths, and escalation-skip during active failures

### JIRA / release metadata note
The PR references **[DPTP-2938](https://redhat.atlassian.net/browse/DPTP-2938)**, but the issue should have a **target version set to `5.0.0`** to match the expected main-branch release version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->