### PR TITLE
Fix issue DPTP-4756 Add CF template

### DIFF
--- a/hack/aws-sts-roles/home-role.cf
+++ b/hack/aws-sts-roles/home-role.cf
@@ -1,0 +1,66 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  Home role for CI STS role chaining. Deploy once in each build cluster's
+  AWS account (where the OIDC provider is already registered by the cluster
+  installer).
+
+  Per-test pods authenticate via a projected ServiceAccount token (OIDC)
+  and the AWS SDK performs a three-hop STS exchange:
+    per-test SA token (OIDC) -> ci-step-runner (this, build cluster acct)
+      -> ci-step-runner-hub (hub-role.cf, hub account)
+      -> ci-step-runner-target (target-role.cf, each cluster profile account)
+
+  The :sub condition restricts access to dynamically created ci-operator
+  test namespaces (ci-op-*). The :aud condition ensures only projected SA
+  tokens with audience "sts.amazonaws.com" are accepted.
+
+Parameters:
+  OIDCProviderArn:
+    Type: String
+    Description: >-
+      ARN of the IAM OIDC provider registered by the cluster installer,
+      e.g. arn:aws:iam::123456789012:oidc-provider/rh-oidc.s3.us-east-1.amazonaws.com/abc123
+  OIDCProviderURL:
+    Type: String
+    Description: >-
+      OIDC issuer URL without the https:// prefix,
+      e.g. rh-oidc.s3.us-east-1.amazonaws.com/abc123
+
+Resources:
+  CIHomeRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: ci-step-runner
+      AssumeRolePolicyDocument: !Sub |
+        {
+          "Version": "2012-10-17",
+          "Statement": [{
+            "Effect": "Allow",
+            "Principal": { "Federated": "${OIDCProviderArn}" },
+            "Action": "sts:AssumeRoleWithWebIdentity",
+            "Condition": {
+              "StringLike": {
+                "${OIDCProviderURL}:sub": "system:serviceaccount:ci-op-*:*"
+              },
+              "StringEquals": {
+                "${OIDCProviderURL}:aud": "sts.amazonaws.com"
+              }
+            }
+          }]
+        }
+      Policies:
+        - PolicyName: assume-hub-role
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: sts:AssumeRole
+                Resource: "arn:aws:iam::*:role/ci-step-runner-hub"
+
+Outputs:
+  RoleArn:
+    Description: >-
+      ARN of the home role. Use this as:
+        - home_role_arn in the cluster profile secret
+        - An entry in TrustedHomeRoleArns when deploying hub-role.cf
+    Value: !GetAtt CIHomeRole.Arn

--- a/hack/aws-sts-roles/hub-role.cf
+++ b/hack/aws-sts-roles/hub-role.cf
@@ -1,0 +1,52 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  Hub role for CI STS role chaining. Deploy once in the hub AWS account.
+  Trusts the ci-step-runner home roles from each build cluster's account.
+
+  The assume chain is:
+    per-test SA token (OIDC) -> ci-step-runner (home-role.cf, build cluster acct)
+      -> ci-step-runner-hub (this, hub account)
+      -> ci-step-runner-target (target-role.cf, each cluster profile account)
+
+  To add or remove a build cluster, update the TrustedHomeRoleArns
+  parameter value and run a stack update. The role itself is never
+  replaced, preserving its internal ID and all downstream trust
+  relationships.
+
+Parameters:
+  TrustedHomeRoleArns:
+    Type: CommaDelimitedList
+    Description: >-
+      Comma-separated list of ci-step-runner home role ARNs from all
+      build cluster accounts (output of home-role.cf in each account),
+      e.g. arn:aws:iam::111:role/ci-step-runner,arn:aws:iam::222:role/ci-step-runner
+
+Resources:
+  CIHubRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: ci-step-runner-hub
+      MaxSessionDuration: 14400
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Ref TrustedHomeRoleArns
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: assume-target-roles
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: sts:AssumeRole
+                Resource: "arn:aws:iam::*:role/ci-step-runner-target"
+
+Outputs:
+  RoleArn:
+    Description: >-
+      ARN of the hub role. Use this as:
+        - hub_role_arn in the cluster profile secret
+        - TrustedRoleArn when deploying target-role.cf in target accounts
+    Value: !GetAtt CIHubRole.Arn

--- a/hack/aws-sts-roles/target-role.cf
+++ b/hack/aws-sts-roles/target-role.cf
@@ -1,0 +1,125 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  IAM role for a CI cluster profile's target AWS account. Deploy in every
+  AWS account that a cluster profile needs access to (e.g. the aws-5
+  account).
+
+  Trusts the ci-step-runner-hub hub role. The assume chain is:
+    per-test SA token (OIDC) -> ci-step-runner-hub (hub-role.cf, hub account)
+      -> ci-step-runner-target (this, target account)
+
+  Permissions mirror the origin-ci-robot-provision user: full access to
+  EC2, S3, IAM, Route53, ECR, EFS, Lambda, CloudFormation, Secrets
+  Manager, ELB server certificates, Resource Groups, Service Quotas
+  read-only, and unrestricted STS AssumeRole.
+
+Parameters:
+  TrustedRoleArn:
+    Type: String
+    Description: >-
+      ARN of the ci-step-runner-hub hub role (output of hub-role.cf),
+      e.g. arn:aws:iam::123456789012:role/ci-step-runner-hub
+
+Resources:
+  CITargetRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: ci-step-runner-target
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Ref TrustedRoleArn
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        # CloudFormation full
+        - arn:aws:iam::aws:policy/AWSCloudFormationFullAccess
+        # ECR full
+        - arn:aws:iam::aws:policy/AmazonElasticContainerRegistryPublicFullAccess
+        # EFS full + client
+        - arn:aws:iam::aws:policy/AmazonElasticFileSystemFullAccess
+        - arn:aws:iam::aws:policy/AmazonElasticFileSystemClientFullAccess
+        # Secrets Manager read/write
+        - arn:aws:iam::aws:policy/SecretsManagerReadWrite
+        # Lambda full
+        - arn:aws:iam::aws:policy/AWSLambda_FullAccess
+      Policies:
+        - PolicyName: ci-provision-compute-networking
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: EC2Full
+                Effect: Allow
+                Action: "ec2:*"
+                Resource: "*"
+              - Sid: ELBFull
+                Effect: Allow
+                Action: "elasticloadbalancing:*"
+                Resource: "*"
+              - Sid: AutoScalingFull
+                Effect: Allow
+                Action: "autoscaling:*"
+                Resource: "*"
+        - PolicyName: ci-provision-storage
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: S3Full
+                Effect: Allow
+                Action: "s3:*"
+                Resource: "*"
+        - PolicyName: ci-provision-identity
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: IAMFull
+                Effect: Allow
+                Action: "iam:*"
+                Resource: "*"
+              - Sid: STSAssumeRole
+                Effect: Allow
+                Action: "sts:*"
+                Resource: "*"
+        - PolicyName: ci-provision-dns-certs
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: Route53Full
+                Effect: Allow
+                Action: "route53:*"
+                Resource: "*"
+              - Sid: Route53DomainsFull
+                Effect: Allow
+                Action: "route53domains:*"
+                Resource: "*"
+              - Sid: ELBServerCerts
+                Effect: Allow
+                Action:
+                  - "iam:ListServerCertificates"
+                  - "iam:GetServerCertificate"
+                  - "iam:UploadServerCertificate"
+                Resource: "*"
+        - PolicyName: ci-provision-resource-groups-quotas
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: ResourceGroupsFull
+                Effect: Allow
+                Action:
+                  - "resource-groups:*"
+                  - "tag:*"
+                Resource: "*"
+              - Sid: ServiceQuotasReadOnly
+                Effect: Allow
+                Action:
+                  - "servicequotas:Get*"
+                  - "servicequotas:List*"
+                Resource: "*"
+
+Outputs:
+  RoleArn:
+    Description: >-
+      ARN of the target role (arn:aws:iam::<account>:role/ci-step-runner-target).
+      Use this as target_role_arn in the cluster profiles config.
+    Value: !GetAtt CITargetRole.Arn

--- a/pkg/steps/multi_stage/gen_test.go
+++ b/pkg/steps/multi_stage/gen_test.go
@@ -202,8 +202,8 @@ func TestGeneratePods(t *testing.T) {
 				return params
 			},
 			stsHomeRoleARN:   "arn:aws:iam::000000000000:role/ci-step-runner",
-			stsHubRoleARN:    "arn:aws:iam::111111111111:role/ci-step-runner",
-			stsTargetRoleARN: "arn:aws:iam::222222222222:role/ci-step-runner",
+			stsHubRoleARN:    "arn:aws:iam::111111111111:role/ci-step-runner-hub",
+			stsTargetRoleARN: "arn:aws:iam::222222222222:role/ci-step-runner-target",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/steps/multi_stage/init_test.go
+++ b/pkg/steps/multi_stage/init_test.go
@@ -413,8 +413,8 @@ func TestCreateSTSConfigMap(t *testing.T) {
 	s := &multiStageTestStep{
 		name:             "e2e-aws",
 		stsHomeRoleARN:   "arn:aws:iam::000000000000:role/ci-step-runner",
-		stsHubRoleARN:    "arn:aws:iam::111111111111:role/ci-step-runner",
-		stsTargetRoleARN: "arn:aws:iam::222222222222:role/ci-step-runner",
+		stsHubRoleARN:    "arn:aws:iam::111111111111:role/ci-step-runner-hub",
+		stsTargetRoleARN: "arn:aws:iam::222222222222:role/ci-step-runner-target",
 		client:           fakeClient,
 		jobSpec:          &api.JobSpec{},
 	}
@@ -440,10 +440,10 @@ func TestCreateSTSConfigMap(t *testing.T) {
 	if !strings.Contains(config, "arn:aws:iam::000000000000:role/ci-step-runner") {
 		t.Error("config missing home role ARN")
 	}
-	if !strings.Contains(config, "arn:aws:iam::111111111111:role/ci-step-runner") {
+	if !strings.Contains(config, "arn:aws:iam::111111111111:role/ci-step-runner-hub") {
 		t.Error("config missing hub role ARN")
 	}
-	if !strings.Contains(config, "arn:aws:iam::222222222222:role/ci-step-runner") {
+	if !strings.Contains(config, "arn:aws:iam::222222222222:role/ci-step-runner-target") {
 		t.Error("config missing target role ARN")
 	}
 	if !strings.Contains(config, "source_profile = home") {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## AWS STS Role Chaining Infrastructure

This PR adds three AWS CloudFormation templates to establish a secure, cross-account role chaining mechanism for CI test execution using OIDC-based authentication instead of static AWS credentials.

### The Role Chain Architecture

The templates implement a three-hop assume-role chain that enables per-test pods to authenticate to AWS without embedding credentials in the cluster:

1. **Home Role** (`home-role.cf`): Deployed once in each build cluster's AWS account, this role trusts the cluster's OIDC provider. It allows per-test ServiceAccount tokens to be exchanged for temporary credentials via `sts:AssumeRoleWithWebIdentity`, restricted to test namespaces matching the pattern `ci-op-*` with the audience `sts.amazonaws.com`.

2. **Hub Role** (`hub-role.cf`): Deployed centrally in a shared hub account, this role trusts all home roles from build clusters and permits assuming target roles. The hub role serves as a central trust anchor that allows the architecture to scale to multiple target accounts without requiring each to maintain a list of all build cluster home roles.

3. **Target Role** (`target-role.cf`): Deployed in each AWS account that tests need to access (e.g., aws-5 account), this role trusts only the hub role and provides comprehensive AWS permissions matching the legacy `origin-ci-robot-provision` user. It grants full access to CloudFormation, EC2, S3, IAM, Route53, ECR, EFS, Lambda, Secrets Manager, Elastic Load Balancing, and related services—all required for CI infrastructure provisioning and testing.

### Authentication Flow

When a CI test pod requires AWS access:
1. The pod uses a projected Kubernetes ServiceAccount token with audience `sts.amazonaws.com`
2. The AWS SDK calls `sts:AssumeRoleWithWebIdentity` against the home role using the token
3. The home role assumes the hub role to get temporary credentials
4. The hub role assumes the appropriate target role for the required AWS account
5. The test executes with the target role's permissions

### Key Benefits

- **No Static Credentials**: Eliminates need to store AWS API keys in cluster secrets; uses Kubernetes' projected ServiceAccount tokens instead
- **Scalable**: Adding new build clusters or target accounts only requires parameter updates to the hub role stack
- **Auditable**: All AWS API calls are traceable back to specific test namespaces and ServiceAccounts
- **Least Privilege**: The trust relationships enforce specific conditions (namespace patterns, audience constraints) preventing unauthorized assume-role operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->