### PR TITLE
Revert "fix: accept legacy cluster_profile in resolved configs (#5257)"

### DIFF
--- a/pkg/api/leases.go
+++ b/pkg/api/leases.go
@@ -10,7 +10,7 @@ import (
 // unique values.
 func LeasesForTest(test *TestStepConfiguration) (ret []StepLease) {
 	multiStageTest := test.MultiStageTestConfigurationLiteral
-	if p := multiStageTest.ClusterProfileLiteralOrLegacy(); p != nil {
+	if p := multiStageTest.ClusterProfileLiteral; p != nil {
 		ret = append(ret, StepLease{
 			ResourceType:   p.LeaseType,
 			Env:            DefaultLeaseEnv,

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -936,15 +936,15 @@ func (config TestStepConfiguration) IsPeriodic() bool {
 
 // GetClusterProfileName returns the cluster profile name if it's set
 func (config TestStepConfiguration) GetClusterProfileName() string {
-	if config.MultiStageTestConfigurationLiteral != nil {
-		if p := config.MultiStageTestConfigurationLiteral.ClusterProfileLiteralOrLegacy(); p != nil {
-			return p.Name
-		}
-	}
-	if config.MultiStageTestConfiguration != nil {
+	switch {
+	case config.MultiStageTestConfigurationLiteral != nil &&
+		config.MultiStageTestConfigurationLiteral.ClusterProfileLiteral != nil:
+		return config.MultiStageTestConfigurationLiteral.ClusterProfileLiteral.Name
+	case config.MultiStageTestConfiguration != nil:
 		return config.MultiStageTestConfiguration.ClusterProfile.Name()
+	default:
+		return ""
 	}
-	return ""
 }
 
 // Cloud is the name of a cloud provider, e.g., aws cluster topology, etc.
@@ -970,27 +970,6 @@ func FromClusterProfileDetails(profileDetails *ClusterProfileDetails) *ClusterPr
 		LeaseType:   profileDetails.LeaseType,
 		ClusterType: profileDetails.ClusterType,
 		Secret:      profileDetails.Secret,
-	}
-}
-
-// ClusterProfileLiteralOrLegacy returns the resolved cluster profile literal, falling back to
-// the deprecated cluster_profile string emitted by older configresolver builds.
-func (m *MultiStageTestConfigurationLiteral) ClusterProfileLiteralOrLegacy() *ClusterProfileLiteral {
-	if m == nil {
-		return nil
-	}
-	if m.ClusterProfileLiteral != nil {
-		return m.ClusterProfileLiteral
-	}
-	if m.ClusterProfile == "" {
-		return nil
-	}
-	profile := m.ClusterProfile
-	return &ClusterProfileLiteral{
-		Name:        string(profile),
-		LeaseType:   profile.LeaseType(),
-		ClusterType: profile.ClusterType(),
-		Secret:      GetDefaultClusterProfileSecretName(profile),
 	}
 }
 
@@ -1356,8 +1335,6 @@ type DependencyOverrides map[string]string
 type MultiStageTestConfigurationLiteral struct {
 	// ClusterProfileLiteral defines the profile/cloud provider for end-to-end test steps.
 	ClusterProfileLiteral *ClusterProfileLiteral `json:"cluster_profile_literal,omitempty"`
-	// ClusterProfile is deprecated; retained for configs resolved by older configresolver builds.
-	ClusterProfile ClusterProfile `json:"cluster_profile,omitempty"`
 	// Pre is the array of test steps run to set up the environment for the test.
 	Pre []LiteralTestStep `json:"pre,omitempty"`
 	// Test is the array of test steps that define the actual test.

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -368,7 +368,7 @@ func stepForTest(cfg *Config, inputImages inputImageSet, c *api.TestStepConfigur
 		step := multi_stage.MultiStageTestStep(*c, cfg.CIConfig, params, cfg.podClient, cfg.JobSpec, leases, cfg.NodeName, cfg.TargetAdditionalSuffix, nil, cfg.GSMConfig != nil, cfg.GSMConfig, isLeaseProxyServerAvailable(cfg), retry.DefaultRetry)
 
 		if len(leases) != 0 {
-			step = steps.IPPoolStep(cfg.LeaseClient, cfg.podClient, step, params, cfg.JobSpec.Namespace, cfg.MetricsAgent, test.ClusterProfileLiteralOrLegacy(), cfg.CIConfig.Metadata.Branch)
+			step = steps.IPPoolStep(cfg.LeaseClient, cfg.podClient, step, params, cfg.JobSpec.Namespace, cfg.MetricsAgent, test.ClusterProfileLiteral, cfg.CIConfig.Metadata.Branch)
 			step = steps.LeaseStep(cfg.LeaseClient, leases, step, cfg.JobSpec.Namespace, cfg.MetricsAgent, cfg.kubeClient, cfg.ClusterProfileGetter)
 		}
 

--- a/pkg/prowgen/jobbase.go
+++ b/pkg/prowgen/jobbase.go
@@ -171,7 +171,7 @@ func NewProwJobBaseBuilderForTest(configSpec *cioperatorapi.ReleaseBuildConfigur
 	switch {
 	case test.MultiStageTestConfigurationLiteral != nil:
 		p.PodSpec.Add(LeaseClient())
-		if clusterProfile := test.MultiStageTestConfigurationLiteral.ClusterProfileLiteralOrLegacy(); clusterProfile != nil {
+		if clusterProfile := test.MultiStageTestConfigurationLiteral.ClusterProfileLiteral; clusterProfile != nil {
 			p.WithLabel(cioperatorapi.CloudClusterProfileLabel, clusterProfile.Name)
 			p.WithLabel(cioperatorapi.CloudLabel, clusterProfile.ClusterType)
 		}

--- a/pkg/steps/multi_stage/multi_stage.go
+++ b/pkg/steps/multi_stage/multi_stage.go
@@ -184,7 +184,7 @@ func newMultiStageTestStep(
 		name:                             testConfig.As,
 		additionalSuffix:                 targetAdditionalSuffix,
 		nodeName:                         nodeName,
-		profile:                          ms.ClusterProfileLiteralOrLegacy(),
+		profile:                          ms.ClusterProfileLiteral,
 		config:                           config,
 		params:                           params,
 		env:                              ms.Environment,

--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -636,9 +636,9 @@ func (v *Validator) validateTestConfigurationType(
 	if testConfig := test.MultiStageTestConfigurationLiteral; testConfig != nil {
 		typeCount++
 		context := newContext(fieldPath(fieldRoot).addField("steps"), testConfig.Environment, releases, inputImagesSeen)
-		if clusterProfile := testConfig.ClusterProfileLiteralOrLegacy(); clusterProfile != nil {
+		if testConfig.ClusterProfileLiteral != nil {
 			clusterCount++
-			validationErrors = append(validationErrors, v.validateClusterProfile(fieldRoot, clusterProfile.Name, test.As, metadata)...)
+			validationErrors = append(validationErrors, v.validateClusterProfile(fieldRoot, testConfig.ClusterProfileLiteral.Name, test.As, metadata)...)
 		}
 		validationErrors = append(validationErrors, validateLeases(context.addField("leases"), testConfig.Leases)...)
 		for i, s := range testConfig.Pre {

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -672,8 +672,6 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"            # all previous `pre` and `test` steps were successful. The given step must explicitly\n" +
 	"            # ask for being skipped by setting the OptionalOnSuccess flag to true.\n" +
 	"            allow_skip_on_success: false\n" +
-	"            # ClusterProfile is deprecated; retained for configs resolved by older configresolver builds.\n" +
-	"            cluster_profile: ' '\n" +
 	"            # ClusterProfileLiteral defines the profile/cloud provider for end-to-end test steps.\n" +
 	"            cluster_profile_literal:\n" +
 	"                cluster_type: ' '\n" +
@@ -1620,8 +1618,6 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"        # all previous `pre` and `test` steps were successful. The given step must explicitly\n" +
 	"        # ask for being skipped by setting the OptionalOnSuccess flag to true.\n" +
 	"        allow_skip_on_success: false\n" +
-	"        # ClusterProfile is deprecated; retained for configs resolved by older configresolver builds.\n" +
-	"        cluster_profile: ' '\n" +
 	"        # ClusterProfileLiteral defines the profile/cloud provider for end-to-end test steps.\n" +
 	"        cluster_profile_literal:\n" +
 	"            cluster_type: ' '\n" +


### PR DESCRIPTION
This reverts commit 7b29e2d1f3f0e0488a8871981572fbf1e17c1b33.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR reverts commit 7b29e2d (PR `#5257`), which had introduced backward compatibility support for the legacy `cluster_profile` field in resolved configurations. The revert removes this legacy fallback mechanism, strictly enforcing the newer `cluster_profile_literal` format throughout the configuration processing pipeline.

**Changes Across the Codebase:**

1. **Configuration Schema** (`pkg/api/types.go`): The `MultiStageTestConfigurationLiteral` struct is reverted to use only `ClusterProfileLiteral` (with JSON tag `cluster_profile_literal`), removing the fallback `ClusterProfile` field. The `ClusterProfileLiteralOrLegacy()` helper method that bridged the two formats is deleted entirely.

2. **Configuration Validation** (`pkg/validation/test.go`): Cluster profile ownership and allowlisting validation now only runs when a `ClusterProfileLiteral` is explicitly present, no longer attempting to resolve or accept legacy representations.

3. **Test Execution Infrastructure** (`pkg/steps/multi_stage/multi_stage.go`, `pkg/defaults/defaults.go`, `pkg/api/leases.go`): Test step initialization and resource lease configuration directly use the literal cluster profile format instead of attempting fallback resolution.

4. **Prow Job Generation** (`pkg/prowgen/jobbase.go`): Job base configuration building for multi-stage tests now only recognizes the literal cluster profile format.

**Impact for CI Users and Operators:**

This is a breaking change. Resolved configurations generated by the ci-operator-configresolver must now strictly use the `cluster_profile_literal` field. Any resolved configurations still using the deprecated legacy `cluster_profile` field will fail to load, requiring updates to the configresolver output format. This removes technical debt by eliminating the dual-format support and enforces a cleaner migration away from the deprecated field format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->