### PR TITLE
fix(pod-scaler): defer CPU limit strip until after authoritative decrease

### DIFF
--- a/cmd/pod-scaler/admission.go
+++ b/cmd/pod-scaler/admission.go
@@ -291,14 +291,11 @@ func useOursIfLarger(allOfOurs, allOfTheirs *corev1.ResourceRequirements, worklo
 	}
 }
 
-// reconcileLimits ensures that container resource limits do not set anything for CPU (as we
-// are fairly certain this is never a useful thing to do) and that any limits that have been configured
-// are >=200% of requests (which they may not be any longer if we've changed requests)
+// reconcileLimits ensures memory limits are >=200% of requests after request mutation.
 func reconcileLimits(resources *corev1.ResourceRequirements) {
 	if resources.Limits == nil {
 		return
 	}
-	delete(resources.Limits, corev1.ResourceCPU)
 	if !resources.Limits.Memory().IsZero() { // Never set a limit where there isn't one defined
 		// Note: doing math on Quantities is not easy, since they may contain values that overflow
 		// normal integers. Doing math on inf.Dec is possible, but there does not exist any way to
@@ -402,6 +399,11 @@ func mutatePodResources(pod *corev1.Pod, server *resourceServer, mutateResourceL
 				}
 				applyFailureEscalation(&containers[i].Resources, workloadType, workloadName, escalations, logger)
 				applyAuthoritativeLimitDecrease(&resources, &containers[i].Resources, workloadName, workloadType, isMeasured, workloadClass, authoritativeCPU, authoritativeMemory, authoritativeCPUDryRun, authoritativeMemoryDryRun, authoritativeCPUMaxReductionPercent, authoritativeMemoryMaxReductionPercent, escalations, logger)
+				if mutateResourceLimits && !authoritativeCPU {
+					if containers[i].Resources.Limits != nil {
+						delete(containers[i].Resources.Limits, corev1.ResourceCPU)
+					}
+				}
 				clampRequestsToLimits(&containers[i].Resources)
 			}
 			preventUnschedulable(&containers[i].Resources, cpuCap, memoryCap, logger)

--- a/cmd/pod-scaler/admission_test.go
+++ b/cmd/pod-scaler/admission_test.go
@@ -1308,14 +1308,16 @@ func TestReconcileLimits(t *testing.T) {
 			name: "nothing to do",
 		},
 		{
-			name: "remove CPU limits",
+			name: "leave CPU limits unchanged",
 			input: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
 					corev1.ResourceCPU: *resource.NewQuantity(200, resource.DecimalSI),
 				},
 			},
 			expected: corev1.ResourceRequirements{
-				Limits: corev1.ResourceList{},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: *resource.NewQuantity(200, resource.DecimalSI),
+				},
 			},
 		},
 		{


### PR DESCRIPTION
[DPTP-2938](https://redhat.atlassian.net/browse/DPTP-2938) moved authoritative decrease to limits-only and runs it after reconcileLimits, which removes CPU limits but keeps memory limits. CPU authoritative dry-run/apply never fired because the limit was already gone; memory worked fine on the same path.

/cc @hector-vido 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## pod-scaler: Fix CPU limit removal timing to enable authoritative decrease

This fix corrects the order of operations in the pod-scaler's admission webhook to ensure CPU limits can be properly decreased based on measured usage in authoritative mode.

**The problem:** A previous change moved the authoritative decrease functionality (which reduces CPU and memory limits based on Prometheus-measured usage) to run after `reconcileLimits`. However, `reconcileLimits` was unconditionally removing CPU limits while preserving memory limits. This meant that when the authoritative CPU decrease logic executed, the CPU limit had already been stripped from the container, preventing any CPU limit reduction from being applied. Memory authoritative decrease continued to work since memory limits were preserved.

**The solution:** 
- `reconcileLimits` now only enforces the 200% memory limit threshold and no longer removes CPU limits
- CPU limits are now explicitly deleted after `applyAuthoritativeLimitDecrease` completes, but only when:
  - `mutateResourceLimits` is enabled (limit mutation is active)
  - `authoritativeCPU` is false (CPU authoritative decrease is disabled)

This ensures both CPU and memory limits remain available for the authoritative decrease logic to operate on before being stripped. CI operators who have enabled authoritative CPU decrease will now see CPU limits properly reduced according to measured usage data.

**Files changed:**
- `cmd/pod-scaler/admission.go`: Modified `reconcileLimits` to skip CPU limit removal; added explicit CPU limit deletion after `applyAuthoritativeLimitDecrease` when appropriate
- `cmd/pod-scaler/admission_test.go`: Updated test expectations to reflect that CPU limits are no longer removed by `reconcileLimits`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->