### PR TITLE
Add event-driven repo brancher controller

### DIFF
--- a/cmd/repo-brancher-controller/README.md
+++ b/cmd/repo-brancher-controller/README.md
@@ -1,0 +1,58 @@
+# repo-brancher-controller
+
+`repo-brancher-controller` is an event-driven replacement for the periodic
+`repo-brancher`. It derives a deduplicated set of source and target branches
+from ci-operator configuration, receives GitHub push webhooks, and updates
+target Git refs through the GitHub API with `force: false`.
+
+The controller performs an initial reconciliation and a configurable full
+resync as protection against missed webhook deliveries. Configuration is
+reloaded independently; only repositories whose desired state changed are
+enqueued.
+
+Required flags are `--config-dir`, `--forwarding-config`,
+`--plugin-config-dir`, and one GitHub authentication method. Configure
+authentication with `--github-token-path`, or with both `--github-app-id` and
+`--github-app-private-key-path`. The token or GitHub App installation needs
+repository contents write permission. The plugin config directory is checked
+on every reload so a managed organization cannot silently miss push events.
+Configure GitHub push webhooks using the endpoint and HMAC options exposed by
+the controller; the endpoint defaults to `/hook` on port 8888 and the HMAC
+secret defaults to `/etc/webhook/hmac`.
+
+The webhook listener uses Prow's standard GitHub event server. Health and
+readiness are exposed on `--health-port`, and Prometheus metrics on
+`--metrics-port`. GitHub rate-limit reset headers pause all workers sharing the
+client. Transient failures continue at `--retry-exhausted-delay` after the fast
+retry budget is consumed.
+
+## Forwarding configuration
+
+The forwarding config separates default branches from release branches:
+
+```yaml
+default_branch:
+  configs_promoting_to: "5.0"
+  targets:
+  - "5.0"
+  - "5.1"
+  ignore:
+  - Azure/ARO-HCP
+
+release_branches:
+- source: "5.0"
+  targets:
+  - "4.23"
+  ignore:
+  - Azure/ARO-HCP
+```
+
+`default_branch` selects `main` and `master` ci-operator configurations that
+promote to the configured official OCP stream. Their default branches are
+forwarded to every `release-TARGET` branch. Each `release_branches` entry maps
+one `release-SOURCE` or `openshift-SOURCE` branch to multiple targets while
+preserving the branch prefix. Ignore entries are exact organizations or
+`org/repo` names and are scoped to their containing rule.
+
+The file is strictly validated on every reload. Invalid updates leave the last
+valid desired state active.

--- a/cmd/repo-brancher-controller/config.go
+++ b/cmd/repo-brancher-controller/config.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/config"
+	"github.com/openshift/ci-tools/pkg/promotion"
+)
+
+func loadDesiredState(configDir string, forwardingConfig *forwardingConfig) (map[repoKey]sets.Set[string], error) {
+	result := map[repoKey]sets.Set[string]{}
+	err := config.OperateOnCIOperatorConfigDir(configDir, func(configuration *api.ReleaseBuildConfiguration, info *config.Info) error {
+		addTargets := func(sourceRelease string, targets []string) error {
+			key := repoKey{org: info.Org, repo: info.Repo, source: info.Branch}
+			for _, targetRelease := range targets {
+				target, err := promotion.DetermineReleaseBranch(sourceRelease, targetRelease, info.Branch)
+				if err != nil {
+					return fmt.Errorf("determine target branch for %s: %w", key, err)
+				}
+				if target != info.Branch {
+					if result[key] == nil {
+						result[key] = sets.New[string]()
+					}
+					result[key].Insert(target)
+				}
+			}
+			return nil
+		}
+
+		if current := forwardingConfig.DefaultBranch; current != nil && (info.Branch == "main" || info.Branch == "master") && !isIgnored(current.Ignore, info.Org, info.Repo) && api.PromotesOfficialImage(configuration, api.WithoutOKD, current.ConfigsPromotingTo) {
+			if err := addTargets(current.ConfigsPromotingTo, current.Targets); err != nil {
+				return err
+			}
+		}
+
+		for _, forwarding := range forwardingConfig.ReleaseBranches {
+			if isIgnored(forwarding.Ignore, info.Org, info.Repo) || !api.PromotesOfficialImage(configuration, api.WithoutOKD, forwarding.Source) {
+				continue
+			}
+			if info.Branch != "release-"+forwarding.Source && info.Branch != "openshift-"+forwarding.Source {
+				continue
+			}
+			if err := addTargets(forwarding.Source, forwarding.Targets); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	return result, err
+}

--- a/cmd/repo-brancher-controller/config_test.go
+++ b/cmd/repo-brancher-controller/config_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func writeConfig(t *testing.T, root, org, repo, branch string) {
+	t.Helper()
+	dir := filepath.Join(root, org, repo)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	raw := []byte(fmt.Sprintf(`promotion:
+  to:
+  - name: %q
+    namespace: ocp
+resources:
+  '*':
+    requests:
+      cpu: 10m
+tests:
+- as: unit
+  commands: "true"
+  container:
+    from: src
+zz_generated_metadata:
+  branch: %s
+  org: %s
+  repo: %s
+`, "5.0", branch, org, repo))
+	path := filepath.Join(dir, fmt.Sprintf("%s-%s-%s.yaml", org, repo, branch))
+	if err := os.WriteFile(path, raw, 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoadDesiredStateUsesBranchCategoriesAndScopedIgnores(t *testing.T) {
+	configDir := filepath.Join(t.TempDir(), "config")
+	writeConfig(t, configDir, "org", "default", "main")
+	writeConfig(t, configDir, "org", "release", "release-5.0")
+	writeConfig(t, configDir, "org", "openshift-release", "openshift-5.0")
+	writeConfig(t, configDir, "org", "wrong-release", "release-4.23")
+	writeConfig(t, configDir, "ignored-default", "repo", "master")
+	writeConfig(t, configDir, "org", "ignored-release", "release-5.0")
+
+	rules := &forwardingConfig{
+		DefaultBranch: &defaultBranchForwarding{
+			ConfigsPromotingTo: "5.0",
+			Targets:            []string{"5.0", "5.1"},
+			Ignore:             []string{"ignored-default"},
+		},
+		ReleaseBranches: []releaseBranchForwarding{{
+			Source:  "5.0",
+			Targets: []string{"4.23"},
+			Ignore:  []string{"org/ignored-release"},
+		}},
+	}
+	state, err := loadDesiredState(configDir, rules)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[repoKey]sets.Set[string]{
+		{org: "org", repo: "default", source: "main"}:                    sets.New("release-5.0", "release-5.1"),
+		{org: "org", repo: "release", source: "release-5.0"}:             sets.New("release-4.23"),
+		{org: "org", repo: "openshift-release", source: "openshift-5.0"}: sets.New("openshift-4.23"),
+	}
+	if len(state) != len(want) {
+		t.Fatalf("unexpected desired state: want %v, got %v", want, state)
+	}
+	for key, targets := range want {
+		if got, ok := state[key]; !ok || !got.Equal(targets) {
+			t.Fatalf("unexpected targets for %s: want %v, got %v", key, targets, got)
+		}
+	}
+}

--- a/cmd/repo-brancher-controller/controller.go
+++ b/cmd/repo-brancher-controller/controller.go
@@ -1,0 +1,302 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/workqueue"
+)
+
+type repoKey struct {
+	org, repo, source string
+}
+
+func (k repoKey) String() string { return fmt.Sprintf("%s/%s@%s", k.org, k.repo, k.source) }
+
+type desiredState struct {
+	mu       sync.RWMutex
+	targets  map[repoKey]sets.Set[string]
+	keyLocks map[repoKey]*sync.Mutex
+}
+
+func newDesiredState() *desiredState {
+	return &desiredState{targets: map[repoKey]sets.Set[string]{}, keyLocks: map[repoKey]*sync.Mutex{}}
+}
+
+func (s *desiredState) keyLockLocked(key repoKey) *sync.Mutex {
+	if s.keyLocks[key] == nil {
+		s.keyLocks[key] = &sync.Mutex{}
+	}
+	return s.keyLocks[key]
+}
+
+func cloneTargets(in map[repoKey]sets.Set[string]) map[repoKey]sets.Set[string] {
+	out := make(map[repoKey]sets.Set[string], len(in))
+	for key, targets := range in {
+		out[key] = targets.Clone()
+	}
+	return out
+}
+
+// replace installs a new desired state and returns keys whose configuration changed.
+func (s *desiredState) replace(next map[repoKey]sets.Set[string]) []repoKey {
+	s.mu.Lock()
+	allKeys := sets.New[repoKey]()
+	for key := range s.targets {
+		allKeys.Insert(key)
+	}
+	for key := range next {
+		allKeys.Insert(key)
+	}
+	keys := allKeys.UnsortedList()
+	sort.Slice(keys, func(i, j int) bool { return keys[i].String() < keys[j].String() })
+	locks := make([]*sync.Mutex, 0, len(keys))
+	for _, key := range keys {
+		locks = append(locks, s.keyLockLocked(key))
+	}
+	s.mu.Unlock()
+	for _, lock := range locks {
+		lock.Lock()
+	}
+	defer func() {
+		for i := len(locks) - 1; i >= 0; i-- {
+			locks[i].Unlock()
+		}
+	}()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	changed := sets.New[repoKey]()
+	for key, targets := range next {
+		if old, ok := s.targets[key]; !ok || !old.Equal(targets) {
+			changed.Insert(key)
+		}
+	}
+	s.targets = cloneTargets(next)
+	return changed.UnsortedList()
+}
+
+func (s *desiredState) get(key repoKey) (sets.Set[string], bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	targets, ok := s.targets[key]
+	if !ok {
+		return nil, false
+	}
+	return targets.Clone(), true
+}
+
+func (s *desiredState) matching(org, repo, branch string) []repoKey {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	key := repoKey{org: org, repo: repo, source: branch}
+	if _, ok := s.targets[key]; ok {
+		return []repoKey{key}
+	}
+	return nil
+}
+
+// ifTargetConfigured serializes mutations with desired-state replacement for
+// this repository. Reloads wait for an already-started mutation; mutations
+// starting after a removal observe the new state and are skipped.
+func (s *desiredState) ifTargetConfigured(key repoKey, target string, fn func() error) (bool, error) {
+	s.mu.Lock()
+	keyLock := s.keyLockLocked(key)
+	s.mu.Unlock()
+	keyLock.Lock()
+	defer keyLock.Unlock()
+	s.mu.RLock()
+	targets, ok := s.targets[key]
+	configured := ok && targets.Has(target)
+	s.mu.RUnlock()
+	if !configured {
+		return false, nil
+	}
+	return true, fn()
+}
+
+func (s *desiredState) keys() []repoKey {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	result := make([]repoKey, 0, len(s.targets))
+	for key := range s.targets {
+		result = append(result, key)
+	}
+	return result
+}
+
+type refClient interface {
+	getRef(context.Context, string, string, string) (sha string, exists bool, err error)
+	createRef(context.Context, string, string, string, string) error
+	updateRef(context.Context, string, string, string, string) error
+}
+
+type controller struct {
+	refs                refClient
+	state               *desiredState
+	queue               workqueue.TypedRateLimitingInterface[repoKey]
+	maxRetries          int
+	retryExhaustedDelay time.Duration
+}
+
+type permanentError struct{ error }
+
+func jitterDuration(duration time.Duration, factor float64) time.Duration {
+	if duration <= 0 || factor <= 0 {
+		return duration
+	}
+	multiplier := 1 - factor + rand.Float64()*(2*factor)
+	return time.Duration(float64(duration) * multiplier)
+}
+
+type reconciliationErrors struct {
+	retryable []error
+	permanent []error
+}
+
+func (e *reconciliationErrors) Error() string {
+	return errors.Join(append(append([]error{}, e.retryable...), e.permanent...)...).Error()
+}
+
+func (e *reconciliationErrors) Unwrap() []error {
+	return append(append([]error{}, e.retryable...), e.permanent...)
+}
+
+func newController(refs refClient, state *desiredState, maxRetries int, retryExhaustedDelay ...time.Duration) *controller {
+	delay := 15 * time.Minute
+	if len(retryExhaustedDelay) > 0 {
+		delay = retryExhaustedDelay[0]
+	}
+	return &controller{
+		refs:                refs,
+		state:               state,
+		queue:               workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[repoKey]()),
+		maxRetries:          maxRetries,
+		retryExhaustedDelay: delay,
+	}
+}
+
+func (c *controller) enqueue(keys ...repoKey) {
+	for _, key := range keys {
+		c.queue.Add(key)
+	}
+	queueDepth.Set(float64(c.queue.Len()))
+}
+
+func (c *controller) runWorker(ctx context.Context) {
+	for c.processNext(ctx) {
+	}
+}
+
+func (c *controller) processNext(ctx context.Context) bool {
+	key, shutdown := c.queue.Get()
+	if shutdown {
+		return false
+	}
+	queueDepth.Set(float64(c.queue.Len()))
+	defer c.queue.Done(key)
+
+	if err := c.reconcile(ctx, key); err != nil {
+		logger := logrus.WithField("repo", key.String()).WithError(err)
+		var aggregate *reconciliationErrors
+		if errors.As(err, &aggregate) {
+			if len(aggregate.permanent) > 0 {
+				c.reportPermanentError(key, logger)
+			}
+			if len(aggregate.retryable) > 0 {
+				c.retry(key, logger)
+				return true
+			}
+			return true
+		}
+		var permanent permanentError
+		if errors.As(err, &permanent) {
+			c.reportPermanentError(key, logger)
+			return true
+		}
+		c.retry(key, logger)
+		return true
+	}
+	reconciliationTotal.WithLabelValues("success").Inc()
+	c.queue.Forget(key)
+	return true
+}
+
+func (c *controller) reportPermanentError(key repoKey, logger *logrus.Entry) {
+	logger.Error("reconciliation requires manual intervention")
+	reconciliationTotal.WithLabelValues("permanent_error").Inc()
+	c.queue.Forget(key)
+}
+
+func (c *controller) retry(key repoKey, logger *logrus.Entry) {
+	if c.queue.NumRequeues(key) < c.maxRetries {
+		reconciliationTotal.WithLabelValues("retry").Inc()
+		logger.Warn("reconciliation failed; retrying")
+		c.queue.AddRateLimited(key)
+	} else {
+		logger.WithField("retry_after", c.retryExhaustedDelay).Error("fast retry limit reached; scheduling slow retry")
+		reconciliationTotal.WithLabelValues("retry_exhausted").Inc()
+		c.queue.Forget(key)
+		c.queue.AddAfter(key, jitterDuration(c.retryExhaustedDelay, 0.2))
+	}
+}
+
+func (c *controller) reconcile(ctx context.Context, key repoKey) error {
+	targetSet, configured := c.state.get(key)
+	if !configured {
+		return nil
+	}
+	sourceSHA, exists, err := c.refs.getRef(ctx, key.org, key.repo, key.source)
+	if err != nil {
+		return fmt.Errorf("get source ref: %w", err)
+	}
+	if !exists {
+		return fmt.Errorf("source branch %q does not exist", key.source)
+	}
+
+	targets := targetSet.UnsortedList()
+	sort.Strings(targets)
+	aggregate := &reconciliationErrors{}
+	for _, target := range targets {
+		targetSHA, targetExists, err := c.refs.getRef(ctx, key.org, key.repo, target)
+		if err != nil {
+			aggregate.retryable = append(aggregate.retryable, fmt.Errorf("get target %s: %w", target, err))
+			continue
+		}
+		if targetExists && targetSHA == sourceSHA {
+			continue
+		}
+		performed, err := c.state.ifTargetConfigured(key, target, func() error {
+			if !targetExists {
+				return c.refs.createRef(ctx, key.org, key.repo, target, sourceSHA)
+			}
+			return c.refs.updateRef(ctx, key.org, key.repo, target, sourceSHA)
+		})
+		if !performed {
+			continue
+		}
+		if err != nil {
+			wrapped := fmt.Errorf("fast-forward %s: %w", target, err)
+			var permanent permanentError
+			if errors.As(err, &permanent) {
+				aggregate.permanent = append(aggregate.permanent, wrapped)
+			} else {
+				aggregate.retryable = append(aggregate.retryable, wrapped)
+			}
+			continue
+		}
+		logrus.WithFields(logrus.Fields{"repo": key.org + "/" + key.repo, "source": key.source, "target": target, "sha": sourceSHA}).Info("fast-forwarded branch")
+	}
+	if len(aggregate.retryable) == 0 && len(aggregate.permanent) == 0 {
+		return nil
+	}
+	return aggregate
+}

--- a/cmd/repo-brancher-controller/controller_test.go
+++ b/cmd/repo-brancher-controller/controller_test.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type fakeRefClient struct {
+	refs    map[string]string
+	creates []string
+	updates []string
+	err     error
+}
+
+func refID(org, repo, branch string) string { return fmt.Sprintf("%s/%s@%s", org, repo, branch) }
+
+func (f *fakeRefClient) getRef(_ context.Context, org, repo, branch string) (string, bool, error) {
+	sha, ok := f.refs[refID(org, repo, branch)]
+	return sha, ok, nil
+}
+
+func (f *fakeRefClient) createRef(_ context.Context, org, repo, branch, sha string) error {
+	f.creates = append(f.creates, refID(org, repo, branch)+"="+sha)
+	if f.err == nil {
+		f.refs[refID(org, repo, branch)] = sha
+	}
+	return f.err
+}
+
+func (f *fakeRefClient) updateRef(_ context.Context, org, repo, branch, sha string) error {
+	f.updates = append(f.updates, refID(org, repo, branch)+"="+sha)
+	if f.err == nil {
+		f.refs[refID(org, repo, branch)] = sha
+	}
+	return f.err
+}
+
+func counterValue(t *testing.T, label string) float64 {
+	t.Helper()
+	metric := &dto.Metric{}
+	if err := reconciliationTotal.WithLabelValues(label).Write(metric); err != nil {
+		t.Fatal(err)
+	}
+	return metric.GetCounter().GetValue()
+}
+
+func TestReconcile(t *testing.T) {
+	key := repoKey{org: "org", repo: "repo", source: "main"}
+	state := newDesiredState()
+	state.replace(map[repoKey]sets.Set[string]{key: sets.New("release-4.20", "release-4.21", "release-4.22")})
+	refs := &fakeRefClient{refs: map[string]string{
+		refID("org", "repo", "main"):         "new",
+		refID("org", "repo", "release-4.20"): "new",
+		refID("org", "repo", "release-4.21"): "old",
+	}}
+	c := newController(refs, state, 1)
+	defer c.queue.ShutDown()
+	if err := c.reconcile(context.Background(), key); err != nil {
+		t.Fatal(err)
+	}
+	if len(refs.updates) != 1 || refs.updates[0] != "org/repo@release-4.21=new" {
+		t.Fatalf("unexpected updates: %v", refs.updates)
+	}
+	if len(refs.creates) != 1 || refs.creates[0] != "org/repo@release-4.22=new" {
+		t.Fatalf("unexpected creates: %v", refs.creates)
+	}
+}
+
+func TestDesiredStateDeduplicatesTargets(t *testing.T) {
+	key := repoKey{org: "org", repo: "repo", source: "main"}
+	s := newDesiredState()
+	changed := s.replace(map[repoKey]sets.Set[string]{key: sets.New("release-4.20", "release-4.20")})
+	if len(changed) != 1 {
+		t.Fatalf("expected one changed repository, got %v", changed)
+	}
+	changed = s.replace(map[repoKey]sets.Set[string]{key: sets.New("release-4.20")})
+	if len(changed) != 0 {
+		t.Fatalf("equivalent desired state was reported changed: %v", changed)
+	}
+	if got := s.matching("org", "repo", "main"); len(got) != 1 || got[0] != key {
+		t.Fatalf("unexpected webhook match: %v", got)
+	}
+}
+
+type targetErrorRefClient struct{ fakeRefClient }
+
+func (f *targetErrorRefClient) updateRef(_ context.Context, _, _, branch, _ string) error {
+	if branch == "release-5.0" {
+		return permanentError{errors.New("not a fast forward")}
+	}
+	return errors.New("temporary network failure")
+}
+
+func TestReconcilePreservesRetryableSiblingError(t *testing.T) {
+	key := repoKey{org: "org", repo: "repo", source: "main"}
+	state := newDesiredState()
+	state.replace(map[repoKey]sets.Set[string]{key: sets.New("release-5.0", "release-5.1")})
+	refs := &targetErrorRefClient{fakeRefClient: fakeRefClient{refs: map[string]string{
+		refID("org", "repo", "main"):        "new",
+		refID("org", "repo", "release-5.0"): "old",
+		refID("org", "repo", "release-5.1"): "old",
+	}}}
+	c := newController(refs, state, 1)
+	defer c.queue.ShutDown()
+	err := c.reconcile(context.Background(), key)
+	var aggregate *reconciliationErrors
+	if !errors.As(err, &aggregate) || len(aggregate.permanent) != 1 || len(aggregate.retryable) != 1 {
+		t.Fatalf("expected one permanent and one retryable error, got %#v", err)
+	}
+}
+
+func TestProcessNextReportsPermanentErrorWithRetryableSibling(t *testing.T) {
+	key := repoKey{org: "org", repo: "repo", source: "main"}
+	state := newDesiredState()
+	state.replace(map[repoKey]sets.Set[string]{key: sets.New("release-5.0", "release-5.1")})
+	refs := &targetErrorRefClient{fakeRefClient: fakeRefClient{refs: map[string]string{
+		refID("org", "repo", "main"):        "new",
+		refID("org", "repo", "release-5.0"): "old",
+		refID("org", "repo", "release-5.1"): "old",
+	}}}
+	c := newController(refs, state, 1)
+	defer c.queue.ShutDown()
+
+	beforePermanent := counterValue(t, "permanent_error")
+	beforeRetry := counterValue(t, "retry")
+	c.enqueue(key)
+	if !c.processNext(context.Background()) {
+		t.Fatal("processNext unexpectedly stopped")
+	}
+	if got := counterValue(t, "permanent_error"); got != beforePermanent+1 {
+		t.Fatalf("permanent error metric: want %v, got %v", beforePermanent+1, got)
+	}
+	if got := counterValue(t, "retry"); got != beforeRetry+1 {
+		t.Fatalf("retry metric: want %v, got %v", beforeRetry+1, got)
+	}
+}
+
+func TestRemovedTargetIsNotMutated(t *testing.T) {
+	key := repoKey{org: "org", repo: "repo", source: "main"}
+	state := newDesiredState()
+	state.replace(map[repoKey]sets.Set[string]{key: sets.New("release-5.0")})
+	state.replace(map[repoKey]sets.Set[string]{})
+	called, err := state.ifTargetConfigured(key, "release-5.0", func() error {
+		t.Fatal("mutation called for removed target")
+		return nil
+	})
+	if err != nil || called {
+		t.Fatalf("unexpected result: called=%v err=%v", called, err)
+	}
+}
+
+func TestReplacementWaitsForRepositoryMutation(t *testing.T) {
+	key := repoKey{org: "org", repo: "repo", source: "main"}
+	state := newDesiredState()
+	state.replace(map[repoKey]sets.Set[string]{key: sets.New("release-5.0")})
+	mutationStarted, releaseMutation := make(chan struct{}), make(chan struct{})
+	mutationDone := make(chan struct{})
+	go func() {
+		defer close(mutationDone)
+		_, _ = state.ifTargetConfigured(key, "release-5.0", func() error {
+			close(mutationStarted)
+			<-releaseMutation
+			return nil
+		})
+	}()
+	<-mutationStarted
+	replacementDone := make(chan struct{})
+	go func() {
+		state.replace(map[repoKey]sets.Set[string]{})
+		close(replacementDone)
+	}()
+	select {
+	case <-replacementDone:
+		t.Fatal("replacement completed while mutation was active")
+	case <-time.After(25 * time.Millisecond):
+	}
+	close(releaseMutation)
+	<-mutationDone
+	select {
+	case <-replacementDone:
+	case <-time.After(time.Second):
+		t.Fatal("replacement did not complete after mutation")
+	}
+}

--- a/cmd/repo-brancher-controller/forwarding.go
+++ b/cmd/repo-brancher-controller/forwarding.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/yaml"
+
+	"github.com/openshift/ci-tools/pkg/api/ocplifecycle"
+)
+
+var repositoryPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)?$`)
+
+type forwardingConfig struct {
+	DefaultBranch   *defaultBranchForwarding  `json:"default_branch,omitempty"`
+	ReleaseBranches []releaseBranchForwarding `json:"release_branches,omitempty"`
+}
+
+type defaultBranchForwarding struct {
+	ConfigsPromotingTo string   `json:"configs_promoting_to"`
+	Targets            []string `json:"targets"`
+	Ignore             []string `json:"ignore,omitempty"`
+}
+
+type releaseBranchForwarding struct {
+	Source  string   `json:"source"`
+	Targets []string `json:"targets"`
+	Ignore  []string `json:"ignore,omitempty"`
+}
+
+func loadForwardingConfig(path string) (*forwardingConfig, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read forwarding config: %w", err)
+	}
+	config := &forwardingConfig{}
+	if err := yaml.UnmarshalStrict(raw, config); err != nil {
+		return nil, fmt.Errorf("parse forwarding config: %w", err)
+	}
+	if err := config.validate(); err != nil {
+		return nil, fmt.Errorf("validate forwarding config: %w", err)
+	}
+	return config, nil
+}
+
+func (c *forwardingConfig) validate() error {
+	if c.DefaultBranch == nil && len(c.ReleaseBranches) == 0 {
+		return errors.New("at least one of default_branch or release_branches must be configured")
+	}
+	var errs []error
+	if c.DefaultBranch != nil {
+		if err := validateRelease("default_branch.configs_promoting_to", c.DefaultBranch.ConfigsPromotingTo); err != nil {
+			errs = append(errs, err)
+		}
+		if err := validateTargets("default_branch.targets", c.DefaultBranch.Targets, ""); err != nil {
+			errs = append(errs, err)
+		}
+		if err := validateIgnored("default_branch.ignore", c.DefaultBranch.Ignore); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	sources := sets.New[string]()
+	for i, forwarding := range c.ReleaseBranches {
+		prefix := fmt.Sprintf("release_branches[%d]", i)
+		if err := validateRelease(prefix+".source", forwarding.Source); err != nil {
+			errs = append(errs, err)
+		}
+		if sources.Has(forwarding.Source) {
+			errs = append(errs, fmt.Errorf("%s.source %q is duplicated", prefix, forwarding.Source))
+		}
+		sources.Insert(forwarding.Source)
+		if err := validateTargets(prefix+".targets", forwarding.Targets, forwarding.Source); err != nil {
+			errs = append(errs, err)
+		}
+		if err := validateIgnored(prefix+".ignore", forwarding.Ignore); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func validateRelease(field, value string) error {
+	if _, err := ocplifecycle.ParseMajorMinor(value); err != nil {
+		return fmt.Errorf("%s %q is invalid: %w", field, value, err)
+	}
+	return nil
+}
+
+func validateTargets(field string, targets []string, source string) error {
+	if len(targets) == 0 {
+		return fmt.Errorf("%s must contain at least one release", field)
+	}
+	seen := sets.New[string]()
+	var errs []error
+	for _, target := range targets {
+		if err := validateRelease(field, target); err != nil {
+			errs = append(errs, err)
+		}
+		if seen.Has(target) {
+			errs = append(errs, fmt.Errorf("%s contains duplicate release %q", field, target))
+		}
+		if source != "" && target == source {
+			errs = append(errs, fmt.Errorf("%s contains source release %q", field, source))
+		}
+		seen.Insert(target)
+	}
+	return errors.Join(errs...)
+}
+
+func validateIgnored(field string, ignored []string) error {
+	seen := sets.New[string]()
+	var errs []error
+	for _, entry := range ignored {
+		if entry != strings.TrimSpace(entry) || !repositoryPattern.MatchString(entry) {
+			errs = append(errs, fmt.Errorf("%s entry %q must be an org or org/repo", field, entry))
+		}
+		if seen.Has(entry) {
+			errs = append(errs, fmt.Errorf("%s contains duplicate entry %q", field, entry))
+		}
+		seen.Insert(entry)
+	}
+	return errors.Join(errs...)
+}
+
+func isIgnored(ignored []string, org, repo string) bool {
+	repository := org + "/" + repo
+	for _, entry := range ignored {
+		if entry == org || entry == repository {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/repo-brancher-controller/forwarding_test.go
+++ b/cmd/repo-brancher-controller/forwarding_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadForwardingConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "forwarding.yaml")
+	raw := []byte(`default_branch:
+  configs_promoting_to: "5.0"
+  targets:
+  - "5.0"
+  - "5.1"
+  ignore:
+  - Azure/ARO-HCP
+release_branches:
+- source: "5.0"
+  targets:
+  - "4.23"
+  ignore:
+  - ignored-org
+  - ignored-org/repo
+`)
+	if err := os.WriteFile(path, raw, 0600); err != nil {
+		t.Fatal(err)
+	}
+	config, err := loadForwardingConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.DefaultBranch.ConfigsPromotingTo != "5.0" || len(config.DefaultBranch.Targets) != 2 || len(config.ReleaseBranches) != 1 {
+		t.Fatalf("unexpected config: %#v", config)
+	}
+}
+
+func TestForwardingConfigValidation(t *testing.T) {
+	tests := map[string]string{
+		"empty":                        `{}`,
+		"unknown field":                `unknown: true`,
+		"invalid selected release":     "default_branch:\n  configs_promoting_to: invalid\n  targets: [\"5.0\"]",
+		"empty targets":                "default_branch:\n  configs_promoting_to: \"5.0\"\n  targets: []",
+		"duplicate targets":            "default_branch:\n  configs_promoting_to: \"5.0\"\n  targets: [\"5.1\", \"5.1\"]",
+		"invalid ignore":               "default_branch:\n  configs_promoting_to: \"5.0\"\n  targets: [\"5.1\"]\n  ignore: [org/repo/extra]",
+		"duplicate source":             "release_branches:\n- source: \"5.0\"\n  targets: [\"4.23\"]\n- source: \"5.0\"\n  targets: [\"5.1\"]",
+		"release forwards to itself":   "release_branches:\n- source: \"5.0\"\n  targets: [\"5.0\"]",
+		"duplicate ignored repository": "release_branches:\n- source: \"5.0\"\n  targets: [\"5.1\"]\n  ignore: [org/repo, org/repo]",
+	}
+	for name, raw := range tests {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "forwarding.yaml")
+			if err := os.WriteFile(path, []byte(raw), 0600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := loadForwardingConfig(path); err == nil {
+				t.Fatal("expected invalid configuration to be rejected")
+			}
+		})
+	}
+}
+
+func TestIsIgnored(t *testing.T) {
+	ignored := []string{"all-org", "specific-org/repo"}
+	if !isIgnored(ignored, "all-org", "anything") || !isIgnored(ignored, "specific-org", "repo") || isIgnored(ignored, "specific-org", "other") {
+		t.Fatal("org and org/repo ignore matching is incorrect")
+	}
+}

--- a/cmd/repo-brancher-controller/github.go
+++ b/cmd/repo-brancher-controller/github.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/prow/pkg/github"
+)
+
+type prowRefClient interface {
+	GetRefWithContext(context.Context, string, string, string) (string, error)
+	CreateRefWithContext(context.Context, string, string, string, string) error
+	UpdateRefWithContext(context.Context, string, string, string, string, bool) error
+}
+
+// githubRefClient adapts Prow's shared GitHub client to the controller's
+// deliberately small refClient interface. Authentication, request execution,
+// throttling, and retries remain owned by Prow.
+type githubRefClient struct {
+	client prowRefClient
+	health *runtimeHealth
+}
+
+func newGitHubRefClient(client prowRefClient, health *runtimeHealth) *githubRefClient {
+	return &githubRefClient{client: client, health: health}
+}
+
+func (c *githubRefClient) succeeded() {
+	if c.health != nil {
+		c.health.githubSucceeded()
+	}
+}
+
+func (c *githubRefClient) getRef(ctx context.Context, org, repo, branch string) (string, bool, error) {
+	sha, err := c.client.GetRefWithContext(ctx, org, repo, "heads/"+branch)
+	if github.IsNotFound(err) {
+		c.succeeded()
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	c.succeeded()
+	return sha, true, nil
+}
+
+func (c *githubRefClient) createRef(ctx context.Context, org, repo, branch, sha string) error {
+	err := c.client.CreateRefWithContext(ctx, org, repo, "refs/heads/"+branch, sha)
+	if err == nil {
+		c.succeeded()
+		return nil
+	}
+	if !github.IsUnprocessableEntity(err) {
+		return err
+	}
+
+	// A concurrent reconciliation may have created the target after it was
+	// observed as missing. Re-read it and apply the same non-forced update used
+	// for an existing target.
+	currentSHA, exists, getErr := c.getRef(ctx, org, repo, branch)
+	if getErr != nil {
+		return fmt.Errorf("re-read ref after create conflict: %w", getErr)
+	}
+	if !exists {
+		return permanentError{fmt.Errorf("GitHub rejected ref creation: %w", err)}
+	}
+	if currentSHA == sha {
+		return nil
+	}
+	return c.updateRef(ctx, org, repo, branch, sha)
+}
+
+func (c *githubRefClient) updateRef(ctx context.Context, org, repo, branch, sha string) error {
+	err := c.client.UpdateRefWithContext(ctx, org, repo, "heads/"+branch, sha, false)
+	if err == nil {
+		c.succeeded()
+		return nil
+	}
+	if github.IsUnprocessableEntity(err) {
+		c.succeeded()
+		return permanentError{fmt.Errorf("GitHub rejected non-forced ref update: %w", err)}
+	}
+	return err
+}

--- a/cmd/repo-brancher-controller/github_test.go
+++ b/cmd/repo-brancher-controller/github_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"sigs.k8s.io/prow/pkg/github"
+)
+
+type fakeProwRefClient struct {
+	refs      map[string]string
+	getErr    error
+	createErr error
+	updateErr error
+	creates   []string
+	updates   []string
+}
+
+func (f *fakeProwRefClient) GetRefWithContext(_ context.Context, org, repo, ref string) (string, error) {
+	if f.getErr != nil {
+		return "", f.getErr
+	}
+	sha, ok := f.refs[org+"/"+repo+"@"+ref]
+	if !ok {
+		return "", github.NewNotFound()
+	}
+	return sha, nil
+}
+
+func (f *fakeProwRefClient) CreateRefWithContext(_ context.Context, org, repo, ref, sha string) error {
+	f.creates = append(f.creates, org+"/"+repo+"@"+ref+"="+sha)
+	return f.createErr
+}
+
+func (f *fakeProwRefClient) UpdateRefWithContext(_ context.Context, org, repo, ref, sha string, force bool) error {
+	f.updates = append(f.updates, org+"/"+repo+"@"+ref+"="+sha)
+	if force {
+		return errors.New("force must remain false")
+	}
+	return f.updateErr
+}
+
+func TestGitHubRefClientUsesProwRefOperations(t *testing.T) {
+	upstream := &fakeProwRefClient{refs: map[string]string{"org/repo@heads/main": "source-sha"}}
+	client := newGitHubRefClient(upstream, nil)
+	sha, exists, err := client.getRef(context.Background(), "org", "repo", "main")
+	if err != nil || !exists || sha != "source-sha" {
+		t.Fatalf("get source: sha=%q exists=%v err=%v", sha, exists, err)
+	}
+	if _, exists, err := client.getRef(context.Background(), "org", "repo", "target"); err != nil || exists {
+		t.Fatalf("get missing target: exists=%v err=%v", exists, err)
+	}
+	if err := client.createRef(context.Background(), "org", "repo", "target", sha); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.updateRef(context.Background(), "org", "repo", "target", sha); err != nil {
+		t.Fatal(err)
+	}
+	if len(upstream.creates) != 1 || upstream.creates[0] != "org/repo@refs/heads/target=source-sha" {
+		t.Fatalf("unexpected creates: %v", upstream.creates)
+	}
+	if len(upstream.updates) != 1 || upstream.updates[0] != "org/repo@heads/target=source-sha" {
+		t.Fatalf("unexpected updates: %v", upstream.updates)
+	}
+}
+
+func TestUpdateRefValidationFailureIsPermanent(t *testing.T) {
+	upstream := &fakeProwRefClient{updateErr: github.NewUnprocessableEntity()}
+	err := newGitHubRefClient(upstream, nil).updateRef(context.Background(), "org", "repo", "target", "sha")
+	var permanent permanentError
+	if !errors.As(err, &permanent) {
+		t.Fatalf("expected permanent error, got %T: %v", err, err)
+	}
+}
+
+func TestCreateRefRecoversFromConcurrentCreation(t *testing.T) {
+	upstream := &fakeProwRefClient{
+		refs:      map[string]string{"org/repo@heads/target": "other-sha"},
+		createErr: github.NewUnprocessableEntity(),
+	}
+	if err := newGitHubRefClient(upstream, nil).createRef(context.Background(), "org", "repo", "target", "desired-sha"); err != nil {
+		t.Fatalf("recover create race: %v", err)
+	}
+	if len(upstream.updates) != 1 || upstream.updates[0] != "org/repo@heads/target=desired-sha" {
+		t.Fatalf("unexpected updates: %v", upstream.updates)
+	}
+}
+
+func TestCreateRefValidationFailureIsPermanent(t *testing.T) {
+	upstream := &fakeProwRefClient{refs: map[string]string{}, createErr: github.NewUnprocessableEntity()}
+	err := newGitHubRefClient(upstream, nil).createRef(context.Background(), "org", "repo", "target", "sha")
+	var permanent permanentError
+	if !errors.As(err, &permanent) {
+		t.Fatalf("expected permanent error, got %T: %v", err, err)
+	}
+}

--- a/cmd/repo-brancher-controller/health.go
+++ b/cmd/repo-brancher-controller/health.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+type runtimeHealth struct {
+	serverHealthy      atomic.Bool
+	lastConfigSuccess  atomic.Int64
+	lastGitHubSuccess  atomic.Int64
+	maxConfigStaleness time.Duration
+}
+
+func (h *runtimeHealth) configSucceeded() {
+	now := time.Now().Unix()
+	h.lastConfigSuccess.Store(now)
+	lastSuccessfulConfigReload.Set(float64(now))
+}
+
+func (h *runtimeHealth) githubSucceeded() {
+	now := time.Now().Unix()
+	h.lastGitHubSuccess.Store(now)
+	lastSuccessfulGitHubRequest.Set(float64(now))
+}
+
+func (h *runtimeHealth) ready(now time.Time) bool {
+	if !h.serverHealthy.Load() {
+		return false
+	}
+	lastConfigSuccess := h.lastConfigSuccess.Load()
+	if lastConfigSuccess == 0 || now.Sub(time.Unix(lastConfigSuccess, 0)) > h.maxConfigStaleness {
+		return false
+	}
+	lastGitHubSuccess := h.lastGitHubSuccess.Load()
+	if lastGitHubSuccess == 0 || now.Sub(time.Unix(lastGitHubSuccess, 0)) > h.maxConfigStaleness {
+		return false
+	}
+	return true
+}

--- a/cmd/repo-brancher-controller/health_test.go
+++ b/cmd/repo-brancher-controller/health_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRuntimeHealthReadiness(t *testing.T) {
+	now := time.Now()
+	health := &runtimeHealth{maxConfigStaleness: time.Minute}
+	if health.ready(now) {
+		t.Fatal("new health state must not be ready")
+	}
+	health.serverHealthy.Store(true)
+	health.configSucceeded()
+	health.githubSucceeded()
+	if !health.ready(time.Now()) {
+		t.Fatal("healthy runtime should be ready")
+	}
+	if health.ready(time.Now().Add(2 * time.Minute)) {
+		t.Fatal("stale configuration and GitHub success must fail readiness")
+	}
+
+	health.lastConfigSuccess.Store(now.Unix())
+	health.lastGitHubSuccess.Store(now.Add(-2 * time.Minute).Unix())
+	if health.ready(now) {
+		t.Fatal("stale GitHub success must fail readiness")
+	}
+}

--- a/cmd/repo-brancher-controller/main.go
+++ b/cmd/repo-brancher-controller/main.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"os"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	prowconfig "sigs.k8s.io/prow/pkg/config"
+	"sigs.k8s.io/prow/pkg/config/secret"
+	"sigs.k8s.io/prow/pkg/flagutil"
+	"sigs.k8s.io/prow/pkg/githubeventserver"
+	"sigs.k8s.io/prow/pkg/interrupts"
+	"sigs.k8s.io/prow/pkg/logrusutil"
+	"sigs.k8s.io/prow/pkg/metrics"
+	"sigs.k8s.io/prow/pkg/pjutil"
+	pprofutil "sigs.k8s.io/prow/pkg/pjutil/pprof"
+)
+
+const componentName = "repo-brancher-controller"
+
+type options struct {
+	instrumentation                                  flagutil.InstrumentationOptions
+	github                                           flagutil.GitHubOptions
+	githubEventServer                                githubeventserver.Options
+	configDir, forwardingConfigPath, pluginConfigDir string
+	hmacPath                                         string
+	workers, maxRetries                              int
+	configReload, fullResync, shutdownGracePeriod    time.Duration
+	retryExhaustedDelay                              time.Duration
+	maxConfigStaleness                               time.Duration
+}
+
+func gatherOptions() options {
+	o := options{}
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	fs.StringVar(&o.configDir, "config-dir", "", "Path to the ci-operator configuration directory.")
+	fs.StringVar(&o.forwardingConfigPath, "forwarding-config", "", "Path to the default and release branch forwarding configuration.")
+	fs.StringVar(&o.pluginConfigDir, "plugin-config-dir", "", "Path to Prow's sharded plugin configuration used to verify external-plugin coverage.")
+	fs.StringVar(&o.hmacPath, "hmac-secret-file", "/etc/webhook/hmac", "Path to the GitHub webhook HMAC secret.")
+	fs.IntVar(&o.workers, "workers", 8, "Number of repositories reconciled concurrently.")
+	fs.IntVar(&o.maxRetries, "max-retries", 5, "Maximum fast reconciliation retries per repository.")
+	fs.DurationVar(&o.retryExhaustedDelay, "retry-exhausted-delay", 15*time.Minute, "Delay between reconciliation attempts after fast retries are exhausted.")
+	fs.DurationVar(&o.configReload, "config-reload-period", 5*time.Minute, "How often to reload desired state from configuration.")
+	fs.DurationVar(&o.fullResync, "full-resync-period", 12*time.Hour, "Safety-net interval for reconciling every configured repository.")
+	fs.DurationVar(&o.maxConfigStaleness, "max-config-staleness", 15*time.Minute, "Config reload age after which readiness fails.")
+	fs.DurationVar(&o.shutdownGracePeriod, "shutdown-grace-period", 30*time.Second, "Maximum graceful shutdown duration.")
+	o.github.AddCustomizedFlags(fs, flagutil.ThrottlerDefaults(18000, 10))
+	o.githubEventServer.Bind(fs)
+	o.instrumentation.AddFlags(fs)
+	_ = fs.Parse(os.Args[1:])
+	return o
+}
+
+func (o *options) validate() error {
+	var errs []error
+	if o.configDir == "" {
+		errs = append(errs, errors.New("--config-dir is required"))
+	}
+	if o.forwardingConfigPath == "" {
+		errs = append(errs, errors.New("--forwarding-config is required"))
+	}
+	if o.pluginConfigDir == "" {
+		errs = append(errs, errors.New("--plugin-config-dir is required"))
+	}
+	usingToken := o.github.TokenPath != ""
+	usingApp := o.github.AppID != "" || o.github.AppPrivateKeyPath != ""
+	if usingToken == usingApp || (o.github.AppID == "") != (o.github.AppPrivateKeyPath == "") {
+		errs = append(errs, errors.New("configure exactly one of --github-token-path or --github-app-id with --github-app-private-key-path"))
+	}
+	if err := o.github.Validate(false); err != nil {
+		errs = append(errs, err)
+	}
+	if o.workers < 1 {
+		errs = append(errs, errors.New("--workers must be positive"))
+	}
+	if o.maxRetries < 0 {
+		errs = append(errs, errors.New("--max-retries must not be negative"))
+	}
+	if o.configReload <= 0 || o.fullResync <= 0 || o.retryExhaustedDelay <= 0 {
+		errs = append(errs, errors.New("periods and timeouts must be positive"))
+	}
+	if o.shutdownGracePeriod <= 0 {
+		errs = append(errs, errors.New("shutdown grace period must be positive"))
+	}
+	if o.maxConfigStaleness <= o.configReload {
+		errs = append(errs, errors.New("config staleness must exceed reload period"))
+	}
+	if err := o.instrumentation.Validate(false); err != nil {
+		errs = append(errs, err)
+	}
+	if err := o.githubEventServer.DefaultAndValidate(); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}
+
+func main() {
+	logrusutil.ComponentInit()
+	o := gatherOptions()
+	if err := o.validate(); err != nil {
+		logrus.WithError(err).Fatal("invalid options")
+	}
+	if err := secret.Add(o.hmacPath); err != nil {
+		logrus.WithError(err).Fatal("start HMAC secret agent")
+	}
+	if raw, err := os.ReadFile(o.hmacPath); err != nil || len(raw) == 0 {
+		logrus.WithError(err).Fatal("webhook HMAC secret is missing or empty")
+	}
+	healthState := &runtimeHealth{maxConfigStaleness: o.maxConfigStaleness}
+	githubClient, err := o.github.GitHubClientWithLogFields(false, logrus.Fields{"component": componentName})
+	if err != nil {
+		logrus.WithError(err).Fatal("create GitHub client")
+	}
+	refs := newGitHubRefClient(githubClient, healthState)
+
+	state := newDesiredState()
+	if _, err := githubClient.BotUser(); err != nil {
+		logrus.WithError(err).Fatal("validate GitHub credentials")
+	}
+	healthState.githubSucceeded()
+	controller := newController(refs, state, o.maxRetries, o.retryExhaustedDelay)
+	ctx := interrupts.Context()
+	reload := func() {
+		forwardingConfig, err := loadForwardingConfig(o.forwardingConfigPath)
+		if err != nil {
+			logrus.WithError(err).Error("reload forwarding configuration")
+			return
+		}
+		next, err := loadDesiredState(o.configDir, forwardingConfig)
+		if err != nil {
+			logrus.WithError(err).Error("reload desired state")
+			return
+		}
+		if err := validateExternalPluginRegistrations(o.pluginConfigDir, next); err != nil {
+			if !shouldContinueAfterPluginRegistrationError(err) {
+				logrus.WithError(err).Error("validate external-plugin coverage")
+				return
+			}
+			logrus.WithError(err).Warn("external-plugin coverage is incomplete; continuing with desired-state reload")
+		}
+		changed := state.replace(next)
+		controller.enqueue(changed...)
+		healthState.configSucceeded()
+		logrus.WithFields(logrus.Fields{"repositories": len(next), "changed": len(changed)}).Info("loaded desired state")
+	}
+	reload()
+	if len(state.keys()) == 0 {
+		logrus.Warn("desired state is empty; waiting for configuration reload")
+	}
+
+	for i := 0; i < o.workers; i++ {
+		go controller.runWorker(ctx)
+	}
+	go runPeriodic(ctx, o.configReload, reload)
+	go runPeriodicJittered(ctx, o.fullResync, 0.1, func() {
+		controller.enqueue(state.keys()...)
+		lastFullResync.SetToCurrentTime()
+	})
+
+	metrics.ExposeMetrics(componentName, prowconfig.PushGateway{}, o.instrumentation.MetricsPort)
+	pprofutil.Instrument(o.instrumentation)
+	health := pjutil.NewHealthOnPort(o.instrumentation.HealthPort)
+	health.ServeReady(func() bool { return healthState.ready(time.Now()) })
+	eventServer := githubeventserver.New(o.githubEventServer, secret.GetTokenGenerator(o.hmacPath), logrus.WithField("component", componentName))
+	eventServer.RegisterPushEventHandler((&pushEventHandler{state: state, controller: controller}).handle)
+	interrupts.OnInterrupt(func() {
+		healthState.serverHealthy.Store(false)
+		controller.queue.ShutDown()
+		eventServer.GracefulShutdown()
+	})
+	healthState.serverHealthy.Store(true)
+	interrupts.ListenAndServe(eventServer, o.shutdownGracePeriod)
+	interrupts.WaitForGracefulShutdown()
+}
+
+func runPeriodic(ctx context.Context, interval time.Duration, fn func()) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			fn()
+		}
+	}
+}
+
+func runPeriodicJittered(ctx context.Context, interval time.Duration, factor float64, fn func()) {
+	for {
+		timer := time.NewTimer(jitterDuration(interval, factor))
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+			fn()
+		}
+	}
+}
+
+func shouldContinueAfterPluginRegistrationError(err error) bool {
+	var missing missingExternalPluginRegistrationError
+	return errors.As(err, &missing)
+}

--- a/cmd/repo-brancher-controller/metrics.go
+++ b/cmd/repo-brancher-controller/metrics.go
@@ -1,0 +1,41 @@
+package main
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	reconciliationTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "repo_brancher_reconciliations_total",
+		Help: "Repository reconciliation outcomes.",
+	}, []string{"result"})
+	queueDepth = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "repo_brancher_queue_depth",
+		Help: "Current number of repository keys waiting in the work queue.",
+	})
+	lastSuccessfulConfigReload = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "repo_brancher_last_successful_config_reload_timestamp_seconds",
+		Help: "Unix timestamp of the last successful desired-state reload.",
+	})
+	lastFullResync = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "repo_brancher_last_full_resync_timestamp_seconds",
+		Help: "Unix timestamp of the last full reconciliation enqueue.",
+	})
+	lastSuccessfulGitHubRequest = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "repo_brancher_last_successful_github_request_timestamp_seconds",
+		Help: "Unix timestamp of the last successful GitHub API request.",
+	})
+	webhooksTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "repo_brancher_webhooks_total",
+		Help: "Webhook requests by result.",
+	}, []string{"result"})
+)
+
+func init() {
+	prometheus.MustRegister(
+		reconciliationTotal,
+		queueDepth,
+		lastSuccessfulConfigReload,
+		lastFullResync,
+		lastSuccessfulGitHubRequest,
+		webhooksTotal,
+	)
+}

--- a/cmd/repo-brancher-controller/plugin_config.go
+++ b/cmd/repo-brancher-controller/plugin_config.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/prow/pkg/plugins"
+)
+
+const (
+	externalPluginName     = "repo-brancher-controller"
+	externalPluginEndpoint = "http://repo-brancher-controller"
+)
+
+type missingExternalPluginRegistrationError struct {
+	repository string
+}
+
+func (e missingExternalPluginRegistrationError) Error() string {
+	return fmt.Sprintf("%s: missing %s push registration at %s", e.repository, externalPluginName, externalPluginEndpoint)
+}
+
+// validateExternalPluginRegistrations verifies that every repository in desired is covered by a Prow push-event registration for this external plugin.
+// pluginConfigDir is the path to the directory containing Prow's sharded plugin configuration.
+// desired maps repository and source-branch keys to their sets of target branches.
+// It returns an error if the plugin configuration cannot be loaded or if any desired repository lacks the required registration.
+func validateExternalPluginRegistrations(pluginConfigDir string, desired map[repoKey]sets.Set[string]) error {
+	agent := &plugins.ConfigAgent{}
+	if err := agent.Load(filepath.Join(pluginConfigDir, "_plugins.yaml"), []string{pluginConfigDir}, "_pluginconfig.yaml", false, true); err != nil {
+		return fmt.Errorf("load Prow plugin configuration: %w", err)
+	}
+	pluginConfig := agent.Config()
+
+	repositories := sets.New[string]()
+	for key := range desired {
+		repositories.Insert(key.org + "/" + key.repo)
+	}
+	ordered := repositories.UnsortedList()
+	sort.Strings(ordered)
+	var errs []error
+	for _, repository := range ordered {
+		org := strings.SplitN(repository, "/", 2)[0]
+		configured := append([]plugins.ExternalPlugin{}, pluginConfig.ExternalPlugins[org]...)
+		configured = append(configured, pluginConfig.ExternalPlugins[repository]...)
+		registered := false
+		for _, plugin := range configured {
+			if plugin.Name == externalPluginName && strings.TrimRight(plugin.Endpoint, "/") == externalPluginEndpoint && sets.New(plugin.Events...).Has("push") {
+				registered = true
+				break
+			}
+		}
+		if !registered {
+			errs = append(errs, missingExternalPluginRegistrationError{repository: repository})
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/cmd/repo-brancher-controller/plugin_config_test.go
+++ b/cmd/repo-brancher-controller/plugin_config_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestValidateExternalPluginRegistrations(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "_plugins.yaml"), []byte("{}\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	write := func(org, config string) {
+		t.Helper()
+		dir := filepath.Join(root, org)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "_pluginconfig.yaml"), []byte(config), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("registered", `external_plugins:
+  registered:
+  - endpoint: http://repo-brancher-controller
+    events: [push]
+    name: repo-brancher-controller
+`)
+	write("default-endpoint", `external_plugins:
+  default-endpoint:
+  - events: [push]
+    name: repo-brancher-controller
+`)
+	write("trailing-slash", `external_plugins:
+  trailing-slash:
+  - endpoint: http://repo-brancher-controller/
+    events: [push]
+    name: repo-brancher-controller
+`)
+	write("missing", `plugins: {}`)
+	write("repository", `external_plugins:
+  repository/repo:
+  - events: [push]
+    name: repo-brancher-controller
+`)
+	desired := map[repoKey]sets.Set[string]{
+		{org: "registered", repo: "repo", source: "main"}:       sets.New("release-5.0"),
+		{org: "default-endpoint", repo: "repo", source: "main"}: sets.New("release-5.0"),
+		{org: "trailing-slash", repo: "repo", source: "main"}:   sets.New("release-5.0"),
+		{org: "repository", repo: "repo", source: "main"}:       sets.New("release-5.0"),
+	}
+	if err := validateExternalPluginRegistrations(root, desired); err != nil {
+		t.Fatalf("valid registration rejected: %v", err)
+	}
+	desired[repoKey{org: "missing", repo: "repo", source: "main"}] = sets.New("release-5.0")
+	err := validateExternalPluginRegistrations(root, desired)
+	if err == nil {
+		t.Fatal("missing registration was accepted")
+	}
+	var missing missingExternalPluginRegistrationError
+	if !errors.As(err, &missing) {
+		t.Fatalf("expected missing registration error, got %T: %v", err, err)
+	}
+	if !shouldContinueAfterPluginRegistrationError(err) {
+		t.Fatal("missing registration should not block desired-state reload")
+	}
+	if shouldContinueAfterPluginRegistrationError(errors.New("load plugin config")) {
+		t.Fatal("non-registration errors should still block desired-state reload")
+	}
+}

--- a/cmd/repo-brancher-controller/webhook.go
+++ b/cmd/repo-brancher-controller/webhook.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/prow/pkg/github"
+)
+
+type pushEventHandler struct {
+	state      *desiredState
+	controller *controller
+}
+
+func (h *pushEventHandler) handle(_ *logrus.Entry, event github.PushEvent) {
+	if event.Deleted || !strings.HasPrefix(event.Ref, "refs/heads/") {
+		webhooksTotal.WithLabelValues("ignored_ref").Inc()
+		return
+	}
+	keys := h.state.matching(event.Repo.Owner.Login, event.Repo.Name, event.Branch())
+	h.controller.enqueue(keys...)
+	webhooksTotal.WithLabelValues("accepted").Inc()
+}

--- a/cmd/repo-brancher-controller/webhook_test.go
+++ b/cmd/repo-brancher-controller/webhook_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/prow/pkg/github"
+)
+
+func TestPushEventHandler(t *testing.T) {
+	key := repoKey{org: "org", repo: "repo", source: "main"}
+	state := newDesiredState()
+	state.replace(map[repoKey]sets.Set[string]{key: sets.New("release-5.0")})
+	controller := newController(&fakeRefClient{}, state, 1)
+	defer controller.queue.ShutDown()
+	handler := &pushEventHandler{state: state, controller: controller}
+
+	tests := []struct {
+		name      string
+		event     github.PushEvent
+		wantQueue int
+	}{
+		{name: "source push", event: github.PushEvent{Ref: "refs/heads/main", Repo: github.Repo{Owner: github.User{Login: "org"}, Name: "repo"}}, wantQueue: 1},
+		{name: "tag ignored", event: github.PushEvent{Ref: "refs/tags/main", Repo: github.Repo{Owner: github.User{Login: "org"}, Name: "repo"}}},
+		{name: "deleted branch ignored", event: github.PushEvent{Ref: "refs/heads/main", Deleted: true, Repo: github.Repo{Owner: github.User{Login: "org"}, Name: "repo"}}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for controller.queue.Len() > 0 {
+				item, _ := controller.queue.Get()
+				controller.queue.Done(item)
+				controller.queue.Forget(item)
+			}
+			handler.handle(nil, tc.event)
+			if controller.queue.Len() != tc.wantQueue {
+				t.Fatalf("queue length: want %d, got %d", tc.wantQueue, controller.queue.Len())
+			}
+		})
+	}
+}

--- a/images/repo-brancher-controller/Dockerfile
+++ b/images/repo-brancher-controller/Dockerfile
@@ -1,0 +1,4 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+ADD repo-brancher-controller /usr/bin/repo-brancher-controller
+ENTRYPOINT ["/usr/bin/repo-brancher-controller"]


### PR DESCRIPTION
This introduces a long-running controller that replaces periodic repository branch forwarding. It derives default-branch and release-branch relationships from strictly validated configuration and ci-operator promotion data. It consumes signed push events through Prow Hook while retaining periodic reconciliation for missed deliveries. It performs non-forced GitHub ref updates with scoped retries, rate-limit handling, health checks, and metrics. Unit, concurrency, webhook, configuration, and GitHub client tests cover the controller behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Introduced `repo-brancher-controller` as an event-driven replacement for the periodic `repo-brancher` repo-branch forwarding mechanism. The controller computes the desired source→target ref relationships from strictly validated forwarding config plus ci-operator promotion data, and then keeps GitHub refs aligned by updating targets to the configured source commit SHA using non-forced ref updates (`force: false`).

For CI users/operators, the behavior changes to:
- Drive reconciliation primarily from signed GitHub push events via Prow Hook (default webhook endpoint `/hook` on port `8888`, with HMAC secret defaulting to `/etc/webhook/hmac`). Only repositories whose desired state changed are enqueued on reload, and missed deliveries are handled by an additional jittered full resync safety-net.
- Reload configuration on a fixed cadence (`--config-reload-period`, default 5m) and run an initial reconcile; then periodically do a full reconcile of all configured repositories (`--full-resync-period`, default 12h).
- Perform scoped GitHub ref mutation per `{org, repo, source}` with deduplicated target sets and per-key synchronization, skipping updates when the target SHA already matches the source.
- Update refs safely by fetching current SHAs first and only creating/updating when divergence is detected; create/update races from GitHub validation errors (HTTP 422) are handled in the ref client (create path can recover by re-reading/updating), while update-path 422s are treated as permanent failures.
- Apply strict forwarding configuration validation on every reload (including ignore scoping rules and promotion/branch parsing constraints). External-plugin coverage is verified per-repository on reload against Prow external plugin registrations for this controller’s endpoint and `push` event; if coverage is incomplete but matches the “missing registration” classification, startup/reload continues.
- Add operational controls and observability: worker concurrency (`--workers`, default 8), fast retry budget (`--max-retries`, default 5) and longer delay after exhaustion (`--retry-exhausted-delay`, default 15m), Prometheus metrics for webhook and reconciliation outcomes, and runtime readiness gating.
- Expose readiness/health that requires recent successful config reload and recent successful GitHub interactions, bounded by `--max-config-staleness` (default 15m). GitHub client throttling/rate-limit handling pauses shared workers while preserving retry behavior.

The PR also adds the controller’s dedicated image build (Dockerfile) and comprehensive unit tests covering forwarding-config loading/validation, desired-state computation and deduplication, webhook enqueue behavior, reconciliation retry/permanent error aggregation, concurrency correctness, GitHub ref client semantics, runtime health readiness, and external plugin registration validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->