### PR TITLE
ci-operator: Add `ip_pool_lease_type` field

### DIFF
--- a/pkg/api/clusterprofile.go
+++ b/pkg/api/clusterprofile.go
@@ -1270,12 +1270,13 @@ func (cpl *ClusterProfilesList) Resolve() error {
 type ClusterProfilesMap map[ClusterProfile]ClusterProfileDetails
 
 type ClusterProfileDetails struct {
-	Name        ClusterProfile         `yaml:"name,omitempty" json:"name,omitempty"`
-	Owners      []ClusterProfileOwners `yaml:"owners,omitempty" json:"owners,omitempty"`
-	ClusterType string                 `yaml:"cluster_type,omitempty" json:"cluster_type,omitempty"`
-	LeaseType   string                 `yaml:"lease_type,omitempty" json:"lease_type,omitempty"`
-	Secret      string                 `yaml:"secret,omitempty" json:"secret,omitempty"`
-	ConfigMap   string                 `yaml:"config_map,omitempty" json:"config_map,omitempty"`
+	Name            ClusterProfile         `yaml:"name,omitempty" json:"name,omitempty"`
+	Owners          []ClusterProfileOwners `yaml:"owners,omitempty" json:"owners,omitempty"`
+	ClusterType     string                 `yaml:"cluster_type,omitempty" json:"cluster_type,omitempty"`
+	LeaseType       string                 `yaml:"lease_type,omitempty" json:"lease_type,omitempty"`
+	IPPoolLeaseType string                 `yaml:"ip_pool_lease_type,omitempty" json:"ip_pool_lease_type,omitempty"`
+	Secret          string                 `yaml:"secret,omitempty" json:"secret,omitempty"`
+	ConfigMap       string                 `yaml:"config_map,omitempty" json:"config_map,omitempty"`
 }
 
 type ClusterProfileKonfluxOwner struct {

--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -299,6 +299,9 @@ func ClusterProfilesConfig(configPath string) (api.ClusterProfilesMap, error) {
 		if profile.LeaseType == "" {
 			profile.LeaseType = profileName.LeaseType()
 		}
+		if profile.IPPoolLeaseType == "" {
+			profile.IPPoolLeaseType = profileName.IPPoolLeaseType()
+		}
 
 		mergedMap[profileName] = profile
 	}

--- a/pkg/load/load_test.go
+++ b/pkg/load/load_test.go
@@ -271,10 +271,11 @@ func TestClusterProfilesConfig(t *testing.T) {
 	existingProfiles := make(api.ClusterProfilesMap)
 	for _, profileName := range api.ClusterProfiles() {
 		existingProfiles[profileName] = api.ClusterProfileDetails{
-			Name:        profileName,
-			ClusterType: profileName.ClusterType(),
-			LeaseType:   profileName.LeaseType(),
-			Secret:      api.GetDefaultClusterProfileSecretName(profileName),
+			Name:            profileName,
+			ClusterType:     profileName.ClusterType(),
+			LeaseType:       profileName.LeaseType(),
+			IPPoolLeaseType: profileName.IPPoolLeaseType(),
+			Secret:          api.GetDefaultClusterProfileSecretName(profileName),
 		}
 	}
 
@@ -283,26 +284,29 @@ func TestClusterProfilesConfig(t *testing.T) {
 		switch profileName {
 		case "aws":
 			profilesWithOwners[profileName] = api.ClusterProfileDetails{
-				Name:        profileName,
-				Owners:      []api.ClusterProfileOwners{{Org: "org1"}},
-				ClusterType: profileName.ClusterType(),
-				LeaseType:   profileName.LeaseType(),
-				Secret:      api.GetDefaultClusterProfileSecretName(profileName),
+				Name:            profileName,
+				Owners:          []api.ClusterProfileOwners{{Org: "org1"}},
+				ClusterType:     profileName.ClusterType(),
+				LeaseType:       profileName.LeaseType(),
+				IPPoolLeaseType: profileName.IPPoolLeaseType(),
+				Secret:          api.GetDefaultClusterProfileSecretName(profileName),
 			}
 		case "aws-2":
 			profilesWithOwners[profileName] = api.ClusterProfileDetails{
-				Name:        profileName,
-				Owners:      []api.ClusterProfileOwners{{Org: "org2", Repos: []string{"repo1", "repo2"}}},
-				ClusterType: profileName.ClusterType(),
-				LeaseType:   profileName.LeaseType(),
-				Secret:      api.GetDefaultClusterProfileSecretName(profileName),
+				Name:            profileName,
+				Owners:          []api.ClusterProfileOwners{{Org: "org2", Repos: []string{"repo1", "repo2"}}},
+				ClusterType:     profileName.ClusterType(),
+				LeaseType:       profileName.LeaseType(),
+				IPPoolLeaseType: profileName.IPPoolLeaseType(),
+				Secret:          api.GetDefaultClusterProfileSecretName(profileName),
 			}
 		default:
 			profilesWithOwners[profileName] = api.ClusterProfileDetails{
-				Name:        profileName,
-				ClusterType: profileName.ClusterType(),
-				LeaseType:   profileName.LeaseType(),
-				Secret:      api.GetDefaultClusterProfileSecretName(profileName),
+				Name:            profileName,
+				ClusterType:     profileName.ClusterType(),
+				LeaseType:       profileName.LeaseType(),
+				IPPoolLeaseType: profileName.IPPoolLeaseType(),
+				Secret:          api.GetDefaultClusterProfileSecretName(profileName),
 			}
 		}
 	}
@@ -310,27 +314,39 @@ func TestClusterProfilesConfig(t *testing.T) {
 	profilesWithSecrets := make(api.ClusterProfilesMap)
 	for _, profileName := range api.ClusterProfiles() {
 		switch profileName {
+		case "aws-us-east-1":
+			profilesWithSecrets[profileName] = api.ClusterProfileDetails{
+				Name:            profileName,
+				Owners:          []api.ClusterProfileOwners{{Org: "openshift"}, {Org: "openshift-priv"}},
+				ClusterType:     profileName.ClusterType(),
+				LeaseType:       profileName.LeaseType(),
+				IPPoolLeaseType: profileName.IPPoolLeaseType(),
+				Secret:          "non-default-secret-name-aws",
+			}
 		case "aws-2":
 			profilesWithSecrets[profileName] = api.ClusterProfileDetails{
-				Name:        profileName,
-				Owners:      []api.ClusterProfileOwners{{Org: "org2", Repos: []string{"repo1", "repo2"}}},
-				ClusterType: profileName.ClusterType(),
-				LeaseType:   profileName.LeaseType(),
-				Secret:      "non-default-secret-name-aws",
+				Name:            profileName,
+				Owners:          []api.ClusterProfileOwners{{Org: "org2", Repos: []string{"repo1", "repo2"}}},
+				ClusterType:     profileName.ClusterType(),
+				LeaseType:       profileName.LeaseType(),
+				IPPoolLeaseType: profileName.IPPoolLeaseType(),
+				Secret:          "non-default-secret-name-aws",
 			}
 		case "vsphere-connected-2":
 			profilesWithSecrets[profileName] = api.ClusterProfileDetails{
-				Name:        profileName,
-				ClusterType: profileName.ClusterType(),
-				LeaseType:   profileName.LeaseType(),
-				Secret:      "non-default-secret-name-vsphere",
+				Name:            profileName,
+				ClusterType:     profileName.ClusterType(),
+				LeaseType:       profileName.LeaseType(),
+				IPPoolLeaseType: profileName.IPPoolLeaseType(),
+				Secret:          "non-default-secret-name-vsphere",
 			}
 		default:
 			profilesWithSecrets[profileName] = api.ClusterProfileDetails{
-				Name:        profileName,
-				ClusterType: profileName.ClusterType(),
-				LeaseType:   profileName.LeaseType(),
-				Secret:      api.GetDefaultClusterProfileSecretName(profileName),
+				Name:            profileName,
+				ClusterType:     profileName.ClusterType(),
+				LeaseType:       profileName.LeaseType(),
+				IPPoolLeaseType: profileName.IPPoolLeaseType(),
+				Secret:          api.GetDefaultClusterProfileSecretName(profileName),
 			}
 		}
 	}
@@ -375,6 +391,12 @@ cluster_profiles:
 			testYaml: `
 cluster_profiles:
 - name: aws
+- name: aws-us-east-1
+  owners:
+  - org: openshift
+  - org: openshift-priv
+  ip_pool_lease_type: aws-ip-pools
+  secret: non-default-secret-name-aws
 - name: aws-2
   owners:
   - org: org2


### PR DESCRIPTION
This is part of some preparatory work to move cluster profiles definition out of the code base.

Up until now the `IPPoolLeaseType` exists in code only, this PR adds `ip_pool_lease_type` in the cluster profile configuration file to fill this gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This updates ci-operator’s cluster profile handling to support `ip_pool_lease_type` in profile configuration, closing the gap between config files and the in-code `IPPoolLeaseType` setting. In practice, CI cluster profiles can now carry this value through loading and merging just like the existing lease/secret/owner fields, so operators can define IP pool lease behavior in the cluster profile config instead of relying on code-only defaults.

The loader now fills in missing `ip_pool_lease_type` values from the profile name’s mapped default when needed, and the tests were expanded to cover profiles that include this field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->