### PR TITLE
ci-operator: Remove `IPPoolLeaseType` func

### DIFF
--- a/pkg/api/clusterprofile.go
+++ b/pkg/api/clusterprofile.go
@@ -1164,26 +1164,6 @@ func (p ClusterProfile) LeaseType() string {
 	}
 }
 
-func (p ClusterProfile) IPPoolLeaseType() string {
-	switch p {
-	case
-		ClusterProfileAWSUSEast1:
-		return "aws-ip-pools"
-	default:
-		return ""
-	}
-}
-
-// IPPoolLeaseShouldValidateBranch declares whether the ip-pool leases should only be applied to branches matching a
-// specific OpenShift validation model. returns true by default, but should return false for any cluster-profiles
-// that don't want this validation
-func (p ClusterProfile) IPPoolLeaseShouldValidateBranch() bool {
-	switch p {
-	default:
-		return true
-	}
-}
-
 // GetDefaultClusterProfileSecretName returns the default secret name for the profile
 func GetDefaultClusterProfileSecretName(profile ClusterProfile) string {
 	return fmt.Sprintf("cluster-secrets-%s", string(profile))

--- a/pkg/api/leases.go
+++ b/pkg/api/leases.go
@@ -27,22 +27,15 @@ func LeasesForTest(test *TestStepConfiguration) (ret []StepLease) {
 
 const maxAddressesRequired = 13
 
-func IPPoolLeaseForTest(profile ClusterProfile, branch string) (ret StepLease) {
-	if profile == "" {
-		return
-	}
-
-	if lt := profile.IPPoolLeaseType(); lt != "" {
-		if !profile.IPPoolLeaseShouldValidateBranch() || branchValidForIPPoolLease(branch) {
-			ret = StepLease{
-				ResourceType: lt,
-				Env:          DefaultIPPoolLeaseEnv,
-				Count:        maxAddressesRequired,
-			}
+func IPPoolLeaseForTest(ipPoolLeaseType, branch string) StepLease {
+	if ipPoolLeaseType != "" && branchValidForIPPoolLease(branch) {
+		return StepLease{
+			ResourceType: ipPoolLeaseType,
+			Env:          DefaultIPPoolLeaseEnv,
+			Count:        maxAddressesRequired,
 		}
 	}
-
-	return
+	return StepLease{}
 }
 
 const (

--- a/pkg/api/leases_test.go
+++ b/pkg/api/leases_test.go
@@ -75,9 +75,10 @@ func TestIPPoolLeaseForTest(t *testing.T) {
 			name: "aws",
 			tests: MultiStageTestConfigurationLiteral{
 				ClusterProfileLiteral: &ClusterProfileLiteral{
-					Name:      "aws-us-east-1",
-					LeaseType: "aws-quota-slice",
-					Secret:    "cluster-secrets-aws",
+					Name:            "aws-us-east-1",
+					LeaseType:       "aws-quota-slice",
+					IPPoolLeaseType: "aws-ip-pools",
+					Secret:          "cluster-secrets-aws",
 				},
 			},
 			metadata: Metadata{Branch: "master"},
@@ -101,9 +102,10 @@ func TestIPPoolLeaseForTest(t *testing.T) {
 			name: "aws, with 4.16 branch",
 			tests: MultiStageTestConfigurationLiteral{
 				ClusterProfileLiteral: &ClusterProfileLiteral{
-					Name:      "aws-us-east-1",
-					LeaseType: "aws-quota-slice",
-					Secret:    "cluster-secrets-aws",
+					Name:            "aws-us-east-1",
+					LeaseType:       "aws-quota-slice",
+					IPPoolLeaseType: "aws-ip-pools",
+					Secret:          "cluster-secrets-aws",
 				},
 			},
 			metadata: Metadata{Branch: "release-4.16"},
@@ -128,9 +130,10 @@ func TestIPPoolLeaseForTest(t *testing.T) {
 			name: "aws, with 5.0 branch (should be valid)",
 			tests: MultiStageTestConfigurationLiteral{
 				ClusterProfileLiteral: &ClusterProfileLiteral{
-					Name:      "aws-us-east-1",
-					LeaseType: "aws-quota-slice",
-					Secret:    "cluster-secrets-aws",
+					Name:            "aws-us-east-1",
+					LeaseType:       "aws-quota-slice",
+					IPPoolLeaseType: "aws-ip-pools",
+					Secret:          "cluster-secrets-aws",
 				},
 			},
 			metadata: Metadata{Branch: "release-5.0"},
@@ -144,9 +147,10 @@ func TestIPPoolLeaseForTest(t *testing.T) {
 			name: "aws, with openshift-5.0 branch (should be valid)",
 			tests: MultiStageTestConfigurationLiteral{
 				ClusterProfileLiteral: &ClusterProfileLiteral{
-					Name:      "aws-us-east-1",
-					LeaseType: "aws-quota-slice",
-					Secret:    "cluster-secrets-aws",
+					Name:            "aws-us-east-1",
+					LeaseType:       "aws-quota-slice",
+					IPPoolLeaseType: "aws-ip-pools",
+					Secret:          "cluster-secrets-aws",
 				},
 			},
 			metadata: Metadata{Branch: "openshift-5.0"},
@@ -160,9 +164,10 @@ func TestIPPoolLeaseForTest(t *testing.T) {
 			name: "aws, with 5.1 branch (should be valid)",
 			tests: MultiStageTestConfigurationLiteral{
 				ClusterProfileLiteral: &ClusterProfileLiteral{
-					Name:      "aws-us-east-1",
-					LeaseType: "aws-quota-slice",
-					Secret:    "cluster-secrets-aws",
+					Name:            "aws-us-east-1",
+					LeaseType:       "aws-quota-slice",
+					IPPoolLeaseType: "aws-ip-pools",
+					Secret:          "cluster-secrets-aws",
 				},
 			},
 			metadata: Metadata{Branch: "release-5.1"},
@@ -175,7 +180,7 @@ func TestIPPoolLeaseForTest(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ret := IPPoolLeaseForTest(ClusterProfile(tc.tests.ClusterProfileLiteral.Name), tc.metadata.Branch)
+			ret := IPPoolLeaseForTest(tc.tests.ClusterProfileLiteral.IPPoolLeaseType, tc.metadata.Branch)
 			if diff := cmp.Diff(tc.expected, ret); diff != "" {
 				t.Errorf("incorrect lease returned, diff: %s", diff)
 			}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -958,18 +958,20 @@ const (
 )
 
 type ClusterProfileLiteral struct {
-	Name        string `yaml:"name,omitempty" json:"name,omitempty"`
-	LeaseType   string `yaml:"lease_type,omitempty" json:"lease_type,omitempty"`
-	ClusterType string `yaml:"cluster_type,omitempty" json:"cluster_type,omitempty"`
-	Secret      string `yaml:"secret,omitempty" json:"secret,omitempty"`
+	Name            string `yaml:"name,omitempty" json:"name,omitempty"`
+	LeaseType       string `yaml:"lease_type,omitempty" json:"lease_type,omitempty"`
+	IPPoolLeaseType string `yaml:"ip_pool_lease_type,omitempty" json:"ip_pool_lease_type,omitempty"`
+	ClusterType     string `yaml:"cluster_type,omitempty" json:"cluster_type,omitempty"`
+	Secret          string `yaml:"secret,omitempty" json:"secret,omitempty"`
 }
 
 func FromClusterProfileDetails(profileDetails *ClusterProfileDetails) *ClusterProfileLiteral {
 	return &ClusterProfileLiteral{
-		Name:        string(profileDetails.Name),
-		LeaseType:   profileDetails.LeaseType,
-		ClusterType: profileDetails.ClusterType,
-		Secret:      profileDetails.Secret,
+		Name:            string(profileDetails.Name),
+		LeaseType:       profileDetails.LeaseType,
+		IPPoolLeaseType: profileDetails.IPPoolLeaseType,
+		ClusterType:     profileDetails.ClusterType,
+		Secret:          profileDetails.Secret,
 	}
 }
 

--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -299,9 +299,6 @@ func ClusterProfilesConfig(configPath string) (api.ClusterProfilesMap, error) {
 		if profile.LeaseType == "" {
 			profile.LeaseType = profileName.LeaseType()
 		}
-		if profile.IPPoolLeaseType == "" {
-			profile.IPPoolLeaseType = profileName.IPPoolLeaseType()
-		}
 
 		mergedMap[profileName] = profile
 	}

--- a/pkg/load/load_test.go
+++ b/pkg/load/load_test.go
@@ -271,11 +271,10 @@ func TestClusterProfilesConfig(t *testing.T) {
 	existingProfiles := make(api.ClusterProfilesMap)
 	for _, profileName := range api.ClusterProfiles() {
 		existingProfiles[profileName] = api.ClusterProfileDetails{
-			Name:            profileName,
-			ClusterType:     profileName.ClusterType(),
-			LeaseType:       profileName.LeaseType(),
-			IPPoolLeaseType: profileName.IPPoolLeaseType(),
-			Secret:          api.GetDefaultClusterProfileSecretName(profileName),
+			Name:        profileName,
+			ClusterType: profileName.ClusterType(),
+			LeaseType:   profileName.LeaseType(),
+			Secret:      api.GetDefaultClusterProfileSecretName(profileName),
 		}
 	}
 
@@ -284,29 +283,26 @@ func TestClusterProfilesConfig(t *testing.T) {
 		switch profileName {
 		case "aws":
 			profilesWithOwners[profileName] = api.ClusterProfileDetails{
-				Name:            profileName,
-				Owners:          []api.ClusterProfileOwners{{Org: "org1"}},
-				ClusterType:     profileName.ClusterType(),
-				LeaseType:       profileName.LeaseType(),
-				IPPoolLeaseType: profileName.IPPoolLeaseType(),
-				Secret:          api.GetDefaultClusterProfileSecretName(profileName),
+				Name:        profileName,
+				Owners:      []api.ClusterProfileOwners{{Org: "org1"}},
+				ClusterType: profileName.ClusterType(),
+				LeaseType:   profileName.LeaseType(),
+				Secret:      api.GetDefaultClusterProfileSecretName(profileName),
 			}
 		case "aws-2":
 			profilesWithOwners[profileName] = api.ClusterProfileDetails{
-				Name:            profileName,
-				Owners:          []api.ClusterProfileOwners{{Org: "org2", Repos: []string{"repo1", "repo2"}}},
-				ClusterType:     profileName.ClusterType(),
-				LeaseType:       profileName.LeaseType(),
-				IPPoolLeaseType: profileName.IPPoolLeaseType(),
-				Secret:          api.GetDefaultClusterProfileSecretName(profileName),
+				Name:        profileName,
+				Owners:      []api.ClusterProfileOwners{{Org: "org2", Repos: []string{"repo1", "repo2"}}},
+				ClusterType: profileName.ClusterType(),
+				LeaseType:   profileName.LeaseType(),
+				Secret:      api.GetDefaultClusterProfileSecretName(profileName),
 			}
 		default:
 			profilesWithOwners[profileName] = api.ClusterProfileDetails{
-				Name:            profileName,
-				ClusterType:     profileName.ClusterType(),
-				LeaseType:       profileName.LeaseType(),
-				IPPoolLeaseType: profileName.IPPoolLeaseType(),
-				Secret:          api.GetDefaultClusterProfileSecretName(profileName),
+				Name:        profileName,
+				ClusterType: profileName.ClusterType(),
+				LeaseType:   profileName.LeaseType(),
+				Secret:      api.GetDefaultClusterProfileSecretName(profileName),
 			}
 		}
 	}
@@ -320,33 +316,30 @@ func TestClusterProfilesConfig(t *testing.T) {
 				Owners:          []api.ClusterProfileOwners{{Org: "openshift"}, {Org: "openshift-priv"}},
 				ClusterType:     profileName.ClusterType(),
 				LeaseType:       profileName.LeaseType(),
-				IPPoolLeaseType: profileName.IPPoolLeaseType(),
+				IPPoolLeaseType: "aws-ip-pools",
 				Secret:          "non-default-secret-name-aws",
 			}
 		case "aws-2":
 			profilesWithSecrets[profileName] = api.ClusterProfileDetails{
-				Name:            profileName,
-				Owners:          []api.ClusterProfileOwners{{Org: "org2", Repos: []string{"repo1", "repo2"}}},
-				ClusterType:     profileName.ClusterType(),
-				LeaseType:       profileName.LeaseType(),
-				IPPoolLeaseType: profileName.IPPoolLeaseType(),
-				Secret:          "non-default-secret-name-aws",
+				Name:        profileName,
+				Owners:      []api.ClusterProfileOwners{{Org: "org2", Repos: []string{"repo1", "repo2"}}},
+				ClusterType: profileName.ClusterType(),
+				LeaseType:   profileName.LeaseType(),
+				Secret:      "non-default-secret-name-aws",
 			}
 		case "vsphere-connected-2":
 			profilesWithSecrets[profileName] = api.ClusterProfileDetails{
-				Name:            profileName,
-				ClusterType:     profileName.ClusterType(),
-				LeaseType:       profileName.LeaseType(),
-				IPPoolLeaseType: profileName.IPPoolLeaseType(),
-				Secret:          "non-default-secret-name-vsphere",
+				Name:        profileName,
+				ClusterType: profileName.ClusterType(),
+				LeaseType:   profileName.LeaseType(),
+				Secret:      "non-default-secret-name-vsphere",
 			}
 		default:
 			profilesWithSecrets[profileName] = api.ClusterProfileDetails{
-				Name:            profileName,
-				ClusterType:     profileName.ClusterType(),
-				LeaseType:       profileName.LeaseType(),
-				IPPoolLeaseType: profileName.IPPoolLeaseType(),
-				Secret:          api.GetDefaultClusterProfileSecretName(profileName),
+				Name:        profileName,
+				ClusterType: profileName.ClusterType(),
+				LeaseType:   profileName.LeaseType(),
+				Secret:      api.GetDefaultClusterProfileSecretName(profileName),
 			}
 		}
 	}

--- a/pkg/steps/ip_pool.go
+++ b/pkg/steps/ip_pool.go
@@ -37,7 +37,7 @@ type ipPoolStep struct {
 	// To ease unit testing
 	profile         *api.ClusterProfileLiteral
 	branch          string
-	ipPoolLeaseFunc func(profile api.ClusterProfile, branch string) stepLease
+	ipPoolLeaseFunc func(ipPoolLeaseType, branch string) stepLease
 
 	// Reports whether this step has run or not
 	stepRun *atomic.Bool
@@ -55,8 +55,8 @@ func IPPoolStep(client *lease.Client, secretClient SecretClient, wrapped api.Ste
 		metricsAgent: metricsAgent,
 		profile:      profile,
 		branch:       branch,
-		ipPoolLeaseFunc: func(profile api.ClusterProfile, branch string) stepLease {
-			return stepLease{StepLease: api.IPPoolLeaseForTest(profile, branch)}
+		ipPoolLeaseFunc: func(ipPoolLeaseType, branch string) stepLease {
+			return stepLease{StepLease: api.IPPoolLeaseForTest(ipPoolLeaseType, branch)}
 		},
 		stepRun: &atomic.Bool{},
 	}
@@ -126,12 +126,12 @@ func (s *ipPoolStep) run(ctx context.Context, minute time.Duration) error {
 		s.profile = api.FromClusterProfileDetails(clusterProfileDetails)
 	}
 
-	var profileName string
+	var ipPoolLeaseType string
 	if s.profile != nil {
-		profileName = s.profile.Name
+		ipPoolLeaseType = s.profile.IPPoolLeaseType
 	}
 
-	s.ipPoolLease = s.ipPoolLeaseFunc(api.ClusterProfile(profileName), s.branch)
+	s.ipPoolLease = s.ipPoolLeaseFunc(ipPoolLeaseType, s.branch)
 	if !s.ipPoolLeaseAvailable() {
 		return results.ForReason("executing_test").ForError(s.wrapped.Run(ctx))
 	}

--- a/pkg/steps/ip_pool_test.go
+++ b/pkg/steps/ip_pool_test.go
@@ -19,8 +19,8 @@ import (
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
-func ipPoolLeaseAdapter(lease stepLease) func(api.ClusterProfile, string) stepLease {
-	return func(api.ClusterProfile, string) stepLease { return lease }
+func ipPoolLeaseAdapter(lease stepLease) func(string, string) stepLease {
+	return func(string, string) stepLease { return lease }
 }
 
 func atomicBool(v bool) *atomic.Bool {

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -675,6 +675,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"            # ClusterProfileLiteral defines the profile/cloud provider for end-to-end test steps.\n" +
 	"            cluster_profile_literal:\n" +
 	"                cluster_type: ' '\n" +
+	"                ip_pool_lease_type: ' '\n" +
 	"                lease_type: ' '\n" +
 	"                name: ' '\n" +
 	"                secret: ' '\n" +
@@ -1621,6 +1622,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"        # ClusterProfileLiteral defines the profile/cloud provider for end-to-end test steps.\n" +
 	"        cluster_profile_literal:\n" +
 	"            cluster_type: ' '\n" +
+	"            ip_pool_lease_type: ' '\n" +
 	"            lease_type: ' '\n" +
 	"            name: ' '\n" +
 	"            secret: ' '\n" +


### PR DESCRIPTION
Follow up of https://github.com/openshift/ci-tools/pull/5268. The function is no longer needed since we have now the `ip_pool_lease_type` field in the cluster profile configs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This updates `ci-operator`’s IP pool lease handling to rely on the lease type from cluster profile config instead of deriving it through `ClusterProfile` helper methods.

Practically, CI jobs will now read `ip_pool_lease_type` directly from cluster profile data when deciding whether to request an IP pool lease, and branch validation is always applied when that lease type is present. The old `IPPoolLeaseType()` and `IPPoolLeaseShouldValidateBranch()` logic has been removed.

The change also propagates the new config field through cluster profile loading and test fixtures, and updates the IP pool step wiring to use the explicit lease type string rather than a profile-derived lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->