### PR TITLE
Register aws-konflux-stg cluster profile

### DIFF
--- a/pkg/api/clusterprofile.go
+++ b/pkg/api/clusterprofile.go
@@ -47,6 +47,7 @@ const (
 	ClusterProfileAWSPipelinesPerf           ClusterProfile = "aws-pipelines-performance"
 	ClusterProfileAWSRHTAPQE                 ClusterProfile = "aws-rhtap-qe"
 	ClusterProfileAWSKonfluxQE               ClusterProfile = "aws-konflux-qe"
+	ClusterProfileAWSKonfluxStg              ClusterProfile = "aws-konflux-stg"
 	ClusterProfileAWSRHTAPPerformance        ClusterProfile = "aws-rhtap-performance"
 	ClusterProfileAWSRHDHPerf                ClusterProfile = "aws-rhdh-performance"
 	ClusterProfileAWSRHDHDisconnected        ClusterProfile = "aws-rhdh-disconnected"
@@ -264,6 +265,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileAWSPipelinesPerf,
 		ClusterProfileAWSRHTAPQE,
 		ClusterProfileAWSKonfluxQE,
+		ClusterProfileAWSKonfluxStg,
 		ClusterProfileAWSRHTAPPerformance,
 		ClusterProfileAWSRHDHPerf,
 		ClusterProfileAWSRHDHDisconnected,
@@ -475,6 +477,7 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileAWSPipelinesPerf,
 		ClusterProfileAWSRHTAPQE,
 		ClusterProfileAWSKonfluxQE,
+		ClusterProfileAWSKonfluxStg,
 		ClusterProfileAWSRHTAPPerformance,
 		ClusterProfileAWSRHDHPerf,
 		ClusterProfileAWSRHDHDisconnected,
@@ -818,6 +821,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "aws-rhtap-qe-quota-slice"
 	case ClusterProfileAWSKonfluxQE:
 		return "aws-konflux-qe-quota-slice"
+	case ClusterProfileAWSKonfluxStg:
+		return "aws-konflux-stg-quota-slice"
 	case ClusterProfileAWSRHTAPPerformance:
 		return "aws-rhtap-performance-quota-slice"
 	case ClusterProfileAWSRHDHPerf:


### PR DESCRIPTION
This new cluster profile is needed to support cluster provisioning on AWS using the OpenShift-CI integration in Red Hat's Konflux staging environments.

Assisted-by: Claude claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds support for a new `aws-konflux-stg` cluster profile in the CI API layer.

For CI operators, this means cluster provisioning can now target the AWS Konflux staging environment through OpenShift-CI. The new profile is recognized as an AWS cluster type, is returned with the available cluster profiles, and uses its own lease/quota slice type (`aws-konflux-stg-quota-slice`) for resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->