### PR TITLE
DPTP-2938: pod-scaler authoritative request decrease with dry-run

### DIFF
--- a/cmd/pod-scaler/admission.go
+++ b/cmd/pod-scaler/admission.go
@@ -38,13 +38,41 @@ import (
 	"github.com/openshift/ci-tools/pkg/steps"
 )
 
-func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Interface, kubeClient kubernetes.Interface, loaders map[string][]*cacheReloader, mutateResourceLimits bool, cpuCap int64, memoryCap string, cpuPriorityScheduling int64, percentageMeasured float64, measuredPodCPUIncrease float64, systemReservedCPU int64, authoritativeCPU, authoritativeMemory, authoritativeCPUDryRun, authoritativeMemoryDryRun bool, authoritativeCPUMaxReductionPercent, authoritativeMemoryMaxReductionPercent float64, escalations *escalationServer, reporter results.PodScalerReporter) {
+type authoritativePair struct {
+	apply        bool
+	dryRun       bool
+	maxReduction float64
+}
+
+type authoritativeConfig struct {
+	cpuRequest, cpuLimit, memoryRequest, memoryLimit authoritativePair
+}
+
+func (c authoritativeConfig) pair(field corev1.ResourceName, resourceType string) authoritativePair {
+	switch {
+	case field == corev1.ResourceCPU && resourceType == "request":
+		return c.cpuRequest
+	case field == corev1.ResourceCPU:
+		return c.cpuLimit
+	case resourceType == "request":
+		return c.memoryRequest
+	}
+	return c.memoryLimit
+}
+
+func (c authoritativeConfig) anyDryRun() bool {
+	return c.cpuRequest.dryRun || c.cpuLimit.dryRun || c.memoryRequest.dryRun || c.memoryLimit.dryRun
+}
+
+func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Interface, kubeClient kubernetes.Interface, loaders map[string][]*cacheReloader, mutateResourceLimits bool, cpuCap int64, memoryCap string, cpuPriorityScheduling int64, percentageMeasured float64, measuredPodCPUIncrease float64, systemReservedCPU int64, authoritative authoritativeConfig, escalations *escalationServer, reporter results.PodScalerReporter) {
 	logger := logrus.WithField("component", "pod-scaler admission")
 	logger.Infof("Initializing admission webhook server with %d loaders.", len(loaders))
-	if authoritativeCPUDryRun || authoritativeMemoryDryRun {
+	if authoritative.anyDryRun() {
 		logger.WithFields(logrus.Fields{
-			"authoritative_cpu_dry_run":    authoritativeCPUDryRun,
-			"authoritative_memory_dry_run": authoritativeMemoryDryRun,
+			"authoritative_cpu_request_dry_run":    authoritative.cpuRequest.dryRun,
+			"authoritative_cpu_limit_dry_run":      authoritative.cpuLimit.dryRun,
+			"authoritative_memory_request_dry_run": authoritative.memoryRequest.dryRun,
+			"authoritative_memory_limit_dry_run":   authoritative.memoryLimit.dryRun,
 		}).Info("authoritative decrease dry-run enabled")
 	}
 	health := pjutil.NewHealthOnPort(healthPort)
@@ -58,7 +86,7 @@ func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Int
 		Port:    port,
 		CertDir: certDir,
 	})
-	server.Register("/pods", &webhook.Admission{Handler: &podMutator{logger: logger, client: client, decoder: decoder, resources: resources, mutateResourceLimits: mutateResourceLimits, cpuCap: cpuCap, memoryCap: memoryCap, cpuPriorityScheduling: cpuPriorityScheduling, percentageMeasured: percentageMeasured, measuredPodCPUIncrease: measuredPodCPUIncrease, nodeCache: nodeCache, authoritativeCPU: authoritativeCPU, authoritativeMemory: authoritativeMemory, authoritativeCPUDryRun: authoritativeCPUDryRun, authoritativeMemoryDryRun: authoritativeMemoryDryRun, authoritativeCPUMaxReductionPercent: authoritativeCPUMaxReductionPercent, authoritativeMemoryMaxReductionPercent: authoritativeMemoryMaxReductionPercent, escalations: escalations, reporter: reporter}})
+	server.Register("/pods", &webhook.Admission{Handler: &podMutator{logger: logger, client: client, decoder: decoder, resources: resources, mutateResourceLimits: mutateResourceLimits, cpuCap: cpuCap, memoryCap: memoryCap, cpuPriorityScheduling: cpuPriorityScheduling, percentageMeasured: percentageMeasured, measuredPodCPUIncrease: measuredPodCPUIncrease, nodeCache: nodeCache, authoritative: authoritative, escalations: escalations, reporter: reporter}})
 	logger.Info("Serving admission webhooks.")
 	if err := server.Start(interrupts.Context()); err != nil {
 		logrus.WithError(err).Fatal("Failed to serve webhooks.")
@@ -66,25 +94,20 @@ func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Int
 }
 
 type podMutator struct {
-	logger                                 *logrus.Entry
-	client                                 buildclientv1.BuildV1Interface
-	resources                              *resourceServer
-	mutateResourceLimits                   bool
-	decoder                                admission.Decoder
-	cpuCap                                 int64
-	memoryCap                              string
-	cpuPriorityScheduling                  int64
-	percentageMeasured                     float64
-	measuredPodCPUIncrease                 float64
-	nodeCache                              *nodeAllocatableCache
-	authoritativeCPU                       bool
-	authoritativeMemory                    bool
-	authoritativeCPUDryRun                 bool
-	authoritativeMemoryDryRun              bool
-	authoritativeCPUMaxReductionPercent    float64
-	authoritativeMemoryMaxReductionPercent float64
-	escalations                            *escalationServer
-	reporter                               results.PodScalerReporter
+	logger                 *logrus.Entry
+	client                 buildclientv1.BuildV1Interface
+	resources              *resourceServer
+	mutateResourceLimits   bool
+	decoder                admission.Decoder
+	cpuCap                 int64
+	memoryCap              string
+	cpuPriorityScheduling  int64
+	percentageMeasured     float64
+	measuredPodCPUIncrease float64
+	nodeCache              *nodeAllocatableCache
+	authoritative          authoritativeConfig
+	escalations            *escalationServer
+	reporter               results.PodScalerReporter
 }
 
 func (m *podMutator) Handle(ctx context.Context, req admission.Request) admission.Response {
@@ -133,7 +156,7 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 		m.setMeasuredLabel(pod, false, logger)
 	}
 
-	mutatePodResources(pod, m.resources, m.mutateResourceLimits, m.cpuCap, m.memoryCap, isMeasured, m.nodeCache, m.measuredPodCPUIncrease, m.authoritativeCPU, m.authoritativeMemory, m.authoritativeCPUDryRun, m.authoritativeMemoryDryRun, m.authoritativeCPUMaxReductionPercent, m.authoritativeMemoryMaxReductionPercent, m.escalations, m.reporter, logger)
+	mutatePodResources(pod, m.resources, m.mutateResourceLimits, m.cpuCap, m.memoryCap, isMeasured, m.nodeCache, m.measuredPodCPUIncrease, m.authoritative, m.escalations, m.reporter, logger)
 	m.addPriorityClass(pod)
 
 	marshaledPod, err := json.Marshal(pod)
@@ -341,7 +364,7 @@ func preventUnschedulableWithCaps(resources *corev1.ResourceRequirements, cpuCap
 	}
 }
 
-func mutatePodResources(pod *corev1.Pod, server *resourceServer, mutateResourceLimits bool, cpuCap int64, memoryCap string, isMeasured bool, nodeCache *nodeAllocatableCache, measuredPodCPUIncrease float64, authoritativeCPU, authoritativeMemory, authoritativeCPUDryRun, authoritativeMemoryDryRun bool, authoritativeCPUMaxReductionPercent, authoritativeMemoryMaxReductionPercent float64, escalations *escalationServer, reporter results.PodScalerReporter, logger *logrus.Entry) {
+func mutatePodResources(pod *corev1.Pod, server *resourceServer, mutateResourceLimits bool, cpuCap int64, memoryCap string, isMeasured bool, nodeCache *nodeAllocatableCache, measuredPodCPUIncrease float64, authoritative authoritativeConfig, escalations *escalationServer, reporter results.PodScalerReporter, logger *logrus.Entry) {
 	workloadClass := pod.Labels[ciWorkloadLabel]
 
 	mutateResources := func(containers []corev1.Container) {
@@ -398,8 +421,8 @@ func mutatePodResources(pod *corev1.Pod, server *resourceServer, mutateResourceL
 					reconcileLimits(&containers[i].Resources)
 				}
 				applyFailureEscalation(&containers[i].Resources, workloadType, workloadName, escalations, logger)
-				applyAuthoritativeLimitDecrease(&resources, &containers[i].Resources, workloadName, workloadType, isMeasured, workloadClass, authoritativeCPU, authoritativeMemory, authoritativeCPUDryRun, authoritativeMemoryDryRun, authoritativeCPUMaxReductionPercent, authoritativeMemoryMaxReductionPercent, escalations, logger)
-				if mutateResourceLimits && !authoritativeCPU {
+				applyAuthoritativeLimitDecrease(&resources, &containers[i].Resources, workloadName, workloadType, isMeasured, workloadClass, authoritative, escalations, logger)
+				if mutateResourceLimits && !authoritative.cpuLimit.apply {
 					if containers[i].Resources.Limits != nil {
 						delete(containers[i].Resources.Limits, corev1.ResourceCPU)
 					}
@@ -858,92 +881,96 @@ func storeEscalationIndex(cache Cache, index podscaler.EscalationIndex) error {
 	return context.DeadlineExceeded
 }
 
-func applyAuthoritativeLimitDecrease(recommended, configured *corev1.ResourceRequirements, workloadName, workloadType string, isMeasured bool, workloadClass string, authoritativeCPU, authoritativeMemory, authoritativeCPUDryRun, authoritativeMemoryDryRun bool, authoritativeCPUMaxReductionPercent, authoritativeMemoryMaxReductionPercent float64, escalations *escalationServer, logger *logrus.Entry) {
-	if isMeasured || configured.Limits == nil {
+func applyAuthoritativeLimitDecrease(recommended, configured *corev1.ResourceRequirements, workloadName, workloadType string, isMeasured bool, workloadClass string, authoritative authoritativeConfig, escalations *escalationServer, logger *logrus.Entry) {
+	if isMeasured {
 		return
 	}
 	memoryLevel, cpuLevel := 0, 0
 	if escalations != nil {
 		memoryLevel, cpuLevel = escalations.levels(workloadType, workloadName)
 	}
-	for _, field := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
-		if field == corev1.ResourceCPU && cpuLevel > 0 {
+	for _, target := range []struct {
+		configuredList *corev1.ResourceList
+		resourceType   string
+	}{
+		{configuredList: &configured.Requests, resourceType: "request"},
+		{configuredList: &configured.Limits, resourceType: "limit"},
+	} {
+		if target.configuredList == nil {
 			continue
 		}
-		if field == corev1.ResourceMemory && memoryLevel > 0 {
-			continue
-		}
-		our := recommended.Requests[field]
-		if our.IsZero() {
-			continue
-		}
-		if field == corev1.ResourceCPU {
-			our.SetMilli(int64(float64(our.MilliValue()) * 1.2))
-		} else {
-			increased := our.AsApproximateFloat64() * 1.2
-			our.Set(int64(increased))
-		}
-		their, ok := configured.Limits[field]
-		if !ok || their.IsZero() {
-			continue
-		}
-		authoritative := authoritativeMemory
-		dryRun := authoritativeMemoryDryRun
-		maxReductionPercent := authoritativeMemoryMaxReductionPercent
-		if field == corev1.ResourceCPU {
-			authoritative = authoritativeCPU
-			dryRun = authoritativeCPUDryRun
-			maxReductionPercent = authoritativeCPUMaxReductionPercent
-		}
-		if !authoritative && !dryRun {
-			continue
-		}
-		fieldLogger := logger.WithFields(logrus.Fields{
-			"workloadName": workloadName,
-			"workloadType": workloadType,
-			"field":        field,
-			"resource":     "limit",
-			"determined":   our.String(),
-			"configured":   their.String(),
-		})
-		if our.Cmp(their) >= 0 {
-			continue
-		}
-		theirValue := their.AsApproximateFloat64()
-		ourValue := our.AsApproximateFloat64()
-		if 1.0-(ourValue/theirValue) < 0.05 {
-			continue
-		}
-		reductionCapped := false
-		if 1.0-(ourValue/theirValue) > maxReductionPercent {
-			switch field {
-			case corev1.ResourceCPU:
-				our.SetMilli(int64(float64(their.MilliValue()) * (1.0 - maxReductionPercent)))
-			case corev1.ResourceMemory:
-				our.Set(int64(theirValue * (1.0 - maxReductionPercent)))
-			}
-			reductionCapped = true
-		}
-		if field == corev1.ResourceCPU {
-			if our.Cmp(authoritativeMinCPURequest) < 0 {
-				our = authoritativeMinCPURequest
-			}
-			if our.Cmp(their) >= 0 {
+		for _, field := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+			if field == corev1.ResourceCPU && cpuLevel > 0 {
 				continue
 			}
+			if field == corev1.ResourceMemory && memoryLevel > 0 {
+				continue
+			}
+			determined := recommended.Requests[field]
+			if determined.IsZero() {
+				continue
+			}
+			if field == corev1.ResourceCPU {
+				determined.SetMilli(int64(float64(determined.MilliValue()) * 1.2))
+			} else {
+				increased := determined.AsApproximateFloat64() * 1.2
+				determined.Set(int64(increased))
+			}
+			configuredValue, ok := (*target.configuredList)[field]
+			if !ok || configuredValue.IsZero() {
+				continue
+			}
+			mode := authoritative.pair(field, target.resourceType)
+			if !mode.apply && !mode.dryRun {
+				continue
+			}
+			fieldLogger := logger.WithFields(logrus.Fields{
+				"workloadName": workloadName,
+				"workloadType": workloadType,
+				"field":        field,
+				"resource":     target.resourceType,
+				"determined":   determined.String(),
+				"configured":   configuredValue.String(),
+			})
+			if determined.Cmp(configuredValue) >= 0 {
+				continue
+			}
+			configuredFloat := configuredValue.AsApproximateFloat64()
+			determinedFloat := determined.AsApproximateFloat64()
+			if 1.0-(determinedFloat/configuredFloat) < 0.05 {
+				continue
+			}
+			reductionCapped := false
+			if 1.0-(determinedFloat/configuredFloat) > mode.maxReduction {
+				switch field {
+				case corev1.ResourceCPU:
+					determined.SetMilli(int64(float64(configuredValue.MilliValue()) * (1.0 - mode.maxReduction)))
+				case corev1.ResourceMemory:
+					determined.Set(int64(configuredFloat * (1.0 - mode.maxReduction)))
+				}
+				reductionCapped = true
+			}
+			if field == corev1.ResourceCPU {
+				if determined.Cmp(authoritativeMinCPURequest) < 0 {
+					determined = authoritativeMinCPURequest
+				}
+				if determined.Cmp(configuredValue) >= 0 {
+					continue
+				}
+			}
+			if mode.dryRun {
+				fieldLogger.WithFields(logrus.Fields{
+					"event":            "authoritative_decrease_dry_run",
+					"workloadClass":    workloadClass,
+					"would_set":        determined.String(),
+					"authoritative":    mode.apply,
+					"reduction_pct":    (1.0 - determined.AsApproximateFloat64()/configuredFloat) * 100,
+					"reduction_capped": reductionCapped,
+				}).Infof("authoritative %s decrease dry-run", target.resourceType)
+				continue
+			}
+			(*target.configuredList)[field] = determined
 		}
-		if dryRun {
-			fieldLogger.WithFields(logrus.Fields{
-				"event":            "authoritative_decrease_dry_run",
-				"workloadClass":    workloadClass,
-				"would_set":        our.String(),
-				"authoritative":    authoritative,
-				"reduction_pct":    (1.0 - our.AsApproximateFloat64()/theirValue) * 100,
-				"reduction_capped": reductionCapped,
-			}).Info("authoritative decrease dry-run")
-			continue
-		}
-		configured.Limits[field] = our
 	}
 }
 

--- a/cmd/pod-scaler/admission_test.go
+++ b/cmd/pod-scaler/admission_test.go
@@ -30,6 +30,34 @@ import (
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
+func authPair(apply, dryRun bool, maxReduction float64) authoritativePair {
+	return authoritativePair{apply: apply, dryRun: dryRun, maxReduction: maxReduction}
+}
+
+func authLegacyCPU(maxReduction float64) authoritativeConfig {
+	p := authPair(true, false, maxReduction)
+	return authoritativeConfig{cpuRequest: p, cpuLimit: p}
+}
+
+func authLegacyCPUAndMemory(maxCPU, maxMemory float64) authoritativeConfig {
+	return authoritativeConfig{
+		cpuRequest:    authPair(true, false, maxCPU),
+		cpuLimit:      authPair(true, false, maxCPU),
+		memoryRequest: authPair(true, false, maxMemory),
+		memoryLimit:   authPair(true, false, maxMemory),
+	}
+}
+
+func authLegacyCPUDryRun(maxReduction float64) authoritativeConfig {
+	p := authPair(false, true, maxReduction)
+	return authoritativeConfig{cpuRequest: p, cpuLimit: p}
+}
+
+func authLegacyMemory(maxReduction float64) authoritativeConfig {
+	p := authPair(true, false, maxReduction)
+	return authoritativeConfig{memoryRequest: p, memoryLimit: p}
+}
+
 type mockReporter struct {
 	client *http.Client
 	called bool
@@ -554,7 +582,7 @@ func TestMutatePodResources(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			original := testCase.pod.DeepCopy()
-			mutatePodResources(testCase.pod, testCase.server, testCase.mutateResourceLimits, 10, "20Gi", false, nil, 50.0, false, false, false, false, 0.25, 0.25, nil, &defaultReporter, logrus.WithField("test", testCase.name))
+			mutatePodResources(testCase.pod, testCase.server, testCase.mutateResourceLimits, 10, "20Gi", false, nil, 50.0, authoritativeConfig{}, nil, &defaultReporter, logrus.WithField("test", testCase.name))
 			diff := cmp.Diff(original, testCase.pod)
 			// In some cases, cmp.Diff decides to use non-breaking spaces, and it's not
 			// particularly deterministic about this. We don't care.
@@ -619,7 +647,7 @@ func TestMutatePodResources_ciWorkloadLabelDoesNotBreakCacheLookup(t *testing.T)
 		},
 	}
 
-	mutatePodResources(pod, server, false, 10, "20Gi", false, nil, 50.0, false, false, false, false, 0.25, 0.25, nil, &defaultReporter, logger)
+	mutatePodResources(pod, server, false, 10, "20Gi", false, nil, 50.0, authoritativeConfig{}, nil, &defaultReporter, logger)
 
 	got := pod.Spec.Containers[0].Resources.Requests.Cpu().MilliValue()
 	const want = 6000 // 5000m recommendation inflated by 1.2 in useOursIfLarger
@@ -917,10 +945,10 @@ func TestUseOursIfLarger_authoritative(t *testing.T) {
 
 func TestApplyAuthoritativeLimitDecrease(t *testing.T) {
 	testCases := []struct {
-		name                                  string
-		authoritativeCPU, authoritativeMemory bool
-		isMeasured                            bool
-		ours, theirs, expected                corev1.ResourceRequirements
+		name                   string
+		authoritative          authoritativeConfig
+		isMeasured             bool
+		ours, theirs, expected corev1.ResourceRequirements
 	}{
 		{
 			name: "authoritative disabled",
@@ -944,9 +972,8 @@ func TestApplyAuthoritativeLimitDecrease(t *testing.T) {
 			},
 		},
 		{
-			name:                "capped reduction on limits only",
-			authoritativeCPU:    true,
-			authoritativeMemory: true,
+			name:          "capped reduction on requests and limits",
+			authoritative: authLegacyCPUAndMemory(0.25, 0.25),
 			ours: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    *resource.NewQuantity(10, resource.DecimalSI),
@@ -969,14 +996,14 @@ func TestApplyAuthoritativeLimitDecrease(t *testing.T) {
 					corev1.ResourceMemory: *resource.NewQuantity(15e9, resource.BinarySI),
 				},
 				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    *resource.NewQuantity(100, resource.DecimalSI),
-					corev1.ResourceMemory: *resource.NewQuantity(2e10, resource.BinarySI),
+					corev1.ResourceCPU:    *resource.NewQuantity(75, resource.DecimalSI),
+					corev1.ResourceMemory: *resource.NewQuantity(15e9, resource.BinarySI),
 				},
 			},
 		},
 		{
-			name:             "cpu limit decrease never below 10m",
-			authoritativeCPU: true,
+			name:          "cpu limit decrease never below 10m",
+			authoritative: authLegacyCPU(1.0),
 			ours: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU: resource.MustParse("1m"),
@@ -994,9 +1021,9 @@ func TestApplyAuthoritativeLimitDecrease(t *testing.T) {
 			},
 		},
 		{
-			name:             "measured pod skips limit reduction",
-			authoritativeCPU: true,
-			isMeasured:       true,
+			name:          "measured pod skips reduction",
+			authoritative: authLegacyCPU(0.25),
+			isMeasured:    true,
 			ours: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU: *resource.NewQuantity(10, resource.DecimalSI),
@@ -1006,17 +1033,42 @@ func TestApplyAuthoritativeLimitDecrease(t *testing.T) {
 				Limits: corev1.ResourceList{
 					corev1.ResourceCPU: *resource.NewQuantity(100, resource.DecimalSI),
 				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: *resource.NewQuantity(100, resource.DecimalSI),
+				},
 			},
 			expected: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
 					corev1.ResourceCPU: *resource.NewQuantity(100, resource.DecimalSI),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: *resource.NewQuantity(100, resource.DecimalSI),
+				},
+			},
+		},
+		{
+			name:          "capped reduction on requests without limits",
+			authoritative: authLegacyCPU(0.25),
+			ours: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: *resource.NewQuantity(10, resource.DecimalSI),
+				},
+			},
+			theirs: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: *resource.NewQuantity(100, resource.DecimalSI),
+				},
+			},
+			expected: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: *resource.NewQuantity(75, resource.DecimalSI),
 				},
 			},
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			applyAuthoritativeLimitDecrease(&tc.ours, &tc.theirs, "test", "build", tc.isMeasured, "", tc.authoritativeCPU, tc.authoritativeMemory, false, false, 0.25, 0.25, nil, logrus.WithField("test", tc.name))
+			applyAuthoritativeLimitDecrease(&tc.ours, &tc.theirs, "test", "build", tc.isMeasured, "", tc.authoritative, nil, logrus.WithField("test", tc.name))
 			if diff := cmp.Diff(tc.theirs, tc.expected); diff != "" {
 				t.Errorf("unexpected resources: %s", diff)
 			}
@@ -1044,7 +1096,7 @@ func TestApplyAuthoritativeLimitDecrease_uncappedMemory(t *testing.T) {
 		},
 	}
 
-	applyAuthoritativeLimitDecrease(&ours, &theirs, "test", "build", false, "", true, true, false, false, 0.25, 1.0, nil, logrus.WithField("test", t.Name()))
+	applyAuthoritativeLimitDecrease(&ours, &theirs, "test", "build", false, "", authLegacyCPUAndMemory(0.25, 1.0), nil, logrus.WithField("test", t.Name()))
 	if diff := cmp.Diff(theirs, expected); diff != "" {
 		t.Errorf("unexpected resources: %s", diff)
 	}
@@ -1060,16 +1112,54 @@ func TestApplyAuthoritativeLimitDecrease_dryRun(t *testing.T) {
 		Limits: corev1.ResourceList{
 			corev1.ResourceCPU: *resource.NewQuantity(100, resource.DecimalSI),
 		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU: *resource.NewQuantity(100, resource.DecimalSI),
+		},
 	}
 	expected := corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
 			corev1.ResourceCPU: *resource.NewQuantity(100, resource.DecimalSI),
 		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU: *resource.NewQuantity(100, resource.DecimalSI),
+		},
 	}
 
-	applyAuthoritativeLimitDecrease(&ours, &theirs, "test", "build", false, "", true, false, true, false, 0.25, 0.25, nil, logrus.WithField("test", t.Name()))
+	applyAuthoritativeLimitDecrease(&ours, &theirs, "test", "build", false, "", authLegacyCPUDryRun(0.25), nil, logrus.WithField("test", t.Name()))
 	if diff := cmp.Diff(theirs, expected); diff != "" {
 		t.Errorf("dry-run should not mutate resources: %s", diff)
+	}
+}
+
+func TestApplyAuthoritativeLimitDecrease_separateRequestLimitCaps(t *testing.T) {
+	ours := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU: *resource.NewQuantity(10, resource.DecimalSI),
+		},
+	}
+	theirs := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU: *resource.NewQuantity(100, resource.DecimalSI),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU: *resource.NewQuantity(100, resource.DecimalSI),
+		},
+	}
+	expected := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU: *resource.NewQuantity(12, resource.DecimalSI),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU: *resource.NewQuantity(75, resource.DecimalSI),
+		},
+	}
+
+	applyAuthoritativeLimitDecrease(&ours, &theirs, "test", "build", false, "", authoritativeConfig{
+		cpuRequest: authPair(true, false, 0.25),
+		cpuLimit:   authPair(true, false, 1.0),
+	}, nil, logrus.WithField("test", t.Name()))
+	if diff := cmp.Diff(theirs, expected); diff != "" {
+		t.Errorf("unexpected resources: %s", diff)
 	}
 }
 
@@ -1110,6 +1200,9 @@ func TestApplyAuthoritativeLimitDecrease_skipsDuringEscalation(t *testing.T) {
 		Limits: corev1.ResourceList{
 			corev1.ResourceMemory: *resource.NewQuantity(2e10, resource.BinarySI),
 		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: *resource.NewQuantity(2e10, resource.BinarySI),
+		},
 	}
 	server := &escalationServer{
 		index: podscaler.EscalationIndex{
@@ -1117,10 +1210,13 @@ func TestApplyAuthoritativeLimitDecrease_skipsDuringEscalation(t *testing.T) {
 		},
 	}
 
-	applyAuthoritativeLimitDecrease(&ours, &theirs, "test", "build", false, "", false, true, false, false, 0.25, 0.25, server, logrus.WithField("test", t.Name()))
+	applyAuthoritativeLimitDecrease(&ours, &theirs, "test", "build", false, "", authLegacyMemory(0.25), server, logrus.WithField("test", t.Name()))
 	want := *resource.NewQuantity(2e10, resource.BinarySI)
-	if diff := cmp.Diff(theirs.Limits, corev1.ResourceList{corev1.ResourceMemory: want}); diff != "" {
-		t.Errorf("expected memory limit unchanged during escalation: %s", diff)
+	if diff := cmp.Diff(theirs, corev1.ResourceRequirements{
+		Limits:   corev1.ResourceList{corev1.ResourceMemory: want},
+		Requests: corev1.ResourceList{corev1.ResourceMemory: want},
+	}); diff != "" {
+		t.Errorf("expected memory unchanged during escalation: %s", diff)
 	}
 }
 

--- a/cmd/pod-scaler/main.go
+++ b/cmd/pod-scaler/main.go
@@ -67,21 +67,47 @@ type consumerOptions struct {
 	port   int
 	uiPort int
 
-	dataDir                                string
-	certDir                                string
-	mutateResourceLimits                   bool
-	cpuCap                                 int64
-	memoryCap                              string
-	cpuPriorityScheduling                  int64
-	percentageMeasured                     float64
-	measuredPodCPUIncrease                 float64
-	systemReservedCPU                      int64
-	authoritativeCPU                       bool
-	authoritativeMemory                    bool
-	authoritativeCPUDryRun                 bool
-	authoritativeMemoryDryRun              bool
-	authoritativeCPUMaxReductionPercent    float64
-	authoritativeMemoryMaxReductionPercent float64
+	dataDir                                       string
+	certDir                                       string
+	mutateResourceLimits                          bool
+	cpuCap                                        int64
+	memoryCap                                     string
+	cpuPriorityScheduling                         int64
+	percentageMeasured                            float64
+	measuredPodCPUIncrease                        float64
+	systemReservedCPU                             int64
+	authoritativeCPU                              bool
+	authoritativeMemory                           bool
+	authoritativeCPUDryRun                        bool
+	authoritativeMemoryDryRun                     bool
+	authoritativeCPURequest                       bool
+	authoritativeCPULimit                         bool
+	authoritativeMemoryRequest                    bool
+	authoritativeMemoryLimit                      bool
+	authoritativeCPURequestDryRun                 bool
+	authoritativeCPULimitDryRun                   bool
+	authoritativeMemoryRequestDryRun              bool
+	authoritativeMemoryLimitDryRun                bool
+	authoritativeCPURequestMaxReductionPercent    float64
+	authoritativeCPULimitMaxReductionPercent      float64
+	authoritativeMemoryRequestMaxReductionPercent float64
+	authoritativeMemoryLimitMaxReductionPercent   float64
+}
+
+func (o *consumerOptions) authoritativeConfig() authoritativeConfig {
+	pair := func(apply, dryRun bool, maxReduction float64, legacyApply, legacyDryRun bool) authoritativePair {
+		return authoritativePair{
+			apply:        apply || legacyApply,
+			dryRun:       dryRun || legacyDryRun,
+			maxReduction: maxReduction,
+		}
+	}
+	return authoritativeConfig{
+		cpuRequest:    pair(o.authoritativeCPURequest, o.authoritativeCPURequestDryRun, o.authoritativeCPURequestMaxReductionPercent, o.authoritativeCPU, o.authoritativeCPUDryRun),
+		cpuLimit:      pair(o.authoritativeCPULimit, o.authoritativeCPULimitDryRun, o.authoritativeCPULimitMaxReductionPercent, o.authoritativeCPU, o.authoritativeCPUDryRun),
+		memoryRequest: pair(o.authoritativeMemoryRequest, o.authoritativeMemoryRequestDryRun, o.authoritativeMemoryRequestMaxReductionPercent, o.authoritativeMemory, o.authoritativeMemoryDryRun),
+		memoryLimit:   pair(o.authoritativeMemoryLimit, o.authoritativeMemoryLimitDryRun, o.authoritativeMemoryLimitMaxReductionPercent, o.authoritativeMemory, o.authoritativeMemoryDryRun),
+	}
 }
 
 func bindOptions(fs *flag.FlagSet) *options {
@@ -108,12 +134,24 @@ func bindOptions(fs *flag.FlagSet) *options {
 	fs.Float64Var(&o.percentageMeasured, "percentage-measured", 0, "Percentage of pods to mark as measured (0-100). Measured pods get increased CPU requests and anti-affinity rules.")
 	fs.Float64Var(&o.measuredPodCPUIncrease, "measured-pod-cpu-increase", 50, "Percentage increase in CPU requests for measured pods (default: 50%).")
 	fs.Int64Var(&o.systemReservedCPU, "system-reserved-cpu", 2, "CPU cores to reserve for system overhead when capping measured pod CPU.")
-	fs.BoolVar(&o.authoritativeCPU, "authoritative-cpu", false, "Allow admission to decrease CPU requests and limits based on measured usage.")
-	fs.BoolVar(&o.authoritativeMemory, "authoritative-memory", false, "Allow admission to decrease memory requests and limits based on measured usage.")
-	fs.BoolVar(&o.authoritativeCPUDryRun, "authoritative-cpu-dry-run", false, "Log CPU decreases that authoritative mode would apply without mutating pods.")
-	fs.BoolVar(&o.authoritativeMemoryDryRun, "authoritative-memory-dry-run", false, "Log memory decreases that authoritative mode would apply without mutating pods.")
-	fs.Float64Var(&o.authoritativeCPUMaxReductionPercent, "authoritative-cpu-max-reduction-percent", 1.0, "Maximum CPU limit reduction per admission in authoritative mode, as a fraction (0.25 = 25%, 1.0 = no cap).")
-	fs.Float64Var(&o.authoritativeMemoryMaxReductionPercent, "authoritative-memory-max-reduction-percent", 1.0, "Maximum memory limit reduction per admission in authoritative mode, as a fraction (0.25 = 25%, 1.0 = no cap).")
+	fs.BoolVar(&o.authoritativeCPURequest, "authoritative-cpu-request", false, "Allow admission to decrease CPU requests based on measured usage.")
+	fs.BoolVar(&o.authoritativeCPULimit, "authoritative-cpu-limit", false, "Allow admission to decrease CPU limits based on measured usage.")
+	fs.BoolVar(&o.authoritativeCPU, "authoritative-cpu", false, "Deprecated: enables both --authoritative-cpu-request and --authoritative-cpu-limit.")
+	fs.BoolVar(&o.authoritativeMemoryRequest, "authoritative-memory-request", false, "Allow admission to decrease memory requests based on measured usage.")
+	fs.BoolVar(&o.authoritativeMemoryLimit, "authoritative-memory-limit", false, "Allow admission to decrease memory limits based on measured usage.")
+	fs.BoolVar(&o.authoritativeMemory, "authoritative-memory", false, "Deprecated: enables both --authoritative-memory-request and --authoritative-memory-limit.")
+	fs.BoolVar(&o.authoritativeCPURequestDryRun, "authoritative-cpu-request-dry-run", false, "Log CPU request decreases that authoritative mode would apply without mutating pods.")
+	fs.BoolVar(&o.authoritativeCPULimitDryRun, "authoritative-cpu-limit-dry-run", false, "Log CPU limit decreases that authoritative mode would apply without mutating pods.")
+	fs.BoolVar(&o.authoritativeCPUDryRun, "authoritative-cpu-dry-run", false, "Deprecated: enables both --authoritative-cpu-request-dry-run and --authoritative-cpu-limit-dry-run.")
+	fs.BoolVar(&o.authoritativeMemoryRequestDryRun, "authoritative-memory-request-dry-run", false, "Log memory request decreases that authoritative mode would apply without mutating pods.")
+	fs.BoolVar(&o.authoritativeMemoryLimitDryRun, "authoritative-memory-limit-dry-run", false, "Log memory limit decreases that authoritative mode would apply without mutating pods.")
+	fs.BoolVar(&o.authoritativeMemoryDryRun, "authoritative-memory-dry-run", false, "Deprecated: enables both --authoritative-memory-request-dry-run and --authoritative-memory-limit-dry-run.")
+	fs.Float64Var(&o.authoritativeCPURequestMaxReductionPercent, "authoritative-cpu-request-max-reduction-percent", 1.0, "Maximum CPU request reduction per admission in authoritative mode, as a fraction (0.25 = 25%, 1.0 = no cap).")
+	fs.Float64Var(&o.authoritativeCPULimitMaxReductionPercent, "authoritative-cpu-limit-max-reduction-percent", 1.0, "Maximum CPU limit reduction per admission in authoritative mode, as a fraction (0.25 = 25%, 1.0 = no cap).")
+	fs.Float64Var(&o.authoritativeCPULimitMaxReductionPercent, "authoritative-cpu-max-reduction-percent", 1.0, "Deprecated: use --authoritative-cpu-limit-max-reduction-percent.")
+	fs.Float64Var(&o.authoritativeMemoryRequestMaxReductionPercent, "authoritative-memory-request-max-reduction-percent", 1.0, "Maximum memory request reduction per admission in authoritative mode, as a fraction (0.25 = 25%, 1.0 = no cap).")
+	fs.Float64Var(&o.authoritativeMemoryLimitMaxReductionPercent, "authoritative-memory-limit-max-reduction-percent", 1.0, "Maximum memory limit reduction per admission in authoritative mode, as a fraction (0.25 = 25%, 1.0 = no cap).")
+	fs.Float64Var(&o.authoritativeMemoryLimitMaxReductionPercent, "authoritative-memory-max-reduction-percent", 1.0, "Deprecated: use --authoritative-memory-limit-max-reduction-percent.")
 	fs.Float64Var(&o.failureEscalationFactor, "failure-escalation-factor", 1.5, "Multiplier applied per escalation level after OOM or CPU throttle (1.5 = 50% increase per level).")
 	fs.IntVar(&o.failureEscalationMaxLevel, "failure-escalation-max-level", 10, "Maximum escalation level tracked for a workload.")
 	fs.Float64Var(&o.cpuThrottleThreshold, "cpu-throttle-threshold", 0.25, "Minimum throttled/total CPU CFS period ratio to count as CPU deprived.")
@@ -156,11 +194,17 @@ func (o *options) validate() error {
 		if o.measuredPodCPUIncrease < 0 {
 			return errors.New("--measured-pod-cpu-increase must be >= 0")
 		}
-		if o.authoritativeCPUMaxReductionPercent < 0 || o.authoritativeCPUMaxReductionPercent > 1 {
-			return errors.New("--authoritative-cpu-max-reduction-percent must be between 0 and 1")
+		if o.authoritativeCPURequestMaxReductionPercent < 0 || o.authoritativeCPURequestMaxReductionPercent > 1 {
+			return errors.New("--authoritative-cpu-request-max-reduction-percent must be between 0 and 1")
 		}
-		if o.authoritativeMemoryMaxReductionPercent < 0 || o.authoritativeMemoryMaxReductionPercent > 1 {
-			return errors.New("--authoritative-memory-max-reduction-percent must be between 0 and 1")
+		if o.authoritativeCPULimitMaxReductionPercent < 0 || o.authoritativeCPULimitMaxReductionPercent > 1 {
+			return errors.New("--authoritative-cpu-limit-max-reduction-percent must be between 0 and 1")
+		}
+		if o.authoritativeMemoryRequestMaxReductionPercent < 0 || o.authoritativeMemoryRequestMaxReductionPercent > 1 {
+			return errors.New("--authoritative-memory-request-max-reduction-percent must be between 0 and 1")
+		}
+		if o.authoritativeMemoryLimitMaxReductionPercent < 0 || o.authoritativeMemoryLimitMaxReductionPercent > 1 {
+			return errors.New("--authoritative-memory-limit-max-reduction-percent must be between 0 and 1")
 		}
 		if err := o.resultsOptions.Validate(); err != nil {
 			return err
@@ -323,7 +367,7 @@ func mainAdmission(opts *options, cache Cache) {
 
 	escalations := newEscalationServer(cache, opts.failureEscalationFactor)
 
-	go admit(opts.port, opts.instrumentationOptions.HealthPort, opts.certDir, client, kubeClient, loaders(cache), opts.mutateResourceLimits, opts.cpuCap, opts.memoryCap, opts.cpuPriorityScheduling, opts.percentageMeasured, opts.measuredPodCPUIncrease, opts.systemReservedCPU, opts.authoritativeCPU, opts.authoritativeMemory, opts.authoritativeCPUDryRun, opts.authoritativeMemoryDryRun, opts.authoritativeCPUMaxReductionPercent, opts.authoritativeMemoryMaxReductionPercent, escalations, reporter)
+	go admit(opts.port, opts.instrumentationOptions.HealthPort, opts.certDir, client, kubeClient, loaders(cache), opts.mutateResourceLimits, opts.cpuCap, opts.memoryCap, opts.cpuPriorityScheduling, opts.percentageMeasured, opts.measuredPodCPUIncrease, opts.systemReservedCPU, opts.authoritativeConfig(), escalations, reporter)
 }
 
 func loaders(cache Cache) map[string][]*cacheReloader {

--- a/test/e2e/pod-scaler/e2e_test.go
+++ b/test/e2e/pod-scaler/e2e_test.go
@@ -419,7 +419,11 @@ func TestAdmissionAuthoritativeDryRun(t *testing.T) {
 	t.Run("authoritative decreases CPU", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(interrupts.Context())
 		defer cancel()
-		admissionHost, transport := run.Admission(T, dataDir, kubeconfigFile, ctx, false, "--authoritative-cpu=true", fmt.Sprintf("--cpu-cap=%d", cpuCap))
+		admissionHost, transport := run.Admission(T, dataDir, kubeconfigFile, ctx, false,
+			"--authoritative-cpu=true",
+			"--authoritative-cpu-request-max-reduction-percent=0.25",
+			fmt.Sprintf("--cpu-cap=%d", cpuCap),
+		)
 		got := cpuRequestAfterAdmission(t, &basePod, admissionHost, transport)
 		if got.Cmp(wantCPU) != 0 {
 			t.Fatalf("authoritative CPU request = %s, want %s", got.String(), wantCPU.String())


### PR DESCRIPTION
/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR refactors the pod-scaler admission webhook to make “authoritative” request/limit decreases more precise for CI workloads. CI operators can now configure authoritative reductions separately for CPU and memory, and independently for **requests vs limits**, with separate **apply** and **dry-run** behavior plus per-resource **max-reduction caps**. This replaces the older coarse CPU/memory-only switches and enables request-vs-limit behaviors to diverge intentionally.

In `cmd/pod-scaler/main.go`, new CLI flags are added for the per-resource request/limit apply/dry-run toggles and max-reduction fractions. The webhook wiring is updated to pass a consolidated authoritative config, while deprecated legacy flags are still accepted and mapped into the new model for backward compatibility. The authoritative mutation logic is updated accordingly (including how CPU limit deletion is triggered and how reductions are skipped during escalation/when pods are measured).

`cmd/pod-scaler/admission_test.go` and the pod-scaler e2e test are updated to cover the new request-vs-limit, dry-run, capped reduction, and escalation behaviors, including the added e2e max-reduction flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->