### PR TITLE
Extend Secret struct with GSM fields

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1382,11 +1382,29 @@ type TestDependencies map[string]string
 // Secret describes a secret to be mounted inside a test
 // container.
 type Secret struct {
-	// Secret name, used inside test containers
-	Name string `json:"name"`
+	// Bundle is a named bundle reference from the GSM config mapping file.
+	// Mutually exclusive with Collection/Group and Name.
+	Bundle string `json:"bundle,omitempty"`
+	// Collection is the GSM collection the secret belongs to.
+	// Mutually exclusive with Bundle and Name.
+	Collection string `json:"collection,omitempty"`
+	// Group is the group name within the collection.
+	// Required when Collection is set.
+	Group string `json:"group,omitempty"`
+	// Secret name, used inside test containers.
+	// Mutually exclusive with Bundle and Collection/Group.
+	Name string `json:"name,omitempty"`
 	// Secret mount path. Defaults to /usr/test-secrets for first
 	// secret. /usr/test-secrets-2 for second, and so on.
 	MountPath string `json:"mount_path"`
+}
+
+func (s *Secret) IsGSMReference() bool {
+	return s.Collection != "" && s.Group != ""
+}
+
+func (s *Secret) IsBundleReference() bool {
+	return s.Bundle != ""
 }
 
 // MemoryBackedVolume describes a tmpfs (memory backed volume)

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -1128,20 +1128,40 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"        # You cannot set the Secret and Secrets attributes\n" +
 	"        # at the same time.\n" +
 	"        secret:\n" +
+	"            # Bundle is a named bundle reference from the GSM config mapping file.\n" +
+	"            # Mutually exclusive with Collection/Group and Name.\n" +
+	"            bundle: ' '\n" +
+	"            # Collection is the GSM collection the secret belongs to.\n" +
+	"            # Mutually exclusive with Bundle and Name.\n" +
+	"            collection: ' '\n" +
+	"            # Group is the group name within the collection.\n" +
+	"            # Required when Collection is set.\n" +
+	"            group: ' '\n" +
 	"            # Secret mount path. Defaults to /usr/test-secrets for first\n" +
 	"            # secret. /usr/test-secrets-2 for second, and so on.\n" +
 	"            mount_path: ' '\n" +
-	"            # Secret name, used inside test containers\n" +
+	"            # Secret name, used inside test containers.\n" +
+	"            # Mutually exclusive with Bundle and Collection/Group.\n" +
 	"            name: ' '\n" +
 	"        # Secrets is an optional array of secret objects\n" +
 	"        # which will be mounted inside the test container.\n" +
 	"        # You cannot set the Secret and Secrets attributes\n" +
 	"        # at the same time.\n" +
 	"        secrets:\n" +
-	"            - # Secret mount path. Defaults to /usr/test-secrets for first\n" +
+	"            - # Bundle is a named bundle reference from the GSM config mapping file.\n" +
+	"              # Mutually exclusive with Collection/Group and Name.\n" +
+	"              bundle: ' '\n" +
+	"              # Collection is the GSM collection the secret belongs to.\n" +
+	"              # Mutually exclusive with Bundle and Name.\n" +
+	"              collection: ' '\n" +
+	"              # Group is the group name within the collection.\n" +
+	"              # Required when Collection is set.\n" +
+	"              group: ' '\n" +
+	"              # Secret mount path. Defaults to /usr/test-secrets for first\n" +
 	"              # secret. /usr/test-secrets-2 for second, and so on.\n" +
 	"              mount_path: ' '\n" +
-	"              # Secret name, used inside test containers\n" +
+	"              # Secret name, used inside test containers.\n" +
+	"              # Mutually exclusive with Bundle and Collection/Group.\n" +
 	"              name: ' '\n" +
 	"        # ShardCount describes the number of jobs that should be generated as shards for this test\n" +
 	"        # Each generated job will be a duplication, but contain a suffix and the necessary SHARD_ARGS will be passed to the steps\n" +
@@ -2074,20 +2094,40 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"      # You cannot set the Secret and Secrets attributes\n" +
 	"      # at the same time.\n" +
 	"      secret:\n" +
+	"        # Bundle is a named bundle reference from the GSM config mapping file.\n" +
+	"        # Mutually exclusive with Collection/Group and Name.\n" +
+	"        bundle: ' '\n" +
+	"        # Collection is the GSM collection the secret belongs to.\n" +
+	"        # Mutually exclusive with Bundle and Name.\n" +
+	"        collection: ' '\n" +
+	"        # Group is the group name within the collection.\n" +
+	"        # Required when Collection is set.\n" +
+	"        group: ' '\n" +
 	"        # Secret mount path. Defaults to /usr/test-secrets for first\n" +
 	"        # secret. /usr/test-secrets-2 for second, and so on.\n" +
 	"        mount_path: ' '\n" +
-	"        # Secret name, used inside test containers\n" +
+	"        # Secret name, used inside test containers.\n" +
+	"        # Mutually exclusive with Bundle and Collection/Group.\n" +
 	"        name: ' '\n" +
 	"      # Secrets is an optional array of secret objects\n" +
 	"      # which will be mounted inside the test container.\n" +
 	"      # You cannot set the Secret and Secrets attributes\n" +
 	"      # at the same time.\n" +
 	"      secrets:\n" +
-	"        - # Secret mount path. Defaults to /usr/test-secrets for first\n" +
+	"        - # Bundle is a named bundle reference from the GSM config mapping file.\n" +
+	"          # Mutually exclusive with Collection/Group and Name.\n" +
+	"          bundle: ' '\n" +
+	"          # Collection is the GSM collection the secret belongs to.\n" +
+	"          # Mutually exclusive with Bundle and Name.\n" +
+	"          collection: ' '\n" +
+	"          # Group is the group name within the collection.\n" +
+	"          # Required when Collection is set.\n" +
+	"          group: ' '\n" +
+	"          # Secret mount path. Defaults to /usr/test-secrets for first\n" +
 	"          # secret. /usr/test-secrets-2 for second, and so on.\n" +
 	"          mount_path: ' '\n" +
-	"          # Secret name, used inside test containers\n" +
+	"          # Secret name, used inside test containers.\n" +
+	"          # Mutually exclusive with Bundle and Collection/Group.\n" +
 	"          name: ' '\n" +
 	"      # ShardCount describes the number of jobs that should be generated as shards for this test\n" +
 	"      # Each generated job will be a duplication, but contain a suffix and the necessary SHARD_ARGS will be passed to the steps\n" +


### PR DESCRIPTION
Extends the Secret struct with Collection, Group, and Bundle fields to support GSM secret references, matching the pattern already used by CredentialReference. This is a prerequisite for migrating the ci-operator configs that use the `secrets:` stanza from Vault-synced K8s secrets to GSM. 
No behavior change — existing configs only use Name/MountPath.

https://redhat.atlassian.net/browse/DPTP-5009

- - -

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Extends the ci-operator API `Secret` type to support GSM-based secret references in addition to the existing Vault-backed `Name`/`MountPath` form. CI configs can now express secrets as either a GSM bundle reference or a collection/group reference, using the same pattern already used by credential references.

For existing ci-operator configs, behavior is unchanged: current `secrets:` entries that only specify `Name` and `MountPath` continue to work as before. The new fields and helper methods simply prepare the config loader and related tooling for migrating secrets from Vault-synced Kubernetes secrets to GSM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->