### PR TITLE
ci-operator-prowgen: Add --registry flag everywhere

### DIFF
--- a/cmd/auto-config-brancher/main.go
+++ b/cmd/auto-config-brancher/main.go
@@ -172,8 +172,12 @@ func main() {
 			arguments: []string{"--config-dir", o.ConfigDir, "--confirm"},
 		},
 		{
-			command:   "/usr/bin/ci-operator-prowgen",
-			arguments: []string{"--from-dir", o.ConfigDir, "--to-dir", "./ci-operator/jobs"},
+			command: "/usr/bin/ci-operator-prowgen",
+			arguments: []string{
+				"--from-dir", o.ConfigDir,
+				"--to-dir", "./ci-operator/jobs",
+				"--registry", "./ci-operator/step-registry",
+			},
 		},
 		{
 			command: "/usr/bin/private-prow-configs-mirror",

--- a/cmd/repo-init/api.go
+++ b/cmd/repo-init/api.go
@@ -688,6 +688,7 @@ func generateJobs(logger *logrus.Entry) error {
 			arguments: []string{
 				"--from-dir", "./ci-operator/config",
 				"--to-dir", "./ci-operator/jobs",
+				"--registry", "./ci-operator/step-registry",
 			},
 		},
 		{

--- a/test/integration/repo-init.sh
+++ b/test/integration/repo-init.sh
@@ -101,7 +101,7 @@ inputs=(
 )
 export inputs
 os::cmd::expect_success 'for input in "${inputs[@]}"; do echo "${input}"; done | repo-init -release-repo "${actual}"'
-os::cmd::expect_success 'ci-operator-prowgen --from-dir "${actual}/ci-operator/config" --to-dir "${actual}/ci-operator/jobs"'
+os::cmd::expect_success 'ci-operator-prowgen --from-dir "${actual}/ci-operator/config" --to-dir "${actual}/ci-operator/jobs" --registry "${actual}/ci-operator/step-registry"'
 os::cmd::expect_success 'sanitize-prow-jobs --prow-jobs-dir "${actual}/ci-operator/jobs" --config-path "${actual}/core-services/sanitize-prow-jobs/_config.yaml" --cluster-config-path "${actual}/core-services/sanitize-prow-jobs/_clusters.yaml"'
 os::cmd::expect_success 'determinize-ci-operator --config-dir "${actual}/ci-operator/config" --confirm'
 os::integration::compare "${actual}" "${expected}"

--- a/test/integration/repo-init/expected/ci-operator/step-registry/cluster-profiles/cluster-profiles-config.metadata.json
+++ b/test/integration/repo-init/expected/ci-operator/step-registry/cluster-profiles/cluster-profiles-config.metadata.json
@@ -1,0 +1,8 @@
+{
+	"path": "cluster-profiles/cluster-profiles-config.yaml",
+	"owners": {
+		"approvers": [
+			"fake"
+		]
+	}
+}

--- a/test/integration/repo-init/expected/ci-operator/step-registry/cluster-profiles/cluster-profiles-config.yaml
+++ b/test/integration/repo-init/expected/ci-operator/step-registry/cluster-profiles/cluster-profiles-config.yaml
@@ -1,0 +1,5 @@
+cluster_profiles:
+- name: aws
+  lease_type: aws-quota-slice
+  cluster_type: aws
+  secret: cluster-secrets-aws

--- a/test/integration/repo-init/expected/ci-operator/step-registry/ipi/aws/ipi-aws-workflow.metadata.json
+++ b/test/integration/repo-init/expected/ci-operator/step-registry/ipi/aws/ipi-aws-workflow.metadata.json
@@ -1,0 +1,8 @@
+{
+	"path": "ipi/aws/ipi-aws-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"fake"
+		]
+	}
+}

--- a/test/integration/repo-init/expected/ci-operator/step-registry/ipi/aws/ipi-aws-workflow.yaml
+++ b/test/integration/repo-init/expected/ci-operator/step-registry/ipi/aws/ipi-aws-workflow.yaml
@@ -1,0 +1,3 @@
+workflow:
+  as: ipi-aws
+  documentation: "todo"

--- a/test/integration/repo-init/expected/ci-operator/step-registry/openshift/e2e/aws/openshift-e2e-aws-workflow.metadata.json
+++ b/test/integration/repo-init/expected/ci-operator/step-registry/openshift/e2e/aws/openshift-e2e-aws-workflow.metadata.json
@@ -1,0 +1,8 @@
+{
+	"path": "openshift/e2e/aws/openshift-e2e-aws-workflow.yaml",
+	"owners": {
+		"approvers": [ 
+			"fake"
+		]
+	}
+}

--- a/test/integration/repo-init/expected/ci-operator/step-registry/openshift/e2e/aws/openshift-e2e-aws-workflow.yaml
+++ b/test/integration/repo-init/expected/ci-operator/step-registry/openshift/e2e/aws/openshift-e2e-aws-workflow.yaml
@@ -1,0 +1,3 @@
+workflow:
+  as: openshift-e2e-aws
+  documentation: "todo"

--- a/test/integration/repo-init/input/ci-operator/step-registry/cluster-profiles/cluster-profiles-config.metadata.json
+++ b/test/integration/repo-init/input/ci-operator/step-registry/cluster-profiles/cluster-profiles-config.metadata.json
@@ -1,0 +1,8 @@
+{
+	"path": "cluster-profiles/cluster-profiles-config.yaml",
+	"owners": {
+		"approvers": [
+			"fake"
+		]
+	}
+}

--- a/test/integration/repo-init/input/ci-operator/step-registry/cluster-profiles/cluster-profiles-config.yaml
+++ b/test/integration/repo-init/input/ci-operator/step-registry/cluster-profiles/cluster-profiles-config.yaml
@@ -1,0 +1,5 @@
+cluster_profiles:
+- name: aws
+  lease_type: aws-quota-slice
+  cluster_type: aws
+  secret: cluster-secrets-aws

--- a/test/integration/repo-init/input/ci-operator/step-registry/ipi/aws/ipi-aws-workflow.metadata.json
+++ b/test/integration/repo-init/input/ci-operator/step-registry/ipi/aws/ipi-aws-workflow.metadata.json
@@ -1,0 +1,8 @@
+{
+	"path": "ipi/aws/ipi-aws-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"fake"
+		]
+	}
+}

--- a/test/integration/repo-init/input/ci-operator/step-registry/ipi/aws/ipi-aws-workflow.yaml
+++ b/test/integration/repo-init/input/ci-operator/step-registry/ipi/aws/ipi-aws-workflow.yaml
@@ -1,0 +1,3 @@
+workflow:
+  as: ipi-aws
+  documentation: "todo"

--- a/test/integration/repo-init/input/ci-operator/step-registry/openshift/e2e/aws/openshift-e2e-aws-workflow.metadata.json
+++ b/test/integration/repo-init/input/ci-operator/step-registry/openshift/e2e/aws/openshift-e2e-aws-workflow.metadata.json
@@ -1,0 +1,8 @@
+{
+	"path": "openshift/e2e/aws/openshift-e2e-aws-workflow.yaml",
+	"owners": {
+		"approvers": [ 
+			"fake"
+		]
+	}
+}

--- a/test/integration/repo-init/input/ci-operator/step-registry/openshift/e2e/aws/openshift-e2e-aws-workflow.yaml
+++ b/test/integration/repo-init/input/ci-operator/step-registry/openshift/e2e/aws/openshift-e2e-aws-workflow.yaml
@@ -1,0 +1,3 @@
+workflow:
+  as: openshift-e2e-aws
+  documentation: "todo"

--- a/test/validate-generation-breaking-changes.sh
+++ b/test/validate-generation-breaking-changes.sh
@@ -21,7 +21,7 @@ for org in openshift; do
   pushd "${clonedir}"
 
   echo >&2 "$(date -u +'%Y-%m-%dT%H:%M:%S%z') Executing ci-operator-prowgen"
-  ci-operator-prowgen --from-dir "${clonedir}/ci-operator/config" --to-dir "${clonedir}/ci-operator/jobs"
+  ci-operator-prowgen --from-dir "${clonedir}/ci-operator/config" --to-dir "${clonedir}/ci-operator/jobs" --registry "${clonedir}/ci-operator/step-registry"
   out="$(git status --porcelain)"
   if [[ -n "$out" ]]; then
     echo "ERROR: Changes in $org/release:"


### PR DESCRIPTION
Same as https://github.com/openshift/release/pull/81127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated ci-operator-prowgen to pass the step registry path through every generation path, so generated jobs and repo-init flows now include `--registry ./ci-operator/step-registry` (or the equivalent cloned path in tests). This aligns the generator with step-registry-based configs and ensures the registry is available during job generation.

Also updated repo-init and generation-breaking-change tests to exercise the new registry argument, and added step-registry fixture content for cluster profiles and example AWS workflows so the integration test covers realistic registry output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->