### PR TITLE
ci-operator-configresolver: Merge cluster profiles from code and config properly

### DIFF
--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -282,6 +283,8 @@ func ClusterProfilesConfig(configPath string) (api.ClusterProfilesMap, error) {
 	}
 
 	mergedMap := make(api.ClusterProfilesMap)
+	maps.Copy(mergedMap, profilesFromConfigMap)
+
 	for _, profileName := range api.ClusterProfiles() {
 		profile, found := profilesFromConfigMap[profileName]
 		if !found {

--- a/pkg/load/load_test.go
+++ b/pkg/load/load_test.go
@@ -350,6 +350,7 @@ func TestClusterProfilesConfig(t *testing.T) {
 			}
 		}
 	}
+	profilesWithSecrets["gcp-unique"] = api.ClusterProfileDetails{Name: "gcp-unique"}
 
 	var testCases = []struct {
 		name     string
@@ -406,6 +407,7 @@ cluster_profiles:
   secret: non-default-secret-name-aws
 - name: vsphere-connected-2
   secret: non-default-secret-name-vsphere
+- name: gcp-unique
     `,
 			expected: profilesWithSecrets,
 		},


### PR DESCRIPTION
`ci-operator-configresolver` didn't take into account the profiles coming from the config in `o/release`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixed `ci-operator-configresolver`’s cluster profile merging so it now combines profiles from both the generated code path and the release config source in `o/release`. In practical terms, profiles that were defined only in config are no longer dropped during loading, which prevents CI jobs from missing the secrets and settings they expect.

The update affects `pkg/load` and is covered by an adjusted loader test to include a config-only GCP profile in the expected merged result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->