### PR TITLE
fix(tool-detector): skip build-tagged packages in changed file detection

### DIFF
--- a/pkg/tool-detector/detector.go
+++ b/pkg/tool-detector/detector.go
@@ -235,6 +235,10 @@ func (d *Detector) loadChangedPackages(files []string) (sets.Set[string], error)
 	for _, pkg := range pkgs {
 		if len(pkg.Errors) > 0 {
 			for _, pkgErr := range pkg.Errors {
+				if strings.Contains(pkgErr.Error(), "build constraints exclude all Go files") {
+					logrus.WithField("package", pkg.PkgPath).Warn("Skipping changed package excluded by build constraints")
+					continue
+				}
 				packageErrors = append(packageErrors, fmt.Errorf("package %s: %w", pkg.PkgPath, pkgErr))
 			}
 		}
@@ -248,7 +252,7 @@ func (d *Detector) loadChangedPackages(files []string) (sets.Set[string], error)
 	for _, pkg := range pkgs {
 		if pkg.PkgPath == "" {
 			emptyPkgPaths = append(emptyPkgPaths, fmt.Sprintf("files: %v", pkg.GoFiles))
-		} else if strings.HasPrefix(pkg.PkgPath, ModulePrefix) {
+		} else if strings.HasPrefix(pkg.PkgPath, ModulePrefix) && len(pkg.GoFiles) > 0 {
 			changed.Insert(pkg.PkgPath)
 		}
 	}

--- a/pkg/tool-detector/detector_test.go
+++ b/pkg/tool-detector/detector_test.go
@@ -1,6 +1,8 @@
 package tooldetector
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -870,6 +872,47 @@ some context /image pod-scaler
 			}
 			if all != tt.expectedAll {
 				t.Fatalf("expected all=%v, got %v", tt.expectedAll, all)
+			}
+		})
+	}
+}
+
+func TestDetector_loadChangedPackages(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Clean(filepath.Join(wd, "..", ".."))
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+
+	tests := []struct {
+		name    string
+		files   []string
+		want    sets.Set[string]
+		wantErr bool
+	}{
+		{
+			name: "skips build-tagged packages",
+			files: []string{
+				"cmd/pod-scaler/main.go",
+				"test/e2e/pod-scaler/e2e_test.go",
+			},
+			want: sets.New("github.com/openshift/ci-tools/cmd/pod-scaler"),
+		},
+	}
+
+	d := New(nil, nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := d.loadChangedPackages(tt.files)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("loadChangedPackages() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("loadChangedPackages() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
When a PR changes both real tool code (like cmd/pod-scaler) and e2e test files tagged` //go:build e2e`, the build detector used to crash on the test files and give up, so it built every image instead of just the one that changed.

Now it ignores those build-tagged test packages and still spots which `cmd/*` tools actually changed, so only the right images get built.

/cc @droslean 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the tool detector so CI image selection no longer breaks when a changed file belongs to a `//go:build e2e` package.

In practical terms, when OpenShift CI changes both real tool code and e2e-only test files, the detector now skips the build-tagged test package instead of treating it as a fatal package-load failure. This lets `pkg/tool-detector` continue identifying which `cmd/*` tools actually changed and build only the relevant images, rather than falling back to rebuilding everything.

Added test coverage to verify that build-tagged packages are ignored during changed-package detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->