### PR TITLE
promotion: always use promotion-quay only

### DIFF
--- a/pkg/api/promotion.go
+++ b/pkg/api/promotion.go
@@ -12,8 +12,9 @@ import (
 type OKDInclusion bool
 
 const (
-	okdPromotionNamespace = "origin"
-	ocpPromotionNamespace = "ocp"
+	okdPromotionNamespace     = "origin"
+	ocpPromotionNamespace     = "ocp"
+	ocpPrivPromotionNamespace = "ocp-priv"
 
 	WithOKD    OKDInclusion = true
 	WithoutOKD OKDInclusion = false
@@ -103,6 +104,11 @@ func BuildsAnyOfficialImages(configSpec *ReleaseBuildConfiguration, includeOKD O
 // RefersToOfficialImage determines if an image is official
 func RefersToOfficialImage(namespace string, includeOKD OKDInclusion) bool {
 	return (bool(includeOKD) && namespace == okdPromotionNamespace) || namespace == ocpPromotionNamespace
+}
+
+// RefersToQuayReferenceImage is true for namespaces that get app.ci IS source-refs to QCI.
+func RefersToQuayReferenceImage(namespace string, includeOKD OKDInclusion) bool {
+	return RefersToOfficialImage(namespace, includeOKD) || namespace == ocpPrivPromotionNamespace
 }
 
 // QuayImage returns the image in quay.io for an image stream tag which is used to push the image
@@ -204,6 +210,9 @@ var (
 			mirror[quayImageWithTime(time, tag)] = t
 		}
 
+		if !RefersToQuayReferenceImage(tag.Namespace, WithOKD) {
+			return
+		}
 		proxyTarget := getQuayProxyTarget(target, tag)
 		mirror[proxyTarget] = source
 		if proxySrc, ok := qciPullSpec(source); ok {

--- a/pkg/api/promotion_test.go
+++ b/pkg/api/promotion_test.go
@@ -53,11 +53,66 @@ func TestPromotesOfficialImages(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name: "config promoting to ocp-priv is not official for prowgen",
+			configSpec: &ReleaseBuildConfiguration{
+				PromotionConfiguration: &PromotionConfiguration{
+					Targets: []PromotionTarget{{
+						Namespace: "ocp-priv",
+					}},
+				},
+			},
+			expected: false,
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			if actual, expected := PromotesOfficialImages(testCase.configSpec, WithOKD), testCase.expected; actual != expected {
-				t.Errorf("%s: did not identify official promotion correctly, expected %v got %v", testCase.name, expected, actual)
+			if diff := cmp.Diff(testCase.expected, PromotesOfficialImages(testCase.configSpec, WithOKD)); diff != "" {
+				t.Errorf("%s: mismatch (-want +got):\n%s", testCase.name, diff)
+			}
+		})
+	}
+}
+
+func TestRefersToOfficialImage(t *testing.T) {
+	testCases := []struct {
+		name       string
+		namespace  string
+		includeOKD OKDInclusion
+		expected   bool
+	}{
+		{name: "ocp", namespace: "ocp", includeOKD: WithoutOKD, expected: true},
+		{name: "ocp-priv", namespace: "ocp-priv", includeOKD: WithoutOKD, expected: false},
+		{name: "origin without OKD", namespace: "origin", includeOKD: WithoutOKD, expected: false},
+		{name: "origin with OKD", namespace: "origin", includeOKD: WithOKD, expected: true},
+		{name: "other ns", namespace: "ci", includeOKD: WithOKD, expected: false},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if diff := cmp.Diff(testCase.expected, RefersToOfficialImage(testCase.namespace, testCase.includeOKD)); diff != "" {
+				t.Errorf("%s: mismatch (-want +got):\n%s", testCase.name, diff)
+			}
+		})
+	}
+}
+
+func TestRefersToQuayReferenceImage(t *testing.T) {
+	testCases := []struct {
+		name       string
+		namespace  string
+		includeOKD OKDInclusion
+		expected   bool
+	}{
+		{name: "ocp", namespace: "ocp", includeOKD: WithoutOKD, expected: true},
+		{name: "ocp-priv", namespace: "ocp-priv", includeOKD: WithoutOKD, expected: true},
+		{name: "origin without OKD", namespace: "origin", includeOKD: WithoutOKD, expected: false},
+		{name: "origin with OKD", namespace: "origin", includeOKD: WithOKD, expected: true},
+		{name: "other ns", namespace: "ci", includeOKD: WithOKD, expected: false},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if diff := cmp.Diff(testCase.expected, RefersToQuayReferenceImage(testCase.namespace, testCase.includeOKD)); diff != "" {
+				t.Errorf("%s: mismatch (-want +got):\n%s", testCase.name, diff)
 			}
 		})
 	}
@@ -310,6 +365,37 @@ func TestQuayCombinedMirrorFunc(t *testing.T) {
 				"quay.io/openshift/ci:ocp_4.22_ovn-kubernetes":                      "registry.build02.ci.openshift.org/ci-op-abc/pipeline:some-tag",
 				"quay.io/openshift/ci:20241024102030_prune_ocp_4.22_ovn-kubernetes": "quay.io/openshift/ci:ocp_4.22_ovn-kubernetes",
 				"ocp/4.22:ovn-kubernetes":                                           "registry.build02.ci.openshift.org/ci-op-abc/pipeline:some-tag",
+			},
+		},
+		{
+			name:   "non-payload namespace quay only",
+			source: "registry.build02.ci.openshift.org/ci-op-abc/pipeline@sha256:bbb",
+			target: "quay.io/openshift/ci:ci_ci_sanitize-prow-jobs",
+			tag: ImageStreamTagReference{
+				Namespace: "ci",
+				Name:      "ci",
+				Tag:       "sanitize-prow-jobs",
+			},
+			time: "20241024102030",
+			expected: map[string]string{
+				"quay.io/openshift/ci:ci_ci_sanitize-prow-jobs":                      "registry.build02.ci.openshift.org/ci-op-abc/pipeline@sha256:bbb",
+				"quay.io/openshift/ci:20241024102030_prune_ci_ci_sanitize-prow-jobs": "quay.io/openshift/ci:ci_ci_sanitize-prow-jobs",
+			},
+		},
+		{
+			name:   "ocp-priv payload gets app.ci ref",
+			source: "registry.build02.ci.openshift.org/ci-op-abc/pipeline@sha256:abc123",
+			target: "quay.io/openshift/ci:ocp-priv_4.23_cli",
+			tag: ImageStreamTagReference{
+				Namespace: "ocp-priv",
+				Name:      "4.23",
+				Tag:       "cli",
+			},
+			time: "20241024102030",
+			expected: map[string]string{
+				"quay.io/openshift/ci:ocp-priv_4.23_cli":                      "registry.build02.ci.openshift.org/ci-op-abc/pipeline@sha256:abc123",
+				"quay.io/openshift/ci:20241024102030_prune_ocp-priv_4.23_cli": "quay.io/openshift/ci:ocp-priv_4.23_cli",
+				"ocp-priv/4.23:cli": "quay-proxy.ci.openshift.org/openshift/ci@sha256:abc123",
 			},
 		},
 	}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -294,9 +294,6 @@ func fromConfig(ctx context.Context, cfg *Config) ([]api.Step, []api.Step, error
 			return nil, nil, fmt.Errorf("cannot promote images, no promotion configuration defined")
 		}
 
-		if !api.PromotesOfficialImages(cfg.CIConfig, api.WithoutOKD) {
-			promotionSteps = append(promotionSteps, releasesteps.PromotionStep(api.PromotionStepName, cfg.CIConfig, requiredNames, cfg.SkippedImages, cfg.JobSpec, cfg.podClient, cfg.PushSecret, registryDomain(cfg.CIConfig.PromotionConfiguration), api.DefaultMirrorFunc, api.DefaultTargetNameFunc, cfg.NodeArchitectures, cliVersion))
-		}
 		// Used primarily (only?) by the ci-chat-bot
 		if cfg.CIConfig.PromotionConfiguration.RegistryOverride != "" {
 			logrus.Info("No images to promote to quay.io if the registry is overridden")

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -1715,7 +1715,7 @@ func TestFromConfig(t *testing.T) {
 		},
 		promote:       true,
 		expectedSteps: []string{"[output-images]", "[images]"},
-		expectedPost:  []string{"[promotion]", "[promotion-quay]"},
+		expectedPost:  []string{"[promotion-quay]"},
 	}, {
 		name: "promote 4.12 quay only",
 		config: api.ReleaseBuildConfiguration{

--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -339,7 +339,7 @@ func quayProxyTagFromISKey(isTagKey string) (string, bool) {
 	var streamName string
 	if strings.HasSuffix(streamPart, quayStreamSuffix) {
 		streamName = strings.TrimSuffix(streamPart, quayStreamSuffix)
-	} else if api.RefersToOfficialImage(namespace, api.WithOKD) {
+	} else if api.RefersToQuayReferenceImage(namespace, api.WithOKD) {
 		streamName = streamPart
 	} else {
 		return "", false
@@ -460,7 +460,7 @@ func (s *promotionStep) getQuayPromotionShell(imageMirrorTarget map[string]strin
 		}
 		if !strings.Contains(k, api.ComponentFormatReplacement) {
 			if quayProxyTag, ok := quayProxyTagFromISKey(k); ok {
-				if ns := k[:strings.Index(k, "/")]; api.RefersToOfficialImage(ns, api.WithOKD) {
+				if ns := k[:strings.Index(k, "/")]; api.RefersToQuayReferenceImage(ns, api.WithOKD) {
 					resolveAndTagPairs = append(resolveAndTagPairs, [2]string{quayProxyTag, k})
 					continue
 				}

--- a/pkg/steps/release/promote_test.go
+++ b/pkg/steps/release/promote_test.go
@@ -1250,8 +1250,6 @@ func TestGetQuayPromotionShell(t *testing.T) {
 				"quay.io/openshift/ci:20240603235401_prune_ci_c_latest": "quay.io/openshift/ci:ci_c_latest",
 				"quay.io/openshift/ci:ci_a_latest":                      "registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb",
 				"quay.io/openshift/ci:ci_c_latest":                      "registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:ddd",
-				"ci/ci-quay:${component}":                               "quay-proxy.ci.openshift.org/openshift/ci@sha256:bbb",
-				"ci/${component}-quay:c":                                "quay-proxy.ci.openshift.org/openshift/ci@sha256:ddd",
 			},
 		},
 		{
@@ -1289,7 +1287,6 @@ func TestGetQuayPromotionShell(t *testing.T) {
 				"quay.io/openshift/ci:ocp_4.21_ovn-kubernetes":  "registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:aaa",
 				"ocp/4.21:ovn-kubernetes":                       "quay-proxy.ci.openshift.org/openshift/ci@sha256:aaa",
 				"quay.io/openshift/ci:ci_ci_sanitize-prow-jobs": "registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb",
-				"ci/ci-quay:sanitize-prow-jobs":                 "quay-proxy.ci.openshift.org/openshift/ci@sha256:bbb",
 			},
 		},
 	}
@@ -1425,16 +1422,24 @@ func TestQuayProxyTagFromISKey(t *testing.T) {
 			wantTag:  "quay-proxy.ci.openshift.org/openshift/ci:ocp_5.0_ansible",
 			wantOK:   true,
 		},
+		{
+			name:     "ocp-priv stream",
+			isTagKey: "ocp-priv/4.23:cli",
+			wantTag:  "quay-proxy.ci.openshift.org/openshift/ci:ocp-priv_4.23_cli",
+			wantOK:   true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, ok := quayProxyTagFromISKey(tt.isTagKey)
-			if ok != tt.wantOK {
-				t.Errorf("quayProxyTagFromISKey(%q) ok = %v, want %v", tt.isTagKey, ok, tt.wantOK)
+			if diff := cmp.Diff(tt.wantOK, ok); diff != "" {
+				t.Errorf("quayProxyTagFromISKey(%q) ok mismatch (-want +got):\n%s", tt.isTagKey, diff)
 				return
 			}
-			if ok && got != tt.wantTag {
-				t.Errorf("quayProxyTagFromISKey(%q) = %q, want %q", tt.isTagKey, got, tt.wantTag)
+			if ok {
+				if diff := cmp.Diff(tt.wantTag, got); diff != "" {
+					t.Errorf("quayProxyTagFromISKey(%q) tag mismatch (-want +got):\n%s", tt.isTagKey, diff)
+				}
 			}
 		})
 	}

--- a/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay.yaml
@@ -34,18 +34,6 @@ data:
     if [ "${_OLD_EXISTS}" = "true" ]; then
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_c_latest=quay.io/openshift/ci:ci_c_latest__post1
     fi
-    for r in {1..2}; do
-    echo "Tag attempt $r"
-
-    while read tag; do
-    oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference $tag || break
-    done <<'EOF'
-    quay-proxy.ci.openshift.org/openshift/ci@sha256:ddd ci/${component}-quay:c
-    quay-proxy.ci.openshift.org/openshift/ci@sha256:bbb ci/ci-quay:${component}
-    EOF
-    [[ $? -ne 0 ]] && break
-    :
-    done
 metadata:
   creationTimestamp: null
   name: promotion-quay-script

--- a/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay_non_release_namespace.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay_non_release_namespace.yaml
@@ -1,5 +1,5 @@
 data:
-  promote.sh: |-
+  promote.sh: |
     function mirror {
     for r in $(seq 1 $1); do
       echo Mirror attempt $r
@@ -48,18 +48,6 @@ data:
       echo "promotion: retrying digest-tag for ocp/4.21:ovn-kubernetes (attempt $((r+1))/5 after randomized backoff)" >&2
       backoff=$(($RANDOM % 120))s
       sleep "${backoff}"
-    done
-
-    for r in {1..2}; do
-    echo "Tag attempt $r"
-
-    while read tag; do
-    oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference $tag || break
-    done <<'EOF'
-    quay-proxy.ci.openshift.org/openshift/ci@sha256:bbb ci/ci-quay:sanitize-prow-jobs
-    EOF
-    [[ $? -ne 0 ]] && break
-    :
     done
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
/hold
/cc @jupierce 

## ⚠️ Major announcement

This PR changes **promotion for all namespaces** (OCP and non-OCP).

We **stop pushing image blobs to app.ci / registry.ci** via the legacy `[promotion]` step. Images are promoted to **Quay CI (QCI)** only. **App.ci ImageStreams are updated only for payload namespaces**, and only as **source tag references** to QCI digests—not as blob copies.

**Payload namespaces (app.ci source-refs kept):** `ocp`, `ocp-priv`, `origin` (OKD)

**All other namespaces:** QCI only—no registry.ci blob promote, no new app.ci ImageStream tags.

---

## What this changes

Today many promote jobs write images **twice** (registry.ci **and** QCI) and often also update app.ci ImageStreams with local content.

After this PR:

| Destination | Payload (`ocp` / `ocp-priv` / `origin`) | Everyone else |
|-------------|----------------------------------------|---------------|
| **QCI** (`quay.io/openshift/ci`) | ✅ float tags | ✅ float tags |
| **app.ci ImageStream** | ✅ source-ref to QCI digest | ❌ no new IS tags |
| **registry.ci blob `[promotion]`** | ❌ removed | ❌ removed |

Promotion posts run **`[promotion-quay]` only**. Exception: chat-bot / `registry_override` still skips the Quay promote path (unchanged).

`ocp-priv` now matches public `ocp` for app.ci source-ref behavior (private-org payload streams).

---

## Who is affected

- **Everyone with promoting ci-operator jobs** — promotion output shape changes.
- **Payload / private-org / OKD owners** (`ocp`, `ocp-priv`, `origin`) — images on QCI; app.ci streams keep tracking them via source-refs for release-controller and integration (same model as today’s quay path for `ocp`).
- **Non-payload promoters** (`ci`, product namespaces, etc.) — images land on **QCI only**. Jobs or configs that still pull `registry.ci.openshift.org/<ns>/…` or rely on app.ci IS tags in those namespaces will see **stale or missing** updates unless they switch to **QCI / quay-proxy** pullspecs.
- **Chat-bot / `registry_override`** — unchanged.

---

## Action required

If you consume promoted images outside payload streams (`ocp` / `ocp-priv` / `origin`), plan to pull from:

`quay-proxy.ci.openshift.org/openshift/ci:<namespace>_<stream>_<tag>`

(or the equivalent `quay.io/openshift/ci:…` float), not from registry.ci or non-payload app.ci ImageStreams.

Questions: `#forum-ocp-testplatform`

/cc @openshift/test-platform 