### PR TITLE
ci-operator: Deprecate the `ClusterType` function

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -13,6 +13,7 @@ import (
 	prowconfig "sigs.k8s.io/prow/pkg/config"
 	"sigs.k8s.io/prow/pkg/flagutil"
 
+	"github.com/openshift/ci-tools/pkg/api"
 	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/config"
 	jc "github.com/openshift/ci-tools/pkg/jobconfig"
@@ -123,14 +124,26 @@ func (o *options) generateJobsToDir(subDir string) error {
 func generateJobs(resolver registry.Resolver, output map[string]*prowconfig.JobConfig) func(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *config.Info) error {
 	return func(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *config.Info) error {
 		orgRepo := fmt.Sprintf("%s/%s", info.Org, info.Repo)
+		var clusterProfileResolver func(name string) (*api.ClusterProfileDetails, error) = func(name string) (*api.ClusterProfileDetails, error) {
+			return nil, fmt.Errorf("cluster profile resolver not available")
+		}
+
 		if resolver != nil {
 			resolved, err := registry.ResolveConfig(resolver, *configSpec)
 			if err != nil {
 				return fmt.Errorf("failed to resolve configuration: %w", err)
 			}
 			configSpec = &resolved
+			clusterProfileResolver = func(name string) (*api.ClusterProfileDetails, error) {
+				cp, err := resolver.ResolveClusterProfile(name)
+				if err != nil {
+					return nil, err
+				}
+				return &cp, nil
+			}
 		}
-		generated, err := prowgen.GenerateJobs(configSpec, &info.Metadata)
+
+		generated, err := prowgen.GenerateJobs(configSpec, &info.Metadata, clusterProfileResolver)
 		if err != nil {
 			return err
 		}

--- a/cmd/dptp-controller-manager/main.go
+++ b/cmd/dptp-controller-manager/main.go
@@ -78,6 +78,7 @@ type options struct {
 	ephemeralClusterProvisinerOptions    ephemeralClusterProvisionerOptions
 	*flagutil.GitHubOptions
 	releaseRepoGitSyncPath string
+	registryAgentNeeded    bool
 }
 
 func (o *options) addDefaults() {
@@ -235,8 +236,10 @@ func newOpts() (*options, error) {
 		}
 	}
 
-	if opts.enabledControllersSet.Has(testimagesdistributor.ControllerName) && opts.stepConfigPath == "" {
-		errs = append(errs, fmt.Errorf("--step-config-path is required when the %s controller is enabled", testimagesdistributor.ControllerName))
+	opts.registryAgentNeeded = opts.enabledControllersSet.Has(testimagesdistributor.ControllerName) ||
+		opts.enabledControllersSet.Has(ephemeralcluster.ControllerName)
+	if opts.registryAgentNeeded && opts.stepConfigPath == "" {
+		errs = append(errs, fmt.Errorf("--step-config-path is required when the %s or %s controller is enabled", testimagesdistributor.ControllerName, ephemeralcluster.ControllerName))
 	}
 
 	if opts.enabledControllersSet.Has(serviceaccountsecretrefresher.ControllerName) {
@@ -492,14 +495,17 @@ func main() {
 		}
 	}
 
-	if opts.enabledControllersSet.Has(testimagesdistributor.ControllerName) {
+	var registryAgent agents.RegistryAgent
+	if opts.registryAgentNeeded {
 		registryErrCh := make(chan error)
-		registryConfigAgent, err := agents.NewRegistryAgent(opts.stepConfigPath, registryErrCh, registryAgentOption)
+		go func() { logrus.Fatal(<-registryErrCh) }()
+		registryAgent, err = agents.NewRegistryAgent(opts.stepConfigPath, registryErrCh, registryAgentOption)
 		if err != nil {
 			logrus.WithError(err).Fatal("failed to construct registryAgent")
 		}
-		go func() { logrus.Fatal(<-registryErrCh) }()
+	}
 
+	if opts.enabledControllersSet.Has(testimagesdistributor.ControllerName) {
 		registriesExceptAppCI := sets.New[string]()
 		for cluster := range allClustersExceptRegistryCluster {
 			domain, err := api.RegistryDomainForClusterName(cluster)
@@ -517,7 +523,7 @@ func main() {
 			registryMgr,
 			allClustersExceptRegistryCluster,
 			ciOPConfigAgent,
-			registryConfigAgent,
+			registryAgent,
 			opts.testImagesDistributorOptions.additionalImageStreamTags,
 			opts.testImagesDistributorOptions.additionalImageStreams,
 			opts.testImagesDistributorOptions.additionalImageStreamNamespaces,
@@ -544,7 +550,7 @@ func main() {
 
 	if opts.enabledControllersSet.Has(ephemeralcluster.ControllerName) {
 		log := logrus.NewEntry(logrus.StandardLogger())
-		if err := ephemeralcluster.AddToManager(log, mgr, allManagers, configAgent,
+		if err := ephemeralcluster.AddToManager(log, mgr, allManagers, configAgent, registryAgent,
 			ephemeralcluster.WithPolling(opts.ephemeralClusterProvisinerOptions.polling),
 			ephemeralcluster.WithCLIISTagRef(opts.ephemeralClusterProvisinerOptions.cliISTagRef)); err != nil {
 			logrus.WithError(err).Fatalf("Failed to construct the %s controller", ephemeralcluster.ControllerName)

--- a/cmd/multi-pr-prow-plugin/server.go
+++ b/cmd/multi-pr-prow-plugin/server.go
@@ -85,6 +85,7 @@ func (c *githubTrustedChecker) trustedUser(author, org, repo string, _ int) (boo
 
 type ciOpConfigResolver interface {
 	Config(*api.Metadata) (*api.ReleaseBuildConfiguration, error)
+	ClusterProfile(profileName string) (*api.ClusterProfileDetails, error)
 }
 
 type prowConfigGetter interface {
@@ -358,7 +359,12 @@ func (s *server) generateProwJob(jr jobRun) (*prowv1.ProwJob, error) {
 			test.Timeout.Duration = defaultMultiRefJobTimeout
 		}
 
-		jobBaseGen := prowgen.NewProwJobBaseBuilderForTest(ciopConfig, &testJobMetadata, prowgen.NewCiOperatorPodSpecGenerator(), test)
+		jobBaseGen, err := prowgen.NewProwJobBaseBuilderForTest(ciopConfig, &testJobMetadata,
+			prowgen.NewCiOperatorPodSpecGenerator(), test, s.ciOpConfigResolver.ClusterProfile)
+		if err != nil {
+			return nil, fmt.Errorf("could not create the prowjob builder: %w", err)
+		}
+
 		jobBaseGen.PodSpec.Add(prowgen.InjectTestFrom(&jr.JobMetadata))
 		jobBaseGen.PodSpec.Add(prowgen.CustomHashInput(jobName))
 

--- a/cmd/multi-pr-prow-plugin/server_test.go
+++ b/cmd/multi-pr-prow-plugin/server_test.go
@@ -833,7 +833,8 @@ func TestDetermineJobRuns(t *testing.T) {
 }
 
 type fakeCIOpConfigResolver struct {
-	configs map[api.Metadata]*api.ReleaseBuildConfiguration
+	configs         map[api.Metadata]*api.ReleaseBuildConfiguration
+	clusterProfiles map[string]*api.ClusterProfileDetails
 }
 
 func (r fakeCIOpConfigResolver) Config(m *api.Metadata) (*api.ReleaseBuildConfiguration, error) {
@@ -842,6 +843,14 @@ func (r fakeCIOpConfigResolver) Config(m *api.Metadata) (*api.ReleaseBuildConfig
 	}
 
 	return r.configs[*m], nil
+}
+
+func (r fakeCIOpConfigResolver) ClusterProfile(profileName string) (*api.ClusterProfileDetails, error) {
+	cp, ok := r.clusterProfiles[profileName]
+	if !ok {
+		return nil, fmt.Errorf("cluster profile %q not found", profileName)
+	}
+	return cp, nil
 }
 
 type fakeProwConfigGetter struct {

--- a/pkg/cmd/release/profile.go
+++ b/pkg/cmd/release/profile.go
@@ -51,9 +51,8 @@ func profilePrint(args []string) error {
 	for _, arg := range args {
 		p := api.ClusterProfile(arg)
 		l = append(l, P{
-			Profile:     p,
-			ClusterType: p.ClusterType(),
-			LeaseType:   p.LeaseType(),
+			Profile:   p,
+			LeaseType: p.LeaseType(),
 		})
 	}
 	return printYAML(l)

--- a/pkg/controller/ephemeralcluster/reconciler.go
+++ b/pkg/controller/ephemeralcluster/reconciler.go
@@ -38,6 +38,7 @@ import (
 	"github.com/openshift/ci-tools/pkg/api"
 	ephemeralclusterv1 "github.com/openshift/ci-tools/pkg/api/ephemeralcluster/v1"
 	"github.com/openshift/ci-tools/pkg/jobconfig"
+	"github.com/openshift/ci-tools/pkg/load/agents"
 	"github.com/openshift/ci-tools/pkg/prowgen"
 	"github.com/openshift/ci-tools/pkg/steps"
 	cislices "github.com/openshift/ci-tools/pkg/util/slices"
@@ -111,13 +112,24 @@ func WithCLIISTagRef(isTagRef string) ReconcilerOption {
 
 type NewProwJobFunc func(spec prowv1.ProwJobSpec, extraLabels, extraAnnotations map[string]string, modifiers ...pjutil.Modifier) prowv1.ProwJob
 
+func clusterProfileResolverAdapter(registryAgent agents.RegistryAgent) func(string) (*api.ClusterProfileDetails, error) {
+	return func(name string) (*api.ClusterProfileDetails, error) {
+		cp, err := registryAgent.ResolveClusterProfile(name)
+		if err != nil {
+			return nil, err
+		}
+		return &cp, nil
+	}
+}
+
 type reconciler struct {
-	logger          *logrus.Entry
-	masterClient    ctrlruntimeclient.Client
-	buildClients    buildClients
-	newProwJob      NewProwJobFunc
-	prowConfigAgent *prowconfig.Agent
-	scheme          *runtime.Scheme
+	logger                 *logrus.Entry
+	masterClient           ctrlruntimeclient.Client
+	buildClients           buildClients
+	newProwJob             NewProwJobFunc
+	prowConfigAgent        *prowconfig.Agent
+	clusterProfileResolver prowgen.ClusterProfileResolver
+	scheme                 *runtime.Scheme
 
 	// Mock for testing
 	now         func() time.Time
@@ -130,7 +142,7 @@ func ECPredicateFilter(object ctrlruntimeclient.Object) bool {
 }
 
 func AddToManager(log *logrus.Entry, mgr manager.Manager, allManagers map[string]manager.Manager,
-	prowConfigAgent *prowconfig.Agent, opts ...ReconcilerOption) error {
+	prowConfigAgent *prowconfig.Agent, registryAgent agents.RegistryAgent, opts ...ReconcilerOption) error {
 	buildClients := make(map[string]ctrlruntimeclient.Client)
 	for clusterName, clusterManager := range allManagers {
 		buildClients[clusterName] = clusterManager.GetClient()
@@ -146,15 +158,16 @@ func AddToManager(log *logrus.Entry, mgr manager.Manager, allManagers map[string
 	}
 
 	r := reconciler{
-		logger:          log.WithField("controller", ControllerName),
-		masterClient:    mgr.GetClient(),
-		buildClients:    buildClients,
-		prowConfigAgent: prowConfigAgent,
-		scheme:          mgr.GetScheme(),
-		newProwJob:      pjutil.NewProwJob,
-		now:             time.Now,
-		polling:         func() time.Duration { return defaultReconcilerOpts.polling },
-		cliISTagRef:     cliISTagRef,
+		logger:                 log.WithField("controller", ControllerName),
+		masterClient:           mgr.GetClient(),
+		buildClients:           buildClients,
+		prowConfigAgent:        prowConfigAgent,
+		clusterProfileResolver: clusterProfileResolverAdapter(registryAgent),
+		scheme:                 mgr.GetScheme(),
+		newProwJob:             pjutil.NewProwJob,
+		now:                    time.Now,
+		polling:                func() time.Duration { return defaultReconcilerOpts.polling },
+		cliISTagRef:            cliISTagRef,
 	}
 
 	if err := ctrlbldr.ControllerManagedBy(mgr).
@@ -422,7 +435,7 @@ func (r *reconciler) makeProwJob(ciOperatorConfig *api.ReleaseBuildConfiguration
 		Org:    "org",
 		Repo:   "repo",
 		Branch: "branch",
-	})
+	}, r.clusterProfileResolver)
 	if err != nil {
 		return nil, fmt.Errorf("generate jobs: %w", err)
 	}

--- a/pkg/controller/ephemeralcluster/reconciler_test.go
+++ b/pkg/controller/ephemeralcluster/reconciler_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	ephemeralclusterv1 "github.com/openshift/ci-tools/pkg/api/ephemeralcluster/v1"
+	"github.com/openshift/ci-tools/pkg/load/agents"
 	"github.com/openshift/ci-tools/pkg/steps"
 	"github.com/openshift/ci-tools/pkg/testhelper"
 	ctrlruntimetest "github.com/openshift/ci-tools/pkg/testhelper/kubernetes/ctrlruntime"
@@ -35,6 +36,19 @@ import (
 const (
 	prowJobNamespace = "ci"
 )
+
+type fakeRegistryAgent struct {
+	agents.RegistryAgent
+	clusterProfiles map[string]*api.ClusterProfileDetails
+}
+
+func (f *fakeRegistryAgent) ResolveClusterProfile(name string) (api.ClusterProfileDetails, error) {
+	cp, ok := f.clusterProfiles[name]
+	if !ok {
+		return api.ClusterProfileDetails{}, fmt.Errorf("cluster profile %q not found", name)
+	}
+	return *cp, nil
+}
 
 func newProwJobFaker(name string, now time.Time) NewProwJobFunc {
 	return func(spec prowv1.ProwJobSpec, extraLabels, extraAnnotations map[string]string, modifiers ...pjutil.Modifier) prowv1.ProwJob {
@@ -141,6 +155,12 @@ func TestCreateProwJob(t *testing.T) {
 		},
 	}
 
+	fakeRegistryAgent := fakeRegistryAgent{
+		clusterProfiles: map[string]*api.ClusterProfileDetails{
+			"aws": {ClusterType: "aws"},
+		},
+	}
+
 	for _, tc := range []struct {
 		name         string
 		ec           ephemeralclusterv1.EphemeralCluster
@@ -191,6 +211,48 @@ func TestCreateProwJob(t *testing.T) {
 			},
 			req:     reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "ec"}},
 			wantRes: reconcile.Result{RequeueAfter: pollingTime},
+		},
+		{
+			name: "Invalid cluster profile",
+			ec: ephemeralclusterv1.EphemeralCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "ec",
+				},
+				Spec: ephemeralclusterv1.EphemeralClusterSpec{
+					CIOperator: ephemeralclusterv1.CIOperatorSpec{
+						BuildRootImage: &api.BuildRootImageConfiguration{
+							ImageStreamTagReference: &api.ImageStreamTagReference{
+								Namespace: "ocp",
+								Name:      "4.20",
+								Tag:       "cli",
+							},
+						},
+						BaseImages: map[string]api.ImageStreamTagReference{
+							"upi-installer": {
+								Namespace: "ocp",
+								Name:      "4.20",
+								Tag:       "upi-installer",
+							},
+						},
+						ExternalImages: map[string]api.ExternalImage{
+							"fedora": {Registry: "quay.io/fedora/fedora:43"},
+						},
+						Releases: map[string]api.UnresolvedRelease{
+							"initial": {Integration: &api.Integration{Name: "4.17", Namespace: "ocp"}},
+							"latest":  {Integration: &api.Integration{Name: "4.17", Namespace: "ocp"}},
+						},
+						Test: ephemeralclusterv1.TestSpec{
+							Workflow:       "test-workflow",
+							Env:            map[string]string{"foo": "bar"},
+							ClusterProfile: "aws-2",
+						},
+					},
+				},
+			},
+			req:     reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "ec"}},
+			wantRes: reconcile.Result{},
+			wantErr: errors.New(`terminal error: generate jobs: new prowjob builder: resolve cluster profile "aws-2": cluster profile "aws-2" not found`),
 		},
 		{
 			name: "Hive cluster request creates a ProwJob",
@@ -400,13 +462,14 @@ func TestCreateProwJob(t *testing.T) {
 			}
 
 			r := reconciler{
-				logger:          logrus.NewEntry(logrus.StandardLogger()),
-				masterClient:    client,
-				now:             func() time.Time { return fakeNow },
-				polling:         func() time.Duration { return pollingTime },
-				cliISTagRef:     api.ImageStreamTagReference{Namespace: "ocp", Name: "4.22", Tag: "cli"},
-				newProwJob:      newProwJobFaker("foobar", fakeNow),
-				prowConfigAgent: prowConfigAgent(pc),
+				logger:                 logrus.NewEntry(logrus.StandardLogger()),
+				masterClient:           client,
+				now:                    func() time.Time { return fakeNow },
+				polling:                func() time.Duration { return pollingTime },
+				cliISTagRef:            api.ImageStreamTagReference{Namespace: "ocp", Name: "4.22", Tag: "cli"},
+				newProwJob:             newProwJobFaker("foobar", fakeNow),
+				prowConfigAgent:        prowConfigAgent(pc),
+				clusterProfileResolver: clusterProfileResolverAdapter(&fakeRegistryAgent),
 			}
 
 			gotRes, gotErr := r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.ec.Name, Namespace: tc.ec.Namespace}})

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Invalid_cluster_profile.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Invalid_cluster_profile.yaml
@@ -1,0 +1,46 @@
+metadata:
+  creationTimestamp: null
+  name: ec
+  namespace: ns
+  resourceVersion: "1000"
+spec:
+  ciOperator:
+    baseImages:
+      upi-installer:
+        name: "4.20"
+        namespace: ocp
+        tag: upi-installer
+    buildRoot:
+      image_stream_tag:
+        name: "4.20"
+        namespace: ocp
+        tag: cli
+    externalImages:
+      fedora:
+        name: ""
+        namespace: ""
+        registry: quay.io/fedora/fedora:43
+        tag: ""
+    releases:
+      initial:
+        integration:
+          name: "4.17"
+          namespace: ocp
+      latest:
+        integration:
+          name: "4.17"
+          namespace: ocp
+    test:
+      clusterProfile: aws-2
+      env:
+        foo: bar
+      workflow: test-workflow
+status:
+  conditions:
+  - lastTransitionTime: "2025-04-02T12:12:12Z"
+    message: 'generate jobs: new prowjob builder: resolve cluster profile "aws-2":
+      cluster profile "aws-2" not found'
+    reason: CIOperatorJobsGenerateFailure
+    status: "False"
+    type: ProwJobCreating
+  phase: Failed

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Invalid_cluster_profile.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Invalid_cluster_profile.yaml
@@ -1,0 +1,2 @@
+items: []
+metadata: {}

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -55,6 +55,7 @@ const (
 
 type injectingResolverClient interface {
 	ConfigWithTest(base *api.Metadata, testSource *api.MetadataWithTest) (*api.ReleaseBuildConfiguration, error)
+	ClusterProfile(profileName string) (*api.ClusterProfileDetails, error)
 }
 
 type prowConfigGetter interface {
@@ -312,7 +313,8 @@ func (r *reconciler) triggerJobs(ctx context.Context,
 			prowjobsToCreate = append(prowjobsToCreate, aggregatedProwjobs...)
 
 			submitted := generateJobNameToSubmit(inject, pullRequests, jobSpec.ShardCount, jobSpec.ShardIndex)
-			aggregatorJob, err := generateAggregatorJob(baseMetadata, uid, mimickedJob, jobSpec.JobName(jobconfig.PeriodicPrefix), req.Name, req.Namespace, r.prowConfigGetter, time.Now(), submitted, r.defaultAggregatorJobTimeout)
+			aggregatorJob, err := generateAggregatorJob(baseMetadata, uid, mimickedJob, jobSpec.JobName(jobconfig.PeriodicPrefix),
+				req.Name, req.Namespace, r.prowConfigGetter, time.Now(), submitted, r.defaultAggregatorJobTimeout, r.configResolverClient)
 			if err != nil {
 				logger.WithError(err).Error("Failed to generate an aggregator prowjob")
 				statuses[mimickedJob] = &v1.PullRequestPayloadJobStatus{
@@ -628,7 +630,12 @@ func (r *reconciler) generateProwjob(ciopConfig *api.ReleaseBuildConfiguration,
 				test.Timeout.Duration = r.defaultMultiRefJobTimeout
 			}
 		}
-		jobBaseGen := prowgen.NewProwJobBaseBuilderForTest(ciopConfig, baseCiop, prowgen.NewCiOperatorPodSpecGenerator(), test)
+		jobBaseGen, err := prowgen.NewProwJobBaseBuilderForTest(ciopConfig, baseCiop,
+			prowgen.NewCiOperatorPodSpecGenerator(), test, r.configResolverClient.ClusterProfile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create the prowjob builder: %w", err)
+		}
+
 		jobBaseGen.PodSpec.Add(prowgen.InjectTestFrom(inject))
 		if latestPayloadPullspec != "" {
 			jobBaseGen.PodSpec.Add(prowgen.ReleaseLatest(latestPayloadPullspec))
@@ -802,7 +809,9 @@ func (r *reconciler) generateAggregatedProwjobs(uid string, ciopConfig *api.Rele
 	return ret, nil
 }
 
-func generateAggregatorJob(baseCiop *api.Metadata, uid, aggregatorJobName, jobName, prpqrName, prpqrNamespace string, getCfg prowConfigGetter, startTime time.Time, submitted string, aggregatedJobTimeout time.Duration) (*prowv1.ProwJob, error) {
+func generateAggregatorJob(baseCiop *api.Metadata, uid, aggregatorJobName, jobName, prpqrName, prpqrNamespace string,
+	getCfg prowConfigGetter, startTime time.Time, submitted string, aggregatedJobTimeout time.Duration,
+	configResolverClient injectingResolverClient) (*prowv1.ProwJob, error) {
 	ciopConfig := &api.ReleaseBuildConfiguration{
 		Metadata: *baseCiop,
 		Tests: []api.TestStepConfiguration{
@@ -840,7 +849,10 @@ func generateAggregatorJob(baseCiop *api.Metadata, uid, aggregatorJobName, jobNa
 	}
 
 	emptyMetadata := &api.Metadata{}
-	jobBaseGen := prowgen.NewProwJobBaseBuilderForTest(ciopConfig, emptyMetadata, prowgen.NewCiOperatorPodSpecGenerator(), ciopConfig.Tests[0])
+	jobBaseGen, err := prowgen.NewProwJobBaseBuilderForTest(ciopConfig, emptyMetadata, prowgen.NewCiOperatorPodSpecGenerator(), ciopConfig.Tests[0], configResolverClient.ClusterProfile)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create the prowjob builder: %w", err)
+	}
 
 	periodic := prowgen.GeneratePeriodicForTest(jobBaseGen, emptyMetadata, prowgen.FromConfigSpec(ciopConfig), func(options *prowgen.GeneratePeriodicOptions) {
 		options.Cron = "@yearly"

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler_test.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler_test.go
@@ -540,7 +540,9 @@ func pruneProwjobsForTests(t *testing.T, items []prowv1.ProwJob) {
 	}
 }
 
-type fakeResolverClient struct{}
+type fakeResolverClient struct {
+	clusterProfiles map[string]*api.ClusterProfileDetails
+}
 
 func (f *fakeResolverClient) ConfigWithTest(base *api.Metadata, testSource *api.MetadataWithTest) (*api.ReleaseBuildConfiguration, error) {
 	return &api.ReleaseBuildConfiguration{
@@ -551,6 +553,14 @@ func (f *fakeResolverClient) ConfigWithTest(base *api.Metadata, testSource *api.
 			},
 		},
 	}, nil
+}
+
+func (r fakeResolverClient) ClusterProfile(profileName string) (*api.ClusterProfileDetails, error) {
+	cp, ok := r.clusterProfiles[profileName]
+	if !ok {
+		return nil, fmt.Errorf("cluster profile %q not found", profileName)
+	}
+	return cp, nil
 }
 
 type fakeProwConfigGetter struct {

--- a/pkg/load/agents/registryAgent.go
+++ b/pkg/load/agents/registryAgent.go
@@ -22,7 +22,6 @@ type RegistryAgent interface {
 	GetRegistryComponents() (registry.ReferenceByName, registry.ChainByName, registry.WorkflowByName, map[string]string, api.RegistryMetadata)
 	GetGeneration() int
 	GetClusterProfiles() api.ClusterProfilesMap
-	GetClusterProfileDetails(profileName string) (*api.ClusterProfileDetails, error)
 	registry.Resolver
 }
 
@@ -147,12 +146,12 @@ func (a *registryAgent) GetClusterProfiles() api.ClusterProfilesMap {
 }
 
 // GetClusterProfileDetails returns a struct with all details for a cluster profile
-func (a *registryAgent) GetClusterProfileDetails(profileName string) (*api.ClusterProfileDetails, error) {
+func (a *registryAgent) ResolveClusterProfile(profileName string) (api.ClusterProfileDetails, error) {
 	profileDetails, found := a.GetClusterProfiles()[api.ClusterProfile(profileName)]
 	if found {
-		return &profileDetails, nil
+		return profileDetails, nil
 	}
-	return nil, fmt.Errorf("cluster profile %s not found", profileName)
+	return api.ClusterProfileDetails{}, fmt.Errorf("cluster profile %s not found", profileName)
 }
 
 func (a *registryAgent) loadRegistry() error {

--- a/pkg/load/agents/registryAgent_test.go
+++ b/pkg/load/agents/registryAgent_test.go
@@ -29,13 +29,13 @@ func TestGetClusterProfileDetails(t *testing.T) {
 	testCases := []struct {
 		name          string
 		profileName   string
-		expected      *api.ClusterProfileDetails
+		expected      api.ClusterProfileDetails
 		expectedError error
 	}{
 		{
 			name:        "profile found",
 			profileName: "aws",
-			expected: &api.ClusterProfileDetails{
+			expected: api.ClusterProfileDetails{
 				Name: "aws",
 				Owners: []api.ClusterProfileOwners{{
 					Org:   "openshift",
@@ -55,14 +55,12 @@ func TestGetClusterProfileDetails(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := agent.GetClusterProfileDetails(tc.profileName)
-			if tc.expected != nil {
-				if diff := cmp.Diff(result, tc.expected); diff != "" {
-					t.Errorf("result differs from expected: %v", diff)
-				}
-			}
+			result, err := agent.ResolveClusterProfile(tc.profileName)
 			if diff := cmp.Diff(tc.expectedError, err, testhelper.EquateErrorMessage); diff != "" {
 				t.Errorf("error differs from expected:\n%s", diff)
+			}
+			if diff := cmp.Diff(result, tc.expected); diff != "" {
+				t.Errorf("result differs from expected: %v", diff)
 			}
 		})
 	}

--- a/pkg/prowgen/jobbase.go
+++ b/pkg/prowgen/jobbase.go
@@ -1,6 +1,7 @@
 package prowgen
 
 import (
+	"fmt"
 	"path"
 	"time"
 
@@ -9,10 +10,13 @@ import (
 	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 	prowconfig "sigs.k8s.io/prow/pkg/config"
 
+	"github.com/openshift/ci-tools/pkg/api"
 	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/api/ocplifecycle"
 	jc "github.com/openshift/ci-tools/pkg/jobconfig"
 )
+
+type ClusterProfileResolver func(clusterProfile string) (*api.ClusterProfileDetails, error)
 
 type prowJobBaseBuilder struct {
 	PodSpec CiOperatorPodSpecGenerator
@@ -140,7 +144,8 @@ func NewProwJobBaseBuilder(configSpec *cioperatorapi.ReleaseBuildConfiguration, 
 // NewProwJobBaseBuilderForTest creates a new builder populated with defaults
 // for the given ci-operator test. The resulting builder is a superset of a
 // one built by NewProwJobBaseBuilder, with additional fields set for test
-func NewProwJobBaseBuilderForTest(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *cioperatorapi.Metadata, podSpecGenerator CiOperatorPodSpecGenerator, test cioperatorapi.TestStepConfiguration) *prowJobBaseBuilder {
+func NewProwJobBaseBuilderForTest(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *cioperatorapi.Metadata,
+	podSpecGenerator CiOperatorPodSpecGenerator, test cioperatorapi.TestStepConfiguration, clusterProfileResolver ClusterProfileResolver) (*prowJobBaseBuilder, error) {
 	p := NewProwJobBaseBuilder(configSpec, info, podSpecGenerator)
 	if test.Cluster != "" {
 		p.Cluster(test.Cluster)
@@ -186,8 +191,13 @@ func NewProwJobBaseBuilderForTest(configSpec *cioperatorapi.ReleaseBuildConfigur
 	case test.MultiStageTestConfiguration != nil:
 		p.PodSpec.Add(LeaseClient())
 		if clusterProfile := test.MultiStageTestConfiguration.ClusterProfile; clusterProfile != "" {
+			profileDetails, err := clusterProfileResolver(string(clusterProfile))
+			if err != nil {
+				return nil, fmt.Errorf("resolve cluster profile %q: %w", string(clusterProfile), err)
+			}
+
 			p.WithLabel(cioperatorapi.CloudClusterProfileLabel, string(clusterProfile))
-			p.WithLabel(cioperatorapi.CloudLabel, clusterProfile.ClusterType())
+			p.WithLabel(cioperatorapi.CloudLabel, profileDetails.ClusterType)
 		}
 		if configSpec.Releases != nil {
 			p.PodSpec.Add(CIPullSecret())
@@ -198,7 +208,7 @@ func NewProwJobBaseBuilderForTest(configSpec *cioperatorapi.ReleaseBuildConfigur
 			)
 		}
 	}
-	return p
+	return p, nil
 }
 
 // PathAlias sets UtilityConfig.PathAlias to the given value, including an empty

--- a/pkg/prowgen/jobbase_test.go
+++ b/pkg/prowgen/jobbase_test.go
@@ -1,6 +1,7 @@
 package prowgen
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -8,6 +9,7 @@ import (
 	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 	v1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 
+	"github.com/openshift/ci-tools/pkg/api"
 	ciop "github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
@@ -267,6 +269,13 @@ func TestGenerateJobBase(t *testing.T) {
 }
 
 func TestNewProwJobBaseBuilderForTest(t *testing.T) {
+	clusterProfileResolver := func(name string) (*api.ClusterProfileDetails, error) {
+		if name == "alibabacloud" {
+			return &api.ClusterProfileDetails{ClusterType: "alibabacloud"}, nil
+		}
+		return nil, fmt.Errorf("cluster profile %q not found", name)
+	}
+
 	ciopconfig := &ciop.ReleaseBuildConfiguration{}
 	defaultInfo := &ciop.Metadata{Org: "o", Repo: "r", Branch: "b"}
 	testCases := []struct {
@@ -466,8 +475,12 @@ func TestNewProwJobBaseBuilderForTest(t *testing.T) {
 			if tc.cfg == nil {
 				tc.cfg = ciopconfig
 			}
-			b := NewProwJobBaseBuilderForTest(tc.cfg, tc.info, NewCiOperatorPodSpecGenerator(), tc.test).Build("prefix")
-			testhelper.CompareWithFixture(t, b)
+			b, err := NewProwJobBaseBuilderForTest(tc.cfg, tc.info, NewCiOperatorPodSpecGenerator(), tc.test, clusterProfileResolver)
+			if err != nil {
+				t.Fatalf("failed to create the prowjob builder: %s", err)
+			}
+			prowjob := b.Build("prefix")
+			testhelper.CompareWithFixture(t, prowjob)
 		})
 	}
 }

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -31,7 +31,7 @@ const (
 // new jobs are generated with GenerateJobs, the call site should also use
 // Prune() function to remove all stale jobs and label the jobs as simply
 // "generated".
-func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *cioperatorapi.Metadata) (*prowconfig.JobConfig, error) {
+func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *cioperatorapi.Metadata, clusterProfileResolver ClusterProfileResolver) (*prowconfig.JobConfig, error) {
 	orgrepo := fmt.Sprintf("%s/%s", info.Org, info.Repo)
 	presubmits := map[string][]prowconfig.Presubmit{}
 	postsubmits := map[string][]prowconfig.Postsubmit{}
@@ -46,7 +46,11 @@ func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *cio
 
 		// Most of the time, this loop will only run once. the exception is if shard_count is set to an integer greater than 1
 		for i := 1; i <= shardCount; i++ {
-			g := NewProwJobBaseBuilderForTest(configSpec, info, NewCiOperatorPodSpecGenerator(), element)
+			g, err := NewProwJobBaseBuilderForTest(configSpec, info, NewCiOperatorPodSpecGenerator(), element, clusterProfileResolver)
+			if err != nil {
+				return nil, fmt.Errorf("new prowjob builder: %w", err)
+			}
+
 			name := element.As
 			if shardCount > 1 {
 				name = fmt.Sprintf("%s-%dof%d", name, i, shardCount)

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -1,6 +1,7 @@
 package prowgen
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 	"testing"
@@ -35,6 +36,17 @@ func sorted(spec *corev1.PodSpec) {
 	}
 	if canSortArgs {
 		sort.Strings(container.Args)
+	}
+}
+
+func clusterProfileResolverFunc(profiles ...*api.ClusterProfileDetails) func(string) (*api.ClusterProfileDetails, error) {
+	return func(name string) (*api.ClusterProfileDetails, error) {
+		for _, cp := range profiles {
+			if string(cp.Name) == name {
+				return cp, nil
+			}
+		}
+		return nil, fmt.Errorf("cluster profile %q not found", name)
 	}
 }
 
@@ -111,10 +123,15 @@ func TestShouldAlwaysRun(t *testing.T) {
 }
 
 func TestGeneratePresubmitForTest(t *testing.T) {
+	clusterProfileResolver := clusterProfileResolverFunc(&ciop.ClusterProfileDetails{
+		Name:        "aws",
+		ClusterType: "aws",
+	})
+
 	tests := []struct {
 		description string
 
-		test           string
+		test           ciop.TestStepConfiguration
 		repoInfo       *ciop.Metadata
 		jobRelease     string
 		clone          bool
@@ -122,17 +139,27 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 	}{
 		{
 			description: "presubmit for standard test",
-			test:        "testname",
+			test:        ciop.TestStepConfiguration{As: "testname"},
 			repoInfo:    &ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
 		},
 		{
+			description: "presubmit for multistage test",
+			test: ciop.TestStepConfiguration{
+				As: "testname",
+				MultiStageTestConfiguration: &ciop.MultiStageTestConfiguration{
+					ClusterProfile: "aws",
+				},
+			},
+			repoInfo: &ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
+		},
+		{
 			description: "presubmit for a test in a variant config",
-			test:        "testname",
+			test:        ciop.TestStepConfiguration{As: "testname"},
 			repoInfo:    &ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch", Variant: "also"},
 		},
 		{
 			description: "presubmit with always_run false",
-			test:        "testname",
+			test:        ciop.TestStepConfiguration{As: "testname"},
 			repoInfo:    &ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
 			generateOption: func(options *generatePresubmitOptions) {
 				options.defaultDisable = true
@@ -140,7 +167,7 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 		},
 		{
 			description: "presubmit with always_run but run_if_changed set",
-			test:        "testname",
+			test:        ciop.TestStepConfiguration{As: "testname"},
 			repoInfo:    &ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
 			generateOption: func(options *generatePresubmitOptions) {
 				options.defaultDisable = true
@@ -149,7 +176,7 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 		},
 		{
 			description: "presubmit with always_run but pipeline_run_if_changed set",
-			test:        "testname",
+			test:        ciop.TestStepConfiguration{As: "testname"},
 			repoInfo:    &ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
 			generateOption: func(options *generatePresubmitOptions) {
 				options.defaultDisable = true
@@ -158,7 +185,7 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 		},
 		{
 			description: "presubmit with always_run=false and pipeline_run_if_changed",
-			test:        "testname",
+			test:        ciop.TestStepConfiguration{As: "testname"},
 			repoInfo:    &ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
 			generateOption: func(options *generatePresubmitOptions) {
 				options.defaultDisable = false
@@ -167,7 +194,7 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 		},
 		{
 			description: "presubmit with always_run but pipeline_skip_if_only_changed set",
-			test:        "testname",
+			test:        ciop.TestStepConfiguration{As: "testname"},
 			repoInfo:    &ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
 			generateOption: func(options *generatePresubmitOptions) {
 				options.defaultDisable = true
@@ -176,7 +203,7 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 		},
 		{
 			description: "presubmit with always_run=false and pipeline_skip_if_only_changed",
-			test:        "testname",
+			test:        ciop.TestStepConfiguration{As: "testname"},
 			repoInfo:    &ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
 			generateOption: func(options *generatePresubmitOptions) {
 				options.defaultDisable = false
@@ -185,7 +212,7 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 		},
 		{
 			description: "presubmit with always_run but optional true",
-			test:        "testname",
+			test:        ciop.TestStepConfiguration{As: "testname"},
 			repoInfo:    &ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
 			generateOption: func(options *generatePresubmitOptions) {
 				options.defaultDisable = true
@@ -194,7 +221,7 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 		},
 		{
 			description: "presubmit with run_if_changed",
-			test:        "testname",
+			test:        ciop.TestStepConfiguration{As: "testname"},
 			repoInfo:    &ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
 			generateOption: func(options *generatePresubmitOptions) {
 				options.runIfChanged = "^README.md$"
@@ -202,7 +229,7 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 		},
 		{
 			description: "presubmit with skip_if_only_changed",
-			test:        "testname",
+			test:        ciop.TestStepConfiguration{As: "testname"},
 			repoInfo:    &ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
 			generateOption: func(options *generatePresubmitOptions) {
 				options.skipIfOnlyChanged = "^README.md$"
@@ -210,7 +237,7 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 		},
 		{
 			description: "optional presubmit",
-			test:        "testname",
+			test:        ciop.TestStepConfiguration{As: "testname"},
 			repoInfo:    &ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
 			generateOption: func(options *generatePresubmitOptions) {
 				options.optional = true
@@ -218,7 +245,7 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 		},
 		{
 			description: "rehearsal disabled",
-			test:        "testname",
+			test:        ciop.TestStepConfiguration{As: "testname"},
 			repoInfo:    &ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
 			generateOption: func(options *generatePresubmitOptions) {
 				options.disableRehearsal = true
@@ -226,7 +253,7 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 		},
 		{
 			description: "capabilities added",
-			test:        "testname",
+			test:        ciop.TestStepConfiguration{As: "testname"},
 			repoInfo:    &ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
 			generateOption: func(options *generatePresubmitOptions) {
 				options.Capabilities = []string{"intranet", "arm64", "rce", "sshd-bastion"} // rce - release-controller-eligible, sshd-bastion - for multiarch P/Z libvirt jobs
@@ -234,7 +261,7 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 		},
 		{
 			description: "presubmit with max_concurrency",
-			test:        "testname",
+			test:        ciop.TestStepConfiguration{As: "testname"},
 			repoInfo:    &ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
 			generateOption: func(options *generatePresubmitOptions) {
 				options.maxConcurrency = 4
@@ -242,7 +269,7 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 		},
 		{
 			description: "presubmit with skip_branches",
-			test:        "testname",
+			test:        ciop.TestStepConfiguration{As: "testname"},
 			repoInfo:    &ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
 			generateOption: func(options *generatePresubmitOptions) {
 				options.skipBranches = []string{"^branch-foo$", "^branch-bar$"}
@@ -255,18 +282,25 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 			if generateOption == nil {
 				generateOption = func(options *generatePresubmitOptions) {}
 			}
-			test := ciop.TestStepConfiguration{As: tc.test}
-			jobBaseGen := NewProwJobBaseBuilderForTest(&ciop.ReleaseBuildConfiguration{}, tc.repoInfo, newFakePodSpecBuilder(), test)
-			testhelper.CompareWithFixture(t, generatePresubmitForTest(jobBaseGen, tc.test, tc.repoInfo, generateOption))
+			jobBaseGen, err := NewProwJobBaseBuilderForTest(&ciop.ReleaseBuildConfiguration{}, tc.repoInfo, newFakePodSpecBuilder(), tc.test, clusterProfileResolver)
+			if err != nil {
+				t.Fatalf("failed to create the prowjob builder: %s", err)
+			}
+			testhelper.CompareWithFixture(t, generatePresubmitForTest(jobBaseGen, tc.test.As, tc.repoInfo, generateOption))
 		})
 	}
 }
 
 func TestGeneratePeriodicForTest(t *testing.T) {
+	clusterProfileResolver := clusterProfileResolverFunc(&ciop.ClusterProfileDetails{
+		Name:        "aws",
+		ClusterType: "aws",
+	})
+
 	tests := []struct {
 		description string
 
-		test           string
+		test           ciop.TestStepConfiguration
 		repoInfo       *ciop.Metadata
 		jobRelease     string
 		clone          bool
@@ -274,15 +308,28 @@ func TestGeneratePeriodicForTest(t *testing.T) {
 	}{
 		{
 			description: "periodic for standard test",
-			test:        "testname",
+			test:        ciop.TestStepConfiguration{As: "testname"},
 			repoInfo:    &ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
 			generateOption: func(options *GeneratePeriodicOptions) {
 				options.Cron = "@yearly"
 			},
 		},
 		{
+			description: "periodic for multistage test",
+			test: ciop.TestStepConfiguration{
+				As: "testname",
+				MultiStageTestConfiguration: &ciop.MultiStageTestConfiguration{
+					ClusterProfile: "aws",
+				},
+			},
+			repoInfo: &ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
+			generateOption: func(options *GeneratePeriodicOptions) {
+				options.Cron = "@yearly"
+			},
+		},
+		{
 			description: "periodic for a test with retry",
-			test:        "testname",
+			test:        ciop.TestStepConfiguration{As: "testname"},
 			repoInfo:    &ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
 			generateOption: func(options *GeneratePeriodicOptions) {
 				options.Cron = "@yearly"
@@ -291,7 +338,7 @@ func TestGeneratePeriodicForTest(t *testing.T) {
 		},
 		{
 			description: "periodic for a test in a variant config",
-			test:        "testname",
+			test:        ciop.TestStepConfiguration{As: "testname"},
 			repoInfo:    &ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch", Variant: "also"},
 			generateOption: func(options *GeneratePeriodicOptions) {
 				options.Cron = "@yearly"
@@ -299,7 +346,7 @@ func TestGeneratePeriodicForTest(t *testing.T) {
 		},
 		{
 			description: "periodic using interval",
-			test:        "testname",
+			test:        ciop.TestStepConfiguration{As: "testname"},
 			repoInfo:    &ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
 			generateOption: func(options *GeneratePeriodicOptions) {
 				options.Interval = "6h"
@@ -307,7 +354,7 @@ func TestGeneratePeriodicForTest(t *testing.T) {
 		},
 		{
 			description: "periodic with disabled rehearsal",
-			test:        "testname",
+			test:        ciop.TestStepConfiguration{As: "testname"},
 			repoInfo:    &ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
 			generateOption: func(options *GeneratePeriodicOptions) {
 				options.DisableRehearsal = true
@@ -316,7 +363,7 @@ func TestGeneratePeriodicForTest(t *testing.T) {
 		},
 		{
 			description: "periodic using minimum_interval",
-			test:        "testname",
+			test:        ciop.TestStepConfiguration{As: "testname"},
 			repoInfo:    &ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
 			generateOption: func(options *GeneratePeriodicOptions) {
 				options.MinimumInterval = "4h"
@@ -324,7 +371,7 @@ func TestGeneratePeriodicForTest(t *testing.T) {
 		},
 		{
 			description: "periodic with capabilities",
-			test:        "testname",
+			test:        ciop.TestStepConfiguration{As: "testname"},
 			repoInfo:    &ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
 			generateOption: func(options *GeneratePeriodicOptions) {
 				options.Cron = "@yearly"
@@ -333,7 +380,7 @@ func TestGeneratePeriodicForTest(t *testing.T) {
 		},
 		{
 			description: "periodic with max_concurrency",
-			test:        "testname",
+			test:        ciop.TestStepConfiguration{As: "testname"},
 			repoInfo:    &ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
 			generateOption: func(options *GeneratePeriodicOptions) {
 				options.Cron = "@yearly"
@@ -347,8 +394,11 @@ func TestGeneratePeriodicForTest(t *testing.T) {
 			if generateOption == nil {
 				generateOption = func(options *GeneratePeriodicOptions) {}
 			}
-			test := ciop.TestStepConfiguration{As: tc.test}
-			jobBaseGen := NewProwJobBaseBuilderForTest(&ciop.ReleaseBuildConfiguration{}, tc.repoInfo, newFakePodSpecBuilder(), test)
+			jobBaseGen, err := NewProwJobBaseBuilderForTest(&ciop.ReleaseBuildConfiguration{},
+				tc.repoInfo, newFakePodSpecBuilder(), tc.test, clusterProfileResolver)
+			if err != nil {
+				t.Fatalf("failed to create the prowjob builder: %s", err)
+			}
 			testhelper.CompareWithFixture(t, GeneratePeriodicForTest(jobBaseGen, tc.repoInfo, generateOption))
 		})
 	}
@@ -419,7 +469,12 @@ func TestGeneratePostSubmitForTest(t *testing.T) {
 				generateOption = func(options *generatePostsubmitOptions) {}
 			}
 			test := ciop.TestStepConfiguration{As: testname}
-			jobBaseGen := NewProwJobBaseBuilderForTest(&ciop.ReleaseBuildConfiguration{}, tc.repoInfo, newFakePodSpecBuilder(), test)
+			jobBaseGen, err := NewProwJobBaseBuilderForTest(&ciop.ReleaseBuildConfiguration{}, tc.repoInfo,
+				newFakePodSpecBuilder(), test, func(clusterProfile string) (*ciop.ClusterProfileDetails, error) { return nil, nil })
+			if err != nil {
+				t.Fatalf("failed to create the prowjob builder: %s", err)
+			}
+
 			testhelper.CompareWithFixture(t, generatePostsubmitForTest(jobBaseGen, tc.repoInfo, generateOption))
 		})
 	}
@@ -960,7 +1015,9 @@ func TestGenerateJobs(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.id, func(t *testing.T) {
-			jobConfig, err := GenerateJobs(tc.config, tc.repoInfo)
+			jobConfig, err := GenerateJobs(tc.config, tc.repoInfo, func(clusterProfile string) (*ciop.ClusterProfileDetails, error) {
+				return nil, nil
+			})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -1079,7 +1136,9 @@ func TestBundleWithCapabilities(t *testing.T) {
 				Branch: "main",
 			}
 
-			jobConfig, err := GenerateJobs(config, repoInfo)
+			jobConfig, err := GenerateJobs(config, repoInfo, func(clusterProfile string) (*ciop.ClusterProfileDetails, error) {
+				return nil, nil
+			})
 			if err != nil {
 				t.Fatalf("unexpected error generating jobs: %v", err)
 			}

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_for_multistage_test.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_for_multistage_test.yaml
@@ -1,0 +1,14 @@
+agent: kubernetes
+cron: '@yearly'
+decorate: true
+decoration_config:
+  skip_cloning: true
+extra_refs:
+- base_ref: branch
+  org: org
+  repo: repo
+labels:
+  ci-operator.openshift.io/cloud: aws
+  ci-operator.openshift.io/cloud-cluster-profile: aws
+  pj-rehearse.openshift.io/can-be-rehearsed: "true"
+name: periodic-ci-org-repo-branch-testname

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_for_multistage_test.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_for_multistage_test.yaml
@@ -1,0 +1,16 @@
+agent: kubernetes
+always_run: true
+branches:
+- ^branch$
+- ^branch-
+context: ci/prow/testname
+decorate: true
+decoration_config:
+  skip_cloning: true
+labels:
+  ci-operator.openshift.io/cloud: aws
+  ci-operator.openshift.io/cloud-cluster-profile: aws
+  pj-rehearse.openshift.io/can-be-rehearsed: "true"
+name: pull-ci-org-repo-branch-testname
+rerun_command: /test testname
+trigger: (?m)^/test( | .* )testname,?($|\s.*)

--- a/pkg/registry/resolver.go
+++ b/pkg/registry/resolver.go
@@ -14,6 +14,7 @@ type Resolver interface {
 	Resolve(name string, config api.MultiStageTestConfiguration) (api.MultiStageTestConfigurationLiteral, error)
 	ResolveWorkflow(name string) (api.MultiStageTestConfigurationLiteral, error)
 	ResolveChain(name string) (api.RegistryChain, error)
+	ResolveClusterProfile(name string) (api.ClusterProfileDetails, error)
 }
 
 type ReferenceByName map[string]api.LiteralTestStep
@@ -205,6 +206,14 @@ func (r *registry) ResolveChain(name string) (api.RegistryChain, error) {
 		ret.Steps = append(ret.Steps, api.TestStep{LiteralTestStep: &unique})
 	}
 	return ret, nil
+}
+
+func (r *registry) ResolveClusterProfile(name string) (api.ClusterProfileDetails, error) {
+	cp, ok := r.clusterProfiles[api.ClusterProfile(name)]
+	if !ok {
+		return api.ClusterProfileDetails{}, fmt.Errorf("no cluster profile named %s", name)
+	}
+	return cp, nil
 }
 
 // mergeEnvironments joins two environment maps.

--- a/pkg/registry/server/server.go
+++ b/pkg/registry/server/server.go
@@ -514,7 +514,7 @@ func ResolveClusterProfile(agent agents.RegistryAgent, resolverMetrics *metrics.
 			logrus.WithError(err).Warning("failed to read query from request")
 			return
 		}
-		profileDetails, err := agent.GetClusterProfileDetails(profileNameFromQuery)
+		profileDetails, err := agent.ResolveClusterProfile(profileNameFromQuery)
 		if err != nil {
 			metrics.RecordError("cluster profile not found", resolverMetrics.ErrorRate)
 			w.WriteHeader(http.StatusNotFound)


### PR DESCRIPTION
This is part of the ongoing effort to move cluster profiles out of this code base. We are now removing all the `ClusterType()` occurrences from the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR removes the last cluster-type-by-`ClusterType()` derivation from ci-operator’s prow job generation path and switches it to resolving full cluster profile details (including the cluster/lease type) through resolver callbacks.

Practically, prow job generation now requires cluster profile resolution to succeed up front: ephemeral cluster reconciliation, PRPQR job creation, and multi-PR prow job generation all pass a cluster-profile resolver into the job base builder, and when the requested profile can’t be found they now return explicit resolution errors instead of operating on empty/implicit values. The release profile printing path is also adjusted to stop populating `cluster_type` from the old field.

To support this, the cluster-profile APIs were updated across the codebase:
- The registry/Resolver layer now exposes cluster-profile lookup via `ResolveClusterProfile`, and the registry agent uses value-based semantics for the resolved profile details.
- Controllers and generators are updated to use these resolver methods (including wiring an adapted resolver into the ephemeralcluster reconciler).
- The registry agent setup in the controller manager is consolidated so components that need profile lookups can share a single agent instance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->