### PR TITLE
fix(release): promotion tag retry shell exit 0 on success

### DIFF
--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -389,7 +389,8 @@ func tagRetryShell(attempts int, echoLine, tagCmd, backoff string) string {
 	loop := fmt.Sprintf(`for r in {1..%d}; do
 echo %s
 %s
-[[ $? -ne 0 ]] && break`, attempts, echoLine, tagCmd)
+[[ $? -ne 0 ]] && break
+:`, attempts, echoLine, tagCmd)
 	if backoff != "" {
 		return loop + "\n" + backoff + "\ndone"
 	}

--- a/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay.yaml
@@ -44,6 +44,7 @@ data:
     quay-proxy.ci.openshift.org/openshift/ci@sha256:bbb ci/ci-quay:${component}
     EOF
     [[ $? -ne 0 ]] && break
+    :
     done
 metadata:
   creationTimestamp: null

--- a/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay_non_release_namespace.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay_non_release_namespace.yaml
@@ -55,6 +55,7 @@ data:
     quay-proxy.ci.openshift.org/openshift/ci@sha256:bbb ci/ci-quay:sanitize-prow-jobs
     EOF
     [[ $? -ne 0 ]] && break
+    :
     done
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
/cc @hector-vido 

found a bug failing promotion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change fixes Quay promotion retries in the release flow by ensuring the generated shell script exits cleanly after a successful tag attempt instead of falling through and failing the promotion step. The affected release promotion logic now emits an explicit no-op command in the retry loop, and the updated test fixtures reflect the corrected script behavior for both release and non-release namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->