### PR TITLE
Update prowgen and validation to handle GSM secrets in the `secrets` field

### DIFF
--- a/pkg/prowgen/jobbase.go
+++ b/pkg/prowgen/jobbase.go
@@ -163,6 +163,7 @@ func NewProwJobBaseBuilderForTest(configSpec *cioperatorapi.ReleaseBuildConfigur
 	}
 
 	p.PodSpec.Add(Secrets(test.Secret), Secrets(test.Secrets...))
+	p.PodSpec.Add(GSMSecrets(test.Secret), GSMSecrets(test.Secrets...))
 	p.PodSpec.Add(Targets(test.As))
 
 	if test.ClusterClaim != nil {

--- a/pkg/prowgen/jobbase_test.go
+++ b/pkg/prowgen/jobbase_test.go
@@ -377,6 +377,36 @@ func TestNewProwJobBaseBuilderForTest(t *testing.T) {
 			info: defaultInfo,
 		},
 		{
+			name: "container test with GSM bundle secret",
+			test: ciop.TestStepConfiguration{
+				As:                         "simple",
+				Commands:                   "make",
+				ContainerTestConfiguration: &ciop.ContainerTestConfiguration{From: "src"},
+				Secrets:                    []*ciop.Secret{{Bundle: "my-bundle", MountPath: "/path"}},
+			},
+			info: defaultInfo,
+		},
+		{
+			name: "container test with GSM collection group secret",
+			test: ciop.TestStepConfiguration{
+				As:                         "simple",
+				Commands:                   "make",
+				ContainerTestConfiguration: &ciop.ContainerTestConfiguration{From: "src"},
+				Secrets:                    []*ciop.Secret{{Collection: "col", Group: "grp", MountPath: "/path"}},
+			},
+			info: defaultInfo,
+		},
+		{
+			name: "container test with mixed k8s and GSM secrets",
+			test: ciop.TestStepConfiguration{
+				As:                         "simple",
+				Commands:                   "make",
+				ContainerTestConfiguration: &ciop.ContainerTestConfiguration{From: "src"},
+				Secrets:                    []*ciop.Secret{{Name: "k8s-secret", MountPath: "/k8s"}, {Bundle: "bnd", MountPath: "/bnd"}},
+			},
+			info: defaultInfo,
+		},
+		{
 			name: "multi-stage test with CSI enabled via ci-operator config",
 			cfg: &ciop.ReleaseBuildConfiguration{
 				Prowgen: &ciop.ProwgenOverrides{EnableSecretsStoreCSIDriver: true},

--- a/pkg/prowgen/podspec.go
+++ b/pkg/prowgen/podspec.go
@@ -321,13 +321,28 @@ func Arg(name, value string) PodSpecMutator {
 	}
 }
 
-// Secrets exposes the configured secrets via mounted volumes and a `--secret-dir`
-// option passed to ci-operator
+// Secrets exposes the configured K8s secrets via mounted volumes and a `--secret-dir`
+// option passed to ci-operator. GSM-referenced secrets (Collection/Group or Bundle)
+// are skipped — those are handled via GSMSecrets().
 func Secrets(secrets ...*cioperatorapi.Secret) PodSpecMutator {
 	var mutators []PodSpecMutator
 	for i := range secrets {
-		if secrets[i] != nil {
-			mutators = append(mutators, makeSecretAddingMutator(secrets[i].Name))
+		if secrets[i] == nil || secrets[i].IsGSMReference() || secrets[i].IsBundleReference() {
+			continue
+		}
+		mutators = append(mutators, makeSecretAddingMutator(secrets[i].Name))
+	}
+	return aggregateMutator(mutators...)
+}
+
+// GSMSecrets returns a GSMConfig mutator if any of the provided secrets is a
+// GSM reference (Collection/Group or Bundle). Returns a no-op otherwise.
+func GSMSecrets(secrets ...*cioperatorapi.Secret) PodSpecMutator {
+	var mutators []PodSpecMutator
+	for _, s := range secrets {
+		if s != nil && (s.IsGSMReference() || s.IsBundleReference()) {
+			mutators = append(mutators, GSMConfig())
+			break
 		}
 	}
 	return aggregateMutator(mutators...)

--- a/pkg/prowgen/podspec_test.go
+++ b/pkg/prowgen/podspec_test.go
@@ -345,6 +345,18 @@ func TestSecrets(t *testing.T) {
 			name:    "multiple secrets",
 			secrets: []*api.Secret{{Name: "sekret"}, {Name: "another", MountPath: "/with/path"}},
 		},
+		{
+			name:    "gsm collection group secret is skipped",
+			secrets: []*api.Secret{{Collection: "col", Group: "grp", MountPath: "/path"}},
+		},
+		{
+			name:    "gsm bundle secret is skipped",
+			secrets: []*api.Secret{{Bundle: "my-bundle", MountPath: "/path"}},
+		},
+		{
+			name:    "mixed k8s and gsm secrets",
+			secrets: []*api.Secret{{Name: "k8s-secret"}, {Collection: "col", Group: "grp", MountPath: "/gsm"}, {Bundle: "bnd", MountPath: "/bnd"}},
+		},
 	}
 	for _, tc := range tests {
 		tc := tc
@@ -352,6 +364,47 @@ func TestSecrets(t *testing.T) {
 			t.Parallel()
 			g := NewCiOperatorPodSpecGenerator()
 			g.Add(Secrets(tc.secrets...))
+			podspec, err := g.Build()
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			testhelper.CompareWithFixture(t, podspec)
+		})
+	}
+}
+
+func TestGSMSecrets(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		secrets []*api.Secret
+	}{
+		{
+			name: "no secrets is a nop",
+		},
+		{
+			name:    "k8s secrets only is a nop",
+			secrets: []*api.Secret{{Name: "k8s-secret"}},
+		},
+		{
+			name:    "collection group secret adds gsm config",
+			secrets: []*api.Secret{{Collection: "col", Group: "grp", MountPath: "/path"}},
+		},
+		{
+			name:    "bundle secret adds gsm config",
+			secrets: []*api.Secret{{Bundle: "my-bundle", MountPath: "/path"}},
+		},
+		{
+			name:    "mixed secrets adds gsm config",
+			secrets: []*api.Secret{{Name: "k8s-secret"}, {Bundle: "my-bundle", MountPath: "/path"}},
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewCiOperatorPodSpecGenerator()
+			g.Add(GSMSecrets(tc.secrets...))
 			podspec, err := g.Build()
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)

--- a/pkg/prowgen/testdata/zz_fixture_TestGSMSecrets_bundle_secret_adds_gsm_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGSMSecrets_bundle_secret_adds_gsm_config.yaml
@@ -1,0 +1,56 @@
+containers:
+- args:
+  - --enable-secrets-store-csi-driver=true
+  - --gcs-upload-secret=/secrets/gcs/service-account.json
+  - --gsm-config=/etc/gsm-config/gsm-config.yaml
+  - --gsm-credentials-file=/etc/gsm-credentials/key.json
+  - --gsm-project-config=/etc/gsm-config/gsm-project-config.yaml
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --report-credentials-file=/etc/report/credentials
+  command:
+  - ci-operator
+  image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+  imagePullPolicy: Always
+  name: ""
+  resources:
+    requests:
+      cpu: 10m
+  volumeMounts:
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
+  - mountPath: /etc/gsm-config
+    name: gsm-config
+    readOnly: true
+  - mountPath: /etc/gsm-credentials
+    name: gsm-sa-key
+    readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
+    readOnly: true
+serviceAccountName: ci-operator
+volumes:
+- configMap:
+    name: gsm-config
+  name: gsm-config
+- csi:
+    driver: secrets-store.csi.k8s.io
+    readOnly: true
+    volumeAttributes:
+      secretProviderClass: ci-operator-sa-key-spc
+  name: gsm-sa-key
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
+- name: pull-secret
+  secret:
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGSMSecrets_collection_group_secret_adds_gsm_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGSMSecrets_collection_group_secret_adds_gsm_config.yaml
@@ -1,0 +1,56 @@
+containers:
+- args:
+  - --enable-secrets-store-csi-driver=true
+  - --gcs-upload-secret=/secrets/gcs/service-account.json
+  - --gsm-config=/etc/gsm-config/gsm-config.yaml
+  - --gsm-credentials-file=/etc/gsm-credentials/key.json
+  - --gsm-project-config=/etc/gsm-config/gsm-project-config.yaml
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --report-credentials-file=/etc/report/credentials
+  command:
+  - ci-operator
+  image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+  imagePullPolicy: Always
+  name: ""
+  resources:
+    requests:
+      cpu: 10m
+  volumeMounts:
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
+  - mountPath: /etc/gsm-config
+    name: gsm-config
+    readOnly: true
+  - mountPath: /etc/gsm-credentials
+    name: gsm-sa-key
+    readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
+    readOnly: true
+serviceAccountName: ci-operator
+volumes:
+- configMap:
+    name: gsm-config
+  name: gsm-config
+- csi:
+    driver: secrets-store.csi.k8s.io
+    readOnly: true
+    volumeAttributes:
+      secretProviderClass: ci-operator-sa-key-spc
+  name: gsm-sa-key
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
+- name: pull-secret
+  secret:
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGSMSecrets_k8s_secrets_only_is_a_nop.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGSMSecrets_k8s_secrets_only_is_a_nop.yaml
@@ -1,0 +1,37 @@
+containers:
+- args:
+  - --gcs-upload-secret=/secrets/gcs/service-account.json
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --report-credentials-file=/etc/report/credentials
+  command:
+  - ci-operator
+  image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+  imagePullPolicy: Always
+  name: ""
+  resources:
+    requests:
+      cpu: 10m
+  volumeMounts:
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
+    readOnly: true
+serviceAccountName: ci-operator
+volumes:
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
+- name: pull-secret
+  secret:
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGSMSecrets_mixed_secrets_adds_gsm_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGSMSecrets_mixed_secrets_adds_gsm_config.yaml
@@ -1,0 +1,56 @@
+containers:
+- args:
+  - --enable-secrets-store-csi-driver=true
+  - --gcs-upload-secret=/secrets/gcs/service-account.json
+  - --gsm-config=/etc/gsm-config/gsm-config.yaml
+  - --gsm-credentials-file=/etc/gsm-credentials/key.json
+  - --gsm-project-config=/etc/gsm-config/gsm-project-config.yaml
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --report-credentials-file=/etc/report/credentials
+  command:
+  - ci-operator
+  image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+  imagePullPolicy: Always
+  name: ""
+  resources:
+    requests:
+      cpu: 10m
+  volumeMounts:
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
+  - mountPath: /etc/gsm-config
+    name: gsm-config
+    readOnly: true
+  - mountPath: /etc/gsm-credentials
+    name: gsm-sa-key
+    readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
+    readOnly: true
+serviceAccountName: ci-operator
+volumes:
+- configMap:
+    name: gsm-config
+  name: gsm-config
+- csi:
+    driver: secrets-store.csi.k8s.io
+    readOnly: true
+    volumeAttributes:
+      secretProviderClass: ci-operator-sa-key-spc
+  name: gsm-sa-key
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
+- name: pull-secret
+  secret:
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGSMSecrets_no_secrets_is_a_nop.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGSMSecrets_no_secrets_is_a_nop.yaml
@@ -1,0 +1,37 @@
+containers:
+- args:
+  - --gcs-upload-secret=/secrets/gcs/service-account.json
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --report-credentials-file=/etc/report/credentials
+  command:
+  - ci-operator
+  image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+  imagePullPolicy: Always
+  name: ""
+  resources:
+    requests:
+      cpu: 10m
+  volumeMounts:
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
+    readOnly: true
+serviceAccountName: ci-operator
+volumes:
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
+- name: pull-secret
+  secret:
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_container_test_with_GSM_bundle_secret.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_container_test_with_GSM_bundle_secret.yaml
@@ -1,0 +1,71 @@
+agent: kubernetes
+decorate: true
+decoration_config:
+  skip_cloning: true
+name: prefix-ci-o-r-b-simple
+spec:
+  containers:
+  - args:
+    - --enable-secrets-store-csi-driver=true
+    - --gcs-upload-secret=/secrets/gcs/service-account.json
+    - --gsm-config=/etc/gsm-config/gsm-config.yaml
+    - --gsm-credentials-file=/etc/gsm-credentials/key.json
+    - --gsm-project-config=/etc/gsm-config/gsm-project-config.yaml
+    - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+    - --report-credentials-file=/etc/report/credentials
+    - --target=simple
+    command:
+    - ci-operator
+    env:
+    - name: HTTP_SERVER_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+    imagePullPolicy: Always
+    name: ""
+    ports:
+    - containerPort: 8080
+      name: http
+    resources:
+      requests:
+        cpu: 10m
+    volumeMounts:
+    - mountPath: /secrets/gcs
+      name: gcs-credentials
+      readOnly: true
+    - mountPath: /etc/gsm-config
+      name: gsm-config
+      readOnly: true
+    - mountPath: /etc/gsm-credentials
+      name: gsm-sa-key
+      readOnly: true
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
+    - mountPath: /etc/pull-secret
+      name: pull-secret
+      readOnly: true
+    - mountPath: /etc/report
+      name: result-aggregator
+      readOnly: true
+  serviceAccountName: ci-operator
+  volumes:
+  - configMap:
+      name: gsm-config
+    name: gsm-config
+  - csi:
+      driver: secrets-store.csi.k8s.io
+      readOnly: true
+      volumeAttributes:
+        secretProviderClass: ci-operator-sa-key-spc
+    name: gsm-sa-key
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
+  - name: pull-secret
+    secret:
+      secretName: registry-pull-credentials
+  - name: result-aggregator
+    secret:
+      secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_container_test_with_GSM_collection_group_secret.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_container_test_with_GSM_collection_group_secret.yaml
@@ -1,0 +1,71 @@
+agent: kubernetes
+decorate: true
+decoration_config:
+  skip_cloning: true
+name: prefix-ci-o-r-b-simple
+spec:
+  containers:
+  - args:
+    - --enable-secrets-store-csi-driver=true
+    - --gcs-upload-secret=/secrets/gcs/service-account.json
+    - --gsm-config=/etc/gsm-config/gsm-config.yaml
+    - --gsm-credentials-file=/etc/gsm-credentials/key.json
+    - --gsm-project-config=/etc/gsm-config/gsm-project-config.yaml
+    - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+    - --report-credentials-file=/etc/report/credentials
+    - --target=simple
+    command:
+    - ci-operator
+    env:
+    - name: HTTP_SERVER_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+    imagePullPolicy: Always
+    name: ""
+    ports:
+    - containerPort: 8080
+      name: http
+    resources:
+      requests:
+        cpu: 10m
+    volumeMounts:
+    - mountPath: /secrets/gcs
+      name: gcs-credentials
+      readOnly: true
+    - mountPath: /etc/gsm-config
+      name: gsm-config
+      readOnly: true
+    - mountPath: /etc/gsm-credentials
+      name: gsm-sa-key
+      readOnly: true
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
+    - mountPath: /etc/pull-secret
+      name: pull-secret
+      readOnly: true
+    - mountPath: /etc/report
+      name: result-aggregator
+      readOnly: true
+  serviceAccountName: ci-operator
+  volumes:
+  - configMap:
+      name: gsm-config
+    name: gsm-config
+  - csi:
+      driver: secrets-store.csi.k8s.io
+      readOnly: true
+      volumeAttributes:
+        secretProviderClass: ci-operator-sa-key-spc
+    name: gsm-sa-key
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
+  - name: pull-secret
+    secret:
+      secretName: registry-pull-credentials
+  - name: result-aggregator
+    secret:
+      secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_container_test_with_mixed_k8s_and_GSM_secrets.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_container_test_with_mixed_k8s_and_GSM_secrets.yaml
@@ -1,0 +1,78 @@
+agent: kubernetes
+decorate: true
+decoration_config:
+  skip_cloning: true
+name: prefix-ci-o-r-b-simple
+spec:
+  containers:
+  - args:
+    - --enable-secrets-store-csi-driver=true
+    - --gcs-upload-secret=/secrets/gcs/service-account.json
+    - --gsm-config=/etc/gsm-config/gsm-config.yaml
+    - --gsm-credentials-file=/etc/gsm-credentials/key.json
+    - --gsm-project-config=/etc/gsm-config/gsm-project-config.yaml
+    - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+    - --report-credentials-file=/etc/report/credentials
+    - --secret-dir=/secrets/k8s-secret
+    - --target=simple
+    command:
+    - ci-operator
+    env:
+    - name: HTTP_SERVER_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+    imagePullPolicy: Always
+    name: ""
+    ports:
+    - containerPort: 8080
+      name: http
+    resources:
+      requests:
+        cpu: 10m
+    volumeMounts:
+    - mountPath: /secrets/gcs
+      name: gcs-credentials
+      readOnly: true
+    - mountPath: /etc/gsm-config
+      name: gsm-config
+      readOnly: true
+    - mountPath: /etc/gsm-credentials
+      name: gsm-sa-key
+      readOnly: true
+    - mountPath: /secrets/k8s-secret
+      name: k8s-secret
+      readOnly: true
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
+    - mountPath: /etc/pull-secret
+      name: pull-secret
+      readOnly: true
+    - mountPath: /etc/report
+      name: result-aggregator
+      readOnly: true
+  serviceAccountName: ci-operator
+  volumes:
+  - configMap:
+      name: gsm-config
+    name: gsm-config
+  - csi:
+      driver: secrets-store.csi.k8s.io
+      readOnly: true
+      volumeAttributes:
+        secretProviderClass: ci-operator-sa-key-spc
+    name: gsm-sa-key
+  - name: k8s-secret
+    secret:
+      secretName: k8s-secret
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
+  - name: pull-secret
+    secret:
+      secretName: registry-pull-credentials
+  - name: result-aggregator
+    secret:
+      secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestSecrets_gsm_bundle_secret_is_skipped.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestSecrets_gsm_bundle_secret_is_skipped.yaml
@@ -1,0 +1,37 @@
+containers:
+- args:
+  - --gcs-upload-secret=/secrets/gcs/service-account.json
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --report-credentials-file=/etc/report/credentials
+  command:
+  - ci-operator
+  image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+  imagePullPolicy: Always
+  name: ""
+  resources:
+    requests:
+      cpu: 10m
+  volumeMounts:
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
+    readOnly: true
+serviceAccountName: ci-operator
+volumes:
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
+- name: pull-secret
+  secret:
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestSecrets_gsm_collection_group_secret_is_skipped.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestSecrets_gsm_collection_group_secret_is_skipped.yaml
@@ -1,0 +1,37 @@
+containers:
+- args:
+  - --gcs-upload-secret=/secrets/gcs/service-account.json
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --report-credentials-file=/etc/report/credentials
+  command:
+  - ci-operator
+  image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+  imagePullPolicy: Always
+  name: ""
+  resources:
+    requests:
+      cpu: 10m
+  volumeMounts:
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
+    readOnly: true
+serviceAccountName: ci-operator
+volumes:
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
+- name: pull-secret
+  secret:
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestSecrets_mixed_k8s_and_gsm_secrets.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestSecrets_mixed_k8s_and_gsm_secrets.yaml
@@ -1,0 +1,44 @@
+containers:
+- args:
+  - --gcs-upload-secret=/secrets/gcs/service-account.json
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --report-credentials-file=/etc/report/credentials
+  - --secret-dir=/secrets/k8s-secret
+  command:
+  - ci-operator
+  image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+  imagePullPolicy: Always
+  name: ""
+  resources:
+    requests:
+      cpu: 10m
+  volumeMounts:
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
+  - mountPath: /secrets/k8s-secret
+    name: k8s-secret
+    readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
+    readOnly: true
+serviceAccountName: ci-operator
+volumes:
+- name: k8s-secret
+  secret:
+    secretName: k8s-secret
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
+- name: pull-secret
+  secret:
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator

--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -248,22 +248,52 @@ func (v *Validator) validateTestStepConfiguration(
 			validationErrors = append(validationErrors, fmt.Errorf("%s: secret/secrets can be only used with container-based tests (use credentials in multi-stage tests)", fieldRootN))
 		}
 
-		seen := sets.New[string]()
-		for _, secret := range test.Secrets {
-			// K8s object names must be valid DNS 1123 subdomains.
-			if len(validation.IsDNS1123Subdomain(secret.Name)) != 0 {
-				validationErrors = append(validationErrors, fmt.Errorf("%s.name: '%s' is not a valid Kubernetes object name", fieldRootN, secret.Name))
+		seenNames := sets.New[string]()
+		seenBundles := sets.New[string]()
+		type collectionGroup struct{ collection, group string }
+		seenCollectionGroups := sets.New[collectionGroup]()
+		for i, secret := range test.Secrets {
+			isGSM := secret.IsGSMReference() || secret.IsBundleReference()
+			hasGSMFields := secret.Collection != "" || secret.Group != "" || secret.Bundle != ""
+			if isGSM || hasGSMFields {
+				if secret.Name != "" {
+					validationErrors = append(validationErrors, fmt.Errorf("%s.secrets[%d]: `name` cannot be used with `bundle`, `collection`, or `group`", fieldRootN, i))
+				}
+				if secret.IsBundleReference() {
+					if secret.Collection != "" || secret.Group != "" {
+						validationErrors = append(validationErrors, fmt.Errorf("%s.secrets[%d]: `bundle` cannot be used with `collection` or `group`", fieldRootN, i))
+					}
+					if seenBundles.Has(secret.Bundle) {
+						validationErrors = append(validationErrors, fmt.Errorf("%s.secrets[%d]: duplicate bundle reference %q", fieldRootN, i, secret.Bundle))
+					}
+					seenBundles.Insert(secret.Bundle)
+				} else if secret.IsGSMReference() {
+					key := collectionGroup{secret.Collection, secret.Group}
+					if seenCollectionGroups.Has(key) {
+						validationErrors = append(validationErrors, fmt.Errorf("%s.secrets[%d]: duplicate collection/group reference %s/%s", fieldRootN, i, secret.Collection, secret.Group))
+					}
+					seenCollectionGroups.Insert(key)
+				} else if secret.Collection != "" {
+					validationErrors = append(validationErrors, fmt.Errorf("%s.secrets[%d].group: is required when `collection` is set", fieldRootN, i))
+				} else if secret.Group != "" {
+					validationErrors = append(validationErrors, fmt.Errorf("%s.secrets[%d].collection: is required when `group` is set", fieldRootN, i))
+				} else {
+					validationErrors = append(validationErrors, fmt.Errorf("%s.secrets[%d]: must specify `bundle` or `collection`+`group`", fieldRootN, i))
+				}
+			} else {
+				// K8s object names must be valid DNS 1123 subdomains.
+				if len(validation.IsDNS1123Subdomain(secret.Name)) != 0 {
+					validationErrors = append(validationErrors, fmt.Errorf("%s.secrets[%d].name: %q is not a valid Kubernetes object name", fieldRootN, i, secret.Name))
+				}
+				if seenNames.Has(secret.Name) {
+					validationErrors = append(validationErrors, fmt.Errorf("%s.secrets[%d]: duplicate secret name %q", fieldRootN, i, secret.Name))
+				}
+				seenNames.Insert(secret.Name)
 			}
-			// Validate no duplicate secret names, then append to list of names.
-			if seen.Has(secret.Name) {
-				validationErrors = append(validationErrors, fmt.Errorf("duplicate secret name entries found for %s", secret.Name))
-			}
-			seen.Insert(secret.Name)
-
 			// validate path only if name is passed
 			if secret.MountPath != "" {
 				if ok := filepath.IsAbs(secret.MountPath); !ok {
-					validationErrors = append(validationErrors, fmt.Errorf("%s.path: '%s' secret mount path must be an absolute path", fieldRootN, secret.MountPath))
+					validationErrors = append(validationErrors, fmt.Errorf("%s.secrets[%d].mount_path: %q is not an absolute path", fieldRootN, i, secret.MountPath))
 				}
 			}
 		}

--- a/pkg/validation/test_test.go
+++ b/pkg/validation/test_test.go
@@ -232,7 +232,7 @@ func TestValidateTests(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("tests[0].name: 'secret_test' is not a valid Kubernetes object name"),
+			expectedError: errors.New(`tests[0].secrets[0].name: "secret_test" is not a valid Kubernetes object name`),
 		},
 		{
 			id: "invalid secret and secrets both set",
@@ -274,7 +274,7 @@ func TestValidateTests(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("duplicate secret name entries found for secret-test-a"),
+			expectedError: errors.New(`tests[0].secrets[1]: duplicate secret name "secret-test-a"`),
 		},
 		{
 			id: "valid secret",
@@ -349,7 +349,155 @@ func TestValidateTests(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New(`tests[0].path: 'path/to/secret' secret mount path must be an absolute path`),
+			expectedError: errors.New(`tests[0].secrets[0].mount_path: "path/to/secret" is not an absolute path`),
+		},
+		{
+			id: "valid GSM bundle secret",
+			tests: []api.TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
+					Secrets: []*api.Secret{
+						{
+							Bundle:    "my-bundle",
+							MountPath: "/path/to/secret",
+						},
+					},
+				},
+			},
+		},
+		{
+			id: "valid GSM collection group secret",
+			tests: []api.TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
+					Secrets: []*api.Secret{
+						{
+							Collection: "col",
+							Group:      "grp",
+							MountPath:  "/path/to/secret",
+						},
+					},
+				},
+			},
+		},
+		{
+			id: "valid mixed k8s and GSM secrets",
+			tests: []api.TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
+					Secrets: []*api.Secret{
+						{Name: "k8s-secret", MountPath: "/k8s"},
+						{Bundle: "my-bundle", MountPath: "/gsm"},
+						{Collection: "col", Group: "grp", MountPath: "/gsm2"},
+					},
+				},
+			},
+		},
+		{
+			id: "invalid GSM secret with name and bundle",
+			tests: []api.TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
+					Secrets: []*api.Secret{
+						{
+							Name:      "secret",
+							Bundle:    "my-bundle",
+							MountPath: "/path",
+						},
+					},
+				},
+			},
+			expectedError: errors.New(`tests[0].secrets[0]: ` + "`name` cannot be used with `bundle`, `collection`, or `group`"),
+		},
+		{
+			id: "invalid GSM secret with bundle and collection",
+			tests: []api.TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
+					Secrets: []*api.Secret{
+						{
+							Bundle:     "my-bundle",
+							Collection: "col",
+							MountPath:  "/path",
+						},
+					},
+				},
+			},
+			expectedError: errors.New(`tests[0].secrets[0]: ` + "`bundle` cannot be used with `collection` or `group`"),
+		},
+		{
+			id: "invalid GSM secret with collection but no group",
+			tests: []api.TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
+					Secrets: []*api.Secret{
+						{
+							Collection: "col",
+							MountPath:  "/path",
+						},
+					},
+				},
+			},
+			expectedError: errors.New("tests[0].secrets[0].group: is required when `collection` is set"),
+		},
+		{
+			id: "invalid GSM secret with group but no collection",
+			tests: []api.TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
+					Secrets: []*api.Secret{
+						{
+							Group:     "grp",
+							MountPath: "/path",
+						},
+					},
+				},
+			},
+			expectedError: errors.New("tests[0].secrets[0].collection: is required when `group` is set"),
+		},
+		{
+			id: "invalid duplicate bundle secrets",
+			tests: []api.TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
+					Secrets: []*api.Secret{
+						{Bundle: "my-bundle", MountPath: "/path1"},
+						{Bundle: "my-bundle", MountPath: "/path2"},
+					},
+				},
+			},
+			expectedError: errors.New(`tests[0].secrets[1]: duplicate bundle reference "my-bundle"`),
+		},
+		{
+			id: "invalid duplicate collection group secrets",
+			tests: []api.TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
+					Secrets: []*api.Secret{
+						{Collection: "col", Group: "grp", MountPath: "/path1"},
+						{Collection: "col", Group: "grp", MountPath: "/path2"},
+					},
+				},
+			},
+			expectedError: errors.New("tests[0].secrets[1]: duplicate collection/group reference col/grp"),
 		},
 		{
 			id:       "non-literal test is invalid in fully-resolved configuration",


### PR DESCRIPTION
Follow-up after https://github.com/openshift/ci-tools/pull/5274

Update Secrets() to skip GSM-referenced secrets (no K8s volume will be created for that case), and add GSMSecrets() func that injects CSI config when any GSM secret is present (same mechanism as for `credentials` in multi-stage tests).

Before (K8s secret only):
```yaml
  secrets:
  - name: my-secret
    mount_path: /usr/test-secrets
```

  New — bundle reference:
```yaml
  secrets:
  - bundle: my-bundle
    mount_path: /usr/test-secrets
```  

  New — collection/group reference:
 ```yaml
 secrets:
  - collection: my-collection
    group: my-group
    mount_path: /usr/test-secrets
```

  New — mixed (K8s + GSM in one test):
 ```yaml
 secrets:
  - name: k8s-secret
    mount_path: /usr/k8s-secrets
  - bundle: my-bundle
    mount_path: /usr/gsm-secrets
  - collection: my-collection
    group: my-group
    mount_path: /usr/gsm-secrets-2
```

https://redhat.atlassian.net/browse/DPTP-5009

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated prowgen and test-step validation to support GSM-backed entries in the `secrets` field (OpenShift CI job authoring and fixture generation).

For CI job authors, `test.Secrets` can now contain a mix of:
- standard Kubernetes Secret references (`name`, mounted via `--secret-dir`), and
- GSM references using either GSM bundle (`bundle`) or GSM collection/group (`collection` + `group`).

On the prowgen side, the `pkg/prowgen` podspec mutators were updated so that:
- `Secrets(...)` skips GSM/bundle entries (no Kubernetes Secret volumes/mounts are generated for them), while
- the new `GSMSecrets(...)` injects the required Secrets Store CSI / GSM configuration (via `GSMConfig()`) when any GSM/bundle secret is present (added once), enabling the same kind of automatic wiring previously used by multi-stage `credentials`.

Validation was made GSM-aware and type-safe:
- it rejects incompatible field shapes (e.g., `name` with `bundle`/`collection`/`group`, or `bundle` mixed with `collection`/`group`),
- enforces required GSM fields (`bundle` only, or `collection`+`group`),
- performs duplicate detection using the appropriate key (bundle name or collection/group pair for GSM; `secret.name` for Kubernetes secrets),
- and keeps mount path validation as an absolute-path check under `secrets[].mount_path`.

Added/updated tests and fixtures cover GSM bundle, GSM collection-group, mixed Kubernetes+GSM inputs, and the resulting CSI/GSM podspec wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->