### PR TITLE
check-cluster-profiles-config: Workround to handle Cluster Profile Sets

### DIFF
--- a/cmd/check-cluster-profiles-config/main.go
+++ b/cmd/check-cluster-profiles-config/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	coreapi "k8s.io/api/core/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -174,18 +175,29 @@ func (validator *profileValidator) Validate(profiles api.ClusterProfilesList) er
 
 // checkCISecrets verifies that the secret for each cluster profile exists in the ci namespace
 func (validator *profileValidator) checkCISecrets() error {
-	for p := range validator.profiles {
-		profileDetails, err := server.NewResolverClient(configResolverAddress).ClusterProfile(p)
-		if err != nil {
-			return fmt.Errorf("failed to retrieve details from config resolver for '%s' cluster profile: %w", p, err)
+	// FIXME: temporary workaround, we should read this information from a config file.
+	clusterProfileSets := sets.New("openshift-org-aws", "openshift-org-azure", "openshift-org-gcp")
+	errs := make([]error, 0)
+
+	for profileName := range validator.profiles {
+		if clusterProfileSets.Has(profileName) {
+			continue
 		}
+
+		profileDetails, err := server.NewResolverClient(configResolverAddress).ClusterProfile(profileName)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to retrieve details from config resolver for '%s' cluster profile: %w", profileName, err))
+			continue
+		}
+
 		ciSecret := &coreapi.Secret{}
 		err = validator.kubeClient.Get(context.Background(), ctrlruntimeclient.ObjectKey{Namespace: "ci", Name: profileDetails.Secret}, ciSecret)
 		if err != nil {
-			return fmt.Errorf("failed to get secret '%s' for cluster profile '%s': %w", profileDetails.Secret, p, err)
+			errs = append(errs, fmt.Errorf("failed to get secret '%s' for cluster profile '%s': %w", profileDetails.Secret, profileName, err))
 		}
 	}
-	return nil
+
+	return utilerrors.NewAggregate(errs)
 }
 
 func normalize(profiles api.ClusterProfilesList) {


### PR DESCRIPTION
Cluster Profile Sets are special, they don't have a secret associated with them. This PR introduces a workaround to skip that check in case of cluster profile sets.
I'll come up with a solid solution once the cluster profile migration is done.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
`check-cluster-profiles-config` (used for CI config validation) now treats Cluster Profile Sets as a special case: it skips secret existence checks for the hardcoded Cluster Profile Set names because they don’t reference a CI secret yet. For all remaining cluster profiles, it attempts to fetch each profile’s details from the config resolver and then verifies the referenced secret exists in the `ci` namespace. Instead of stopping at the first failure, it aggregates all resolver/secret lookup errors and returns them together, serving as a temporary workaround until the cluster profile migration is complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->