### PR TITLE
Add repo brancher failure Slack digest

### DIFF
--- a/cmd/repo-brancher-controller/README.md
+++ b/cmd/repo-brancher-controller/README.md
@@ -26,6 +26,13 @@ readiness are exposed on `--health-port`, and Prometheus metrics on
 client. Transient failures continue at `--retry-exhausted-delay` after the fast
 retry budget is consumed.
 
+If `--slack-token-path` is set, the controller also publishes an active failure
+digest to `--ops-channel-id` every `--slack-report-period`, defaulting to two
+hours. The digest reports the total number of active fast-forward failures and
+shows the five most recently observed entries with compare links. A failure is
+removed from the digest after the matching source-to-target branch forwarding
+succeeds or the target is removed from desired state.
+
 ## Forwarding configuration
 
 The forwarding config separates default branches from release branches:

--- a/cmd/repo-brancher-controller/controller.go
+++ b/cmd/repo-brancher-controller/controller.go
@@ -142,6 +142,7 @@ type refClient interface {
 type controller struct {
 	refs                refClient
 	state               *desiredState
+	issues              *branchIssueStore
 	queue               workqueue.TypedRateLimitingInterface[repoKey]
 	maxRetries          int
 	retryExhaustedDelay time.Duration
@@ -204,8 +205,18 @@ func (c *controller) processNext(ctx context.Context) bool {
 	queueDepth.Set(float64(c.queue.Len()))
 	defer c.queue.Done(key)
 
+	if ctx.Err() != nil {
+		c.queue.Forget(key)
+		return false
+	}
 	if err := c.reconcile(ctx, key); err != nil {
 		logger := logrus.WithField("repo", key.String()).WithError(err)
+		if ctx.Err() != nil {
+			reconciliationTotal.WithLabelValues("shutdown").Inc()
+			logger.Info("reconciliation stopped during shutdown")
+			c.queue.Forget(key)
+			return false
+		}
 		var aggregate *reconciliationErrors
 		if errors.As(err, &aggregate) {
 			if len(aggregate.permanent) > 0 {
@@ -249,6 +260,42 @@ func (c *controller) retry(key repoKey, logger *logrus.Entry) {
 	}
 }
 
+func (c *controller) recordTargetIssue(key repoKey, target, reason, sourceSHA, targetSHA string, err error, permanent bool) {
+	issueKey := branchIssueKey{org: key.org, repo: key.repo, source: key.source, target: target}
+	if c.issues != nil {
+		c.issues.upsert(branchIssue{
+			key:       issueKey,
+			reason:    reason,
+			sourceSHA: sourceSHA,
+			targetSHA: targetSHA,
+			lastError: err.Error(),
+		})
+	}
+	logger := logrus.WithFields(logrus.Fields{
+		"org":                 key.org,
+		"repo":                key.repo,
+		"source_branch":       key.source,
+		"target_branch":       target,
+		"source_sha":          sourceSHA,
+		"target_sha":          targetSHA,
+		"reason":              reason,
+		"github_compare_url":  issueKey.compareURL(),
+		"manual_intervention": permanent,
+	}).WithError(err)
+	if permanent {
+		logger.Error("branch fast-forward requires manual intervention")
+		return
+	}
+	logger.Warn("branch fast-forward failed")
+}
+
+func (c *controller) resolveTargetIssue(key repoKey, target string) {
+	if c.issues == nil {
+		return
+	}
+	c.issues.resolve(branchIssueKey{org: key.org, repo: key.repo, source: key.source, target: target})
+}
+
 func (c *controller) reconcile(ctx context.Context, key repoKey) error {
 	targetSet, configured := c.state.get(key)
 	if !configured {
@@ -268,10 +315,12 @@ func (c *controller) reconcile(ctx context.Context, key repoKey) error {
 	for _, target := range targets {
 		targetSHA, targetExists, err := c.refs.getRef(ctx, key.org, key.repo, target)
 		if err != nil {
+			c.recordTargetIssue(key, target, "get_target_ref_failed", sourceSHA, "", err, false)
 			aggregate.retryable = append(aggregate.retryable, fmt.Errorf("get target %s: %w", target, err))
 			continue
 		}
 		if targetExists && targetSHA == sourceSHA {
+			c.resolveTargetIssue(key, target)
 			continue
 		}
 		performed, err := c.state.ifTargetConfigured(key, target, func() error {
@@ -287,13 +336,24 @@ func (c *controller) reconcile(ctx context.Context, key repoKey) error {
 			wrapped := fmt.Errorf("fast-forward %s: %w", target, err)
 			var permanent permanentError
 			if errors.As(err, &permanent) {
+				reason := "non_fast_forward"
+				if !targetExists {
+					reason = "ref_creation_rejected"
+				}
+				c.recordTargetIssue(key, target, reason, sourceSHA, targetSHA, err, true)
 				aggregate.permanent = append(aggregate.permanent, wrapped)
 			} else {
+				reason := "update_ref_failed"
+				if !targetExists {
+					reason = "create_ref_failed"
+				}
+				c.recordTargetIssue(key, target, reason, sourceSHA, targetSHA, err, false)
 				aggregate.retryable = append(aggregate.retryable, wrapped)
 			}
 			continue
 		}
 		logrus.WithFields(logrus.Fields{"repo": key.org + "/" + key.repo, "source": key.source, "target": target, "sha": sourceSHA}).Info("fast-forwarded branch")
+		c.resolveTargetIssue(key, target)
 	}
 	if len(aggregate.retryable) == 0 && len(aggregate.permanent) == 0 {
 		return nil

--- a/cmd/repo-brancher-controller/controller_test.go
+++ b/cmd/repo-brancher-controller/controller_test.go
@@ -98,6 +98,20 @@ func (f *targetErrorRefClient) updateRef(_ context.Context, _, _, branch, _ stri
 	return errors.New("temporary network failure")
 }
 
+type sourceErrorRefClient struct{ err error }
+
+func (f *sourceErrorRefClient) getRef(_ context.Context, _, _, _ string) (string, bool, error) {
+	return "", false, f.err
+}
+
+func (f *sourceErrorRefClient) createRef(context.Context, string, string, string, string) error {
+	return nil
+}
+
+func (f *sourceErrorRefClient) updateRef(context.Context, string, string, string, string) error {
+	return nil
+}
+
 func TestReconcilePreservesRetryableSiblingError(t *testing.T) {
 	key := repoKey{org: "org", repo: "repo", source: "main"}
 	state := newDesiredState()
@@ -139,6 +153,29 @@ func TestProcessNextReportsPermanentErrorWithRetryableSibling(t *testing.T) {
 	}
 	if got := counterValue(t, "retry"); got != beforeRetry+1 {
 		t.Fatalf("retry metric: want %v, got %v", beforeRetry+1, got)
+	}
+}
+
+func TestProcessNextDoesNotRetryDuringShutdown(t *testing.T) {
+	key := repoKey{org: "org", repo: "repo", source: "main"}
+	state := newDesiredState()
+	state.replace(map[repoKey]sets.Set[string]{key: sets.New("release-5.0")})
+	c := newController(&sourceErrorRefClient{err: context.Canceled}, state, 1)
+	defer c.queue.ShutDown()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c.enqueue(key)
+	cancel()
+	beforeRetry := counterValue(t, "retry")
+	beforeShutdown := counterValue(t, "shutdown")
+	if c.processNext(ctx) {
+		t.Fatal("processNext unexpectedly kept worker running")
+	}
+	if got := counterValue(t, "retry"); got != beforeRetry {
+		t.Fatalf("retry metric: want %v, got %v", beforeRetry, got)
+	}
+	if got := counterValue(t, "shutdown"); got != beforeShutdown {
+		t.Fatalf("shutdown metric: want %v, got %v", beforeShutdown, got)
 	}
 }
 

--- a/cmd/repo-brancher-controller/issues.go
+++ b/cmd/repo-brancher-controller/issues.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/slack-go/slack"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const maxSlackIssues = 5
+
+type branchIssueKey struct {
+	org, repo, source, target string
+}
+
+type branchIssue struct {
+	key       branchIssueKey
+	reason    string
+	sourceSHA string
+	targetSHA string
+	firstSeen time.Time
+	lastSeen  time.Time
+	count     int
+	lastError string
+}
+
+type branchIssueStore struct {
+	mu     sync.RWMutex
+	issues map[branchIssueKey]branchIssue
+	now    func() time.Time
+}
+
+func newBranchIssueStore() *branchIssueStore {
+	return &branchIssueStore{issues: map[branchIssueKey]branchIssue{}, now: time.Now}
+}
+
+func (s *branchIssueStore) upsert(issue branchIssue) {
+	if s == nil {
+		return
+	}
+	now := s.now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if existing, ok := s.issues[issue.key]; ok {
+		issue.firstSeen = existing.firstSeen
+		issue.count = existing.count + 1
+	} else {
+		issue.firstSeen = now
+		issue.count = 1
+	}
+	issue.lastSeen = now
+	s.issues[issue.key] = issue
+}
+
+func (s *branchIssueStore) resolve(key branchIssueKey) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.issues, key)
+}
+
+func (s *branchIssueStore) prune(desired map[repoKey]sets.Set[string]) {
+	if s == nil {
+		return
+	}
+	valid := map[branchIssueKey]struct{}{}
+	for key, targets := range desired {
+		for target := range targets {
+			valid[branchIssueKey{org: key.org, repo: key.repo, source: key.source, target: target}] = struct{}{}
+		}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for key := range s.issues {
+		if _, ok := valid[key]; !ok {
+			delete(s.issues, key)
+		}
+	}
+}
+
+func (s *branchIssueStore) snapshot() []branchIssue {
+	if s == nil {
+		return nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	issues := make([]branchIssue, 0, len(s.issues))
+	for _, issue := range s.issues {
+		issues = append(issues, issue)
+	}
+	sort.Slice(issues, func(i, j int) bool {
+		if issues[i].lastSeen.Equal(issues[j].lastSeen) {
+			return issues[i].key.String() < issues[j].key.String()
+		}
+		return issues[i].lastSeen.After(issues[j].lastSeen)
+	})
+	return issues
+}
+
+func (k branchIssueKey) String() string {
+	return fmt.Sprintf("%s/%s:%s->%s", k.org, k.repo, k.source, k.target)
+}
+
+func (k branchIssueKey) compareURL() string {
+	return fmt.Sprintf("https://github.com/%s/%s/compare/%s...%s", k.org, k.repo, k.target, k.source)
+}
+
+type slackPoster interface {
+	PostMessage(channelID string, options ...slack.MsgOption) (string, string, error)
+}
+
+type slackDigestPublisher struct {
+	client  slackPoster
+	channel string
+	store   *branchIssueStore
+}
+
+func newSlackDigestPublisher(client slackPoster, channel string, store *branchIssueStore) *slackDigestPublisher {
+	return &slackDigestPublisher{client: client, channel: channel, store: store}
+}
+
+func (p *slackDigestPublisher) publish(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return nil
+	default:
+	}
+	issues := p.store.snapshot()
+	if len(issues) == 0 {
+		return nil
+	}
+	blocks := p.blocks(issues)
+	responseChannel, responseTimestamp, err := p.client.PostMessage(
+		p.channel,
+		slack.MsgOptionText(fallbackDigestText(issues), false),
+		slack.MsgOptionBlocks(blocks...),
+		slack.MsgOptionDisableLinkUnfurl(),
+	)
+	if err != nil {
+		return fmt.Errorf("post Slack digest: %w", err)
+	}
+	logrus.WithFields(logrus.Fields{"channel": responseChannel, "timestamp": responseTimestamp, "issues": len(issues)}).Info("posted repo brancher failure digest")
+	return nil
+}
+
+func (p *slackDigestPublisher) blocks(issues []branchIssue) []slack.Block {
+	shown := issues
+	if len(shown) > maxSlackIssues {
+		shown = shown[:maxSlackIssues]
+	}
+	blocks := []slack.Block{
+		slack.NewHeaderBlock(slack.NewTextBlockObject(slack.PlainTextType, "Repo brancher fast-forward failures", false, false)),
+		slack.NewSectionBlock(slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("*%d active failure(s).* Showing the %d most recent.", len(issues), len(shown)), false, false), nil, nil),
+	}
+	for i, issue := range shown {
+		blocks = append(blocks, slack.NewSectionBlock(slack.NewTextBlockObject(slack.MarkdownType, formatIssue(i+1, issue), false, false), nil, nil))
+	}
+	if len(issues) > len(shown) {
+		blocks = append(blocks, slack.NewContextBlock("", slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("Showing %d of %d active failures. Search repo-brancher-controller logs for `branch fast-forward requires manual intervention` for the full list.", len(shown), len(issues)), false, false)))
+	}
+	return blocks
+}
+
+func formatIssue(index int, issue branchIssue) string {
+	lines := []string{
+		fmt.Sprintf("*%d. <%s|%s/%s>*: `%s` -> `%s`", index, issue.key.compareURL(), issue.key.org, issue.key.repo, issue.key.source, issue.key.target),
+		fmt.Sprintf("reason: `%s`; first seen: %s; last seen: %s; attempts: %d", issue.reason, issue.firstSeen.UTC().Format(time.RFC3339), issue.lastSeen.UTC().Format(time.RFC3339), issue.count),
+	}
+	if issue.sourceSHA != "" || issue.targetSHA != "" {
+		lines = append(lines, fmt.Sprintf("source sha: `%s`; target sha: `%s`", shortSHA(issue.sourceSHA), shortSHA(issue.targetSHA)))
+	}
+	if issue.lastError != "" {
+		lines = append(lines, fmt.Sprintf("last error: `%s`", truncate(issue.lastError, 300)))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func fallbackDigestText(issues []branchIssue) string {
+	return fmt.Sprintf("Repo brancher has %d active fast-forward failure(s). Showing the %d most recent in Slack blocks.", len(issues), min(len(issues), maxSlackIssues))
+}
+
+func shortSHA(sha string) string {
+	if len(sha) > 12 {
+		return sha[:12]
+	}
+	return sha
+}
+
+func truncate(value string, limit int) string {
+	value = strings.TrimSpace(value)
+	if len(value) <= limit {
+		return value
+	}
+	if limit <= 3 {
+		return value[:limit]
+	}
+	return value[:limit-3] + "..."
+}
+
+func runSlackDigest(ctx context.Context, interval time.Duration, publisher *slackDigestPublisher) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := publisher.publish(ctx); err != nil {
+				logrus.WithError(err).Error("publish repo brancher failure digest")
+			}
+		}
+	}
+}

--- a/cmd/repo-brancher-controller/issues_test.go
+++ b/cmd/repo-brancher-controller/issues_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/slack-go/slack"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestIssueStoreResolvesSuccessfulFastForward(t *testing.T) {
+	key := repoKey{org: "org", repo: "repo", source: "main"}
+	state := newDesiredState()
+	state.replace(map[repoKey]sets.Set[string]{key: sets.New("release-5.0")})
+	refs := &fakeRefClient{
+		err: permanentError{errors.New("not a fast forward")},
+		refs: map[string]string{
+			refID("org", "repo", "main"):        "new",
+			refID("org", "repo", "release-5.0"): "old",
+		}}
+	issues := newBranchIssueStore()
+	c := newController(refs, state, 1)
+	c.issues = issues
+	defer c.queue.ShutDown()
+
+	if err := c.reconcile(context.Background(), key); err == nil {
+		t.Fatal("expected initial reconciliation to fail")
+	}
+	if got := len(issues.snapshot()); got != 1 {
+		t.Fatalf("expected active issue after failure, got %d", got)
+	}
+
+	refs.err = nil
+	refs.refs[refID("org", "repo", "release-5.0")] = "old"
+	if err := c.reconcile(context.Background(), key); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(issues.snapshot()); got != 0 {
+		t.Fatalf("expected issue to be resolved after successful fast-forward, got %d", got)
+	}
+}
+
+type recordingSlackClient struct {
+	channel string
+	options []slack.MsgOption
+	err     error
+}
+
+func (c *recordingSlackClient) PostMessage(channelID string, options ...slack.MsgOption) (string, string, error) {
+	c.channel = channelID
+	c.options = options
+	return channelID, "123.456", c.err
+}
+
+func TestSlackDigestShowsFiveMostRecentIssues(t *testing.T) {
+	store := newBranchIssueStore()
+	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	store.now = func() time.Time {
+		now = now.Add(time.Minute)
+		return now
+	}
+	for i := 0; i < 7; i++ {
+		store.upsert(branchIssue{
+			key:       branchIssueKey{org: "org", repo: "repo", source: "main", target: "release-5." + string(rune('0'+i))},
+			reason:    "non_fast_forward",
+			sourceSHA: "source-sha",
+			targetSHA: "target-sha",
+			lastError: "GitHub rejected non-forced ref update",
+		})
+	}
+
+	client := &recordingSlackClient{}
+	publisher := newSlackDigestPublisher(client, "CHAN", store)
+	if err := publisher.publish(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if client.channel != "CHAN" {
+		t.Fatalf("unexpected channel: %s", client.channel)
+	}
+	rendered := renderSlackBlocks(publisher.blocks(store.snapshot()))
+	if !strings.Contains(rendered, "7 active failure") {
+		t.Fatalf("digest did not include total count: %s", rendered)
+	}
+	if strings.Count(rendered, "reason:") != maxSlackIssues {
+		t.Fatalf("expected %d rendered issues, got digest: %s", maxSlackIssues, rendered)
+	}
+	if !strings.Contains(rendered, "Showing 5 of 7 active failures") {
+		t.Fatalf("digest did not include truncation notice: %s", rendered)
+	}
+}
+
+func TestSlackDigestPublishError(t *testing.T) {
+	store := newBranchIssueStore()
+	store.upsert(branchIssue{key: branchIssueKey{org: "org", repo: "repo", source: "main", target: "release-5.0"}, reason: "non_fast_forward", lastError: "boom"})
+	publisher := newSlackDigestPublisher(&recordingSlackClient{err: errors.New("slack down")}, "CHAN", store)
+	if err := publisher.publish(context.Background()); err == nil {
+		t.Fatal("expected publish error")
+	}
+}
+
+func TestIssueStorePrunesRemovedTargets(t *testing.T) {
+	store := newBranchIssueStore()
+	store.upsert(branchIssue{key: branchIssueKey{org: "org", repo: "repo", source: "main", target: "release-5.0"}, reason: "non_fast_forward"})
+	store.upsert(branchIssue{key: branchIssueKey{org: "org", repo: "repo", source: "main", target: "release-5.1"}, reason: "non_fast_forward"})
+
+	store.prune(map[repoKey]sets.Set[string]{
+		{org: "org", repo: "repo", source: "main"}: sets.New("release-5.1"),
+	})
+
+	issues := store.snapshot()
+	if len(issues) != 1 || issues[0].key.target != "release-5.1" {
+		t.Fatalf("unexpected remaining issues: %#v", issues)
+	}
+}
+
+func renderSlackBlocks(blocks []slack.Block) string {
+	var parts []string
+	for _, block := range blocks {
+		switch b := block.(type) {
+		case *slack.HeaderBlock:
+			if b.Text != nil {
+				parts = append(parts, b.Text.Text)
+			}
+		case *slack.SectionBlock:
+			if b.Text != nil {
+				parts = append(parts, b.Text.Text)
+			}
+		case *slack.ContextBlock:
+			for _, element := range b.ContextElements.Elements {
+				if text, ok := element.(*slack.TextBlockObject); ok {
+					parts = append(parts, text.Text)
+				}
+			}
+		}
+	}
+	return strings.Join(parts, "\n")
+}

--- a/cmd/repo-brancher-controller/main.go
+++ b/cmd/repo-brancher-controller/main.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/slack-go/slack"
 
 	prowconfig "sigs.k8s.io/prow/pkg/config"
 	"sigs.k8s.io/prow/pkg/config/secret"
@@ -28,9 +29,11 @@ type options struct {
 	githubEventServer                                githubeventserver.Options
 	configDir, forwardingConfigPath, pluginConfigDir string
 	hmacPath                                         string
+	slackTokenPath, opsChannelID                     string
 	workers, maxRetries                              int
 	configReload, fullResync, shutdownGracePeriod    time.Duration
 	retryExhaustedDelay                              time.Duration
+	slackReportPeriod                                time.Duration
 	maxConfigStaleness                               time.Duration
 }
 
@@ -41,11 +44,14 @@ func gatherOptions() options {
 	fs.StringVar(&o.forwardingConfigPath, "forwarding-config", "", "Path to the default and release branch forwarding configuration.")
 	fs.StringVar(&o.pluginConfigDir, "plugin-config-dir", "", "Path to Prow's sharded plugin configuration used to verify external-plugin coverage.")
 	fs.StringVar(&o.hmacPath, "hmac-secret-file", "/etc/webhook/hmac", "Path to the GitHub webhook HMAC secret.")
+	fs.StringVar(&o.slackTokenPath, "slack-token-path", "", "Optional path to a Slack token used to publish active fast-forward failure digests.")
+	fs.StringVar(&o.opsChannelID, "ops-channel-id", "CHY2E1BL4", "Channel ID for #ops-testplatform.")
 	fs.IntVar(&o.workers, "workers", 8, "Number of repositories reconciled concurrently.")
 	fs.IntVar(&o.maxRetries, "max-retries", 5, "Maximum fast reconciliation retries per repository.")
 	fs.DurationVar(&o.retryExhaustedDelay, "retry-exhausted-delay", 15*time.Minute, "Delay between reconciliation attempts after fast retries are exhausted.")
 	fs.DurationVar(&o.configReload, "config-reload-period", 5*time.Minute, "How often to reload desired state from configuration.")
 	fs.DurationVar(&o.fullResync, "full-resync-period", 12*time.Hour, "Safety-net interval for reconciling every configured repository.")
+	fs.DurationVar(&o.slackReportPeriod, "slack-report-period", 2*time.Hour, "How often to publish active fast-forward failures to Slack when --slack-token-path is set.")
 	fs.DurationVar(&o.maxConfigStaleness, "max-config-staleness", 15*time.Minute, "Config reload age after which readiness fails.")
 	fs.DurationVar(&o.shutdownGracePeriod, "shutdown-grace-period", 30*time.Second, "Maximum graceful shutdown duration.")
 	o.github.AddCustomizedFlags(fs, flagutil.ThrottlerDefaults(18000, 10))
@@ -83,6 +89,12 @@ func (o *options) validate() error {
 	if o.configReload <= 0 || o.fullResync <= 0 || o.retryExhaustedDelay <= 0 {
 		errs = append(errs, errors.New("periods and timeouts must be positive"))
 	}
+	if o.slackReportPeriod <= 0 {
+		errs = append(errs, errors.New("--slack-report-period must be positive"))
+	}
+	if o.slackTokenPath != "" && o.opsChannelID == "" {
+		errs = append(errs, errors.New("--ops-channel-id is required with --slack-token-path"))
+	}
 	if o.shutdownGracePeriod <= 0 {
 		errs = append(errs, errors.New("shutdown grace period must be positive"))
 	}
@@ -107,6 +119,11 @@ func main() {
 	if err := secret.Add(o.hmacPath); err != nil {
 		logrus.WithError(err).Fatal("start HMAC secret agent")
 	}
+	if o.slackTokenPath != "" {
+		if err := secret.Add(o.slackTokenPath); err != nil {
+			logrus.WithError(err).Fatal("start Slack token secret agent")
+		}
+	}
 	if raw, err := os.ReadFile(o.hmacPath); err != nil || len(raw) == 0 {
 		logrus.WithError(err).Fatal("webhook HMAC secret is missing or empty")
 	}
@@ -118,12 +135,21 @@ func main() {
 	refs := newGitHubRefClient(githubClient, healthState)
 
 	state := newDesiredState()
+	issueStore := newBranchIssueStore()
 	if _, err := githubClient.BotUser(); err != nil {
 		logrus.WithError(err).Fatal("validate GitHub credentials")
 	}
 	healthState.githubSucceeded()
 	controller := newController(refs, state, o.maxRetries, o.retryExhaustedDelay)
+	controller.issues = issueStore
 	ctx := interrupts.Context()
+
+	metrics.ExposeMetrics(componentName, prowconfig.PushGateway{}, o.instrumentation.MetricsPort)
+	pprofutil.Instrument(o.instrumentation)
+	health := pjutil.NewHealthOnPort(o.instrumentation.HealthPort)
+	health.ServeReady(func() bool { return healthState.ready(time.Now()) })
+	healthState.serverHealthy.Store(true)
+
 	reload := func() {
 		forwardingConfig, err := loadForwardingConfig(o.forwardingConfigPath)
 		if err != nil {
@@ -143,6 +169,7 @@ func main() {
 			logrus.WithError(err).Warn("external-plugin coverage is incomplete; continuing with desired-state reload")
 		}
 		changed := state.replace(next)
+		issueStore.prune(next)
 		controller.enqueue(changed...)
 		healthState.configSucceeded()
 		logrus.WithFields(logrus.Fields{"repositories": len(next), "changed": len(changed)}).Info("loaded desired state")
@@ -160,11 +187,11 @@ func main() {
 		controller.enqueue(state.keys()...)
 		lastFullResync.SetToCurrentTime()
 	})
+	if o.slackTokenPath != "" {
+		slackClient := slack.New(string(secret.GetSecret(o.slackTokenPath)))
+		go runSlackDigest(ctx, o.slackReportPeriod, newSlackDigestPublisher(slackClient, o.opsChannelID, issueStore))
+	}
 
-	metrics.ExposeMetrics(componentName, prowconfig.PushGateway{}, o.instrumentation.MetricsPort)
-	pprofutil.Instrument(o.instrumentation)
-	health := pjutil.NewHealthOnPort(o.instrumentation.HealthPort)
-	health.ServeReady(func() bool { return healthState.ready(time.Now()) })
 	eventServer := githubeventserver.New(o.githubEventServer, secret.GetTokenGenerator(o.hmacPath), logrus.WithField("component", componentName))
 	eventServer.RegisterPushEventHandler((&pushEventHandler{state: state, controller: controller}).handle)
 	interrupts.OnInterrupt(func() {
@@ -172,7 +199,6 @@ func main() {
 		controller.queue.ShutDown()
 		eventServer.GracefulShutdown()
 	})
-	healthState.serverHealthy.Store(true)
 	interrupts.ListenAndServe(eventServer, o.shutdownGracePeriod)
 	interrupts.WaitForGracefulShutdown()
 }


### PR DESCRIPTION
Track active repo-brancher-controller fast-forward failures by source and target branch, including reason, SHAs, timestamps, attempts, and last error.

Publish an optional periodic Slack digest to the ops channel when a Slack token is configured. The digest reports the total active failures and shows the five most recent with compare links.

Resolve stored failures after successful forwarding or when targets are removed from desired state, and add tests for resolution, pruning, digest truncation, and publish errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds optional, periodic Slack digests for `repo-brancher-controller` fast-forward failures when Slack credentials are configured. The controller now maintains an in-memory store of active failures keyed by org/repo/source/target, recording the failure reason, source/target SHAs, first/last seen times, attempt count, and a truncated last error. Failures are marked resolved automatically after a successful forward, or cleared when the target is removed from the desired state.

Operators get improved visibility: on the configured interval (defaulting to two hours), a message is posted to the ops channel with the total number of active failures and the five most recent entries, including GitHub compare links (with a truncation notice when more exist). The implementation also distinguishes permanent vs retryable failures so the digest can route more actionable signals, and it includes tests for issue resolution, pruning, digest truncation, and Slack publish error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->