### PR TITLE
Extend Secret struct with `Field` and `As` fields

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1384,12 +1384,19 @@ type TestDependencies map[string]string
 // Secret describes a secret to be mounted inside a test
 // container.
 type Secret struct {
+	// As is an optional string under which the secret will be stored on the file system.
+	// Requires Field to be not empty.
+	As string `json:"as,omitempty"`
 	// Bundle is a named bundle reference from the GSM config mapping file.
 	// Mutually exclusive with Collection/Group and Name.
 	Bundle string `json:"bundle,omitempty"`
 	// Collection is the GSM collection the secret belongs to.
 	// Mutually exclusive with Bundle and Name.
 	Collection string `json:"collection,omitempty"`
+	// Field is the specific field name within the collection/group.
+	// When set, only this single field is mounted. When omitted, all fields
+	// in the collection/group are auto-discovered.
+	Field string `json:"field,omitempty"`
 	// Group is the group name within the collection.
 	// Required when Collection is set.
 	Group string `json:"group,omitempty"`

--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -254,14 +254,17 @@ func (v *Validator) validateTestStepConfiguration(
 		seenCollectionGroups := sets.New[collectionGroup]()
 		for i, secret := range test.Secrets {
 			isGSM := secret.IsGSMReference() || secret.IsBundleReference()
-			hasGSMFields := secret.Collection != "" || secret.Group != "" || secret.Bundle != ""
+			hasGSMFields := secret.Collection != "" || secret.Group != "" || secret.Bundle != "" || secret.Field != "" || secret.As != ""
 			if isGSM || hasGSMFields {
 				if secret.Name != "" {
-					validationErrors = append(validationErrors, fmt.Errorf("%s.secrets[%d]: `name` cannot be used with `bundle`, `collection`, or `group`", fieldRootN, i))
+					validationErrors = append(validationErrors, fmt.Errorf("%s.secrets[%d]: `name` cannot be used with `bundle`, `collection`, `group`, or `field`", fieldRootN, i))
+				}
+				if secret.As != "" && secret.Field == "" {
+					validationErrors = append(validationErrors, fmt.Errorf("%s.secrets[%d]: `field` is required when `as` is specified", fieldRootN, i))
 				}
 				if secret.IsBundleReference() {
-					if secret.Collection != "" || secret.Group != "" {
-						validationErrors = append(validationErrors, fmt.Errorf("%s.secrets[%d]: `bundle` cannot be used with `collection` or `group`", fieldRootN, i))
+					if secret.Collection != "" || secret.Group != "" || secret.Field != "" {
+						validationErrors = append(validationErrors, fmt.Errorf("%s.secrets[%d]: `bundle` cannot be used with `collection`, `group`, or `field`", fieldRootN, i))
 					}
 					if seenBundles.Has(secret.Bundle) {
 						validationErrors = append(validationErrors, fmt.Errorf("%s.secrets[%d]: duplicate bundle reference %q", fieldRootN, i, secret.Bundle))
@@ -277,6 +280,8 @@ func (v *Validator) validateTestStepConfiguration(
 					validationErrors = append(validationErrors, fmt.Errorf("%s.secrets[%d].group: is required when `collection` is set", fieldRootN, i))
 				} else if secret.Group != "" {
 					validationErrors = append(validationErrors, fmt.Errorf("%s.secrets[%d].collection: is required when `group` is set", fieldRootN, i))
+				} else if secret.Field != "" {
+					validationErrors = append(validationErrors, fmt.Errorf("%s.secrets[%d]: `field` requires `collection` and `group` to be set", fieldRootN, i))
 				} else {
 					validationErrors = append(validationErrors, fmt.Errorf("%s.secrets[%d]: must specify `bundle` or `collection`+`group`", fieldRootN, i))
 				}

--- a/pkg/validation/test_test.go
+++ b/pkg/validation/test_test.go
@@ -385,6 +385,43 @@ func TestValidateTests(t *testing.T) {
 			},
 		},
 		{
+			id: "valid GSM collection group field secret",
+			tests: []api.TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
+					Secrets: []*api.Secret{
+						{
+							Collection: "col",
+							Group:      "grp",
+							Field:      "my-field",
+							MountPath:  "/path/to/secret",
+						},
+					},
+				},
+			},
+		},
+		{
+			id: "valid GSM collection group field secret with as",
+			tests: []api.TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
+					Secrets: []*api.Secret{
+						{
+							As:         "renamed",
+							Collection: "col",
+							Group:      "grp",
+							Field:      "my-field",
+							MountPath:  "/path/to/secret",
+						},
+					},
+				},
+			},
+		},
+		{
 			id: "valid mixed k8s and GSM secrets",
 			tests: []api.TestStepConfiguration{
 				{
@@ -415,7 +452,7 @@ func TestValidateTests(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New(`tests[0].secrets[0]: ` + "`name` cannot be used with `bundle`, `collection`, or `group`"),
+			expectedError: errors.New(`tests[0].secrets[0]: ` + "`name` cannot be used with `bundle`, `collection`, `group`, or `field`"),
 		},
 		{
 			id: "invalid GSM secret with bundle and collection",
@@ -433,7 +470,7 @@ func TestValidateTests(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New(`tests[0].secrets[0]: ` + "`bundle` cannot be used with `collection` or `group`"),
+			expectedError: errors.New(`tests[0].secrets[0]: ` + "`bundle` cannot be used with `collection`, `group`, or `field`"),
 		},
 		{
 			id: "invalid GSM secret with collection but no group",
@@ -468,6 +505,76 @@ func TestValidateTests(t *testing.T) {
 				},
 			},
 			expectedError: errors.New("tests[0].secrets[0].collection: is required when `group` is set"),
+		},
+		{
+			id: "invalid GSM secret with field but no collection or group",
+			tests: []api.TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
+					Secrets: []*api.Secret{
+						{
+							Field:     "my-field",
+							MountPath: "/path",
+						},
+					},
+				},
+			},
+			expectedError: errors.New("tests[0].secrets[0]: `field` requires `collection` and `group` to be set"),
+		},
+		{
+			id: "invalid secret with name and as",
+			tests: []api.TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
+					Secrets: []*api.Secret{
+						{
+							Name:      "secret",
+							As:        "renamed",
+							MountPath: "/path",
+						},
+					},
+				},
+			},
+			expectedError: errors.New(`tests[0].secrets[0]: ` + "`name` cannot be used with `bundle`, `collection`, `group`, or `field`"),
+		},
+		{
+			id: "invalid secret with as but no GSM fields",
+			tests: []api.TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
+					Secrets: []*api.Secret{
+						{
+							As:        "renamed",
+							MountPath: "/path",
+						},
+					},
+				},
+			},
+			expectedError: errors.New("tests[0].secrets[0]: `field` is required when `as` is specified"),
+		},
+		{
+			id: "invalid GSM secret with as and bundle",
+			tests: []api.TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
+					Secrets: []*api.Secret{
+						{
+							As:        "renamed",
+							Bundle:    "my-bundle",
+							MountPath: "/path",
+						},
+					},
+				},
+			},
+			expectedError: errors.New("tests[0].secrets[0]: `field` is required when `as` is specified"),
 		},
 		{
 			id: "invalid duplicate bundle secrets",

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -1129,12 +1129,19 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"        # You cannot set the Secret and Secrets attributes\n" +
 	"        # at the same time.\n" +
 	"        secret:\n" +
+	"            # As is an optional string under which the secret will be stored on the file system.\n" +
+	"            # Requires Field to be not empty.\n" +
+	"            as: ' '\n" +
 	"            # Bundle is a named bundle reference from the GSM config mapping file.\n" +
 	"            # Mutually exclusive with Collection/Group and Name.\n" +
 	"            bundle: ' '\n" +
 	"            # Collection is the GSM collection the secret belongs to.\n" +
 	"            # Mutually exclusive with Bundle and Name.\n" +
 	"            collection: ' '\n" +
+	"            # Field is the specific field name within the collection/group.\n" +
+	"            # When set, only this single field is mounted. When omitted, all fields\n" +
+	"            # in the collection/group are auto-discovered.\n" +
+	"            field: ' '\n" +
 	"            # Group is the group name within the collection.\n" +
 	"            # Required when Collection is set.\n" +
 	"            group: ' '\n" +
@@ -1149,12 +1156,19 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"        # You cannot set the Secret and Secrets attributes\n" +
 	"        # at the same time.\n" +
 	"        secrets:\n" +
-	"            - # Bundle is a named bundle reference from the GSM config mapping file.\n" +
+	"            - # As is an optional string under which the secret will be stored on the file system.\n" +
+	"              # Requires Field to be not empty.\n" +
+	"              as: ' '\n" +
+	"              # Bundle is a named bundle reference from the GSM config mapping file.\n" +
 	"              # Mutually exclusive with Collection/Group and Name.\n" +
 	"              bundle: ' '\n" +
 	"              # Collection is the GSM collection the secret belongs to.\n" +
 	"              # Mutually exclusive with Bundle and Name.\n" +
 	"              collection: ' '\n" +
+	"              # Field is the specific field name within the collection/group.\n" +
+	"              # When set, only this single field is mounted. When omitted, all fields\n" +
+	"              # in the collection/group are auto-discovered.\n" +
+	"              field: ' '\n" +
 	"              # Group is the group name within the collection.\n" +
 	"              # Required when Collection is set.\n" +
 	"              group: ' '\n" +
@@ -2096,12 +2110,19 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"      # You cannot set the Secret and Secrets attributes\n" +
 	"      # at the same time.\n" +
 	"      secret:\n" +
+	"        # As is an optional string under which the secret will be stored on the file system.\n" +
+	"        # Requires Field to be not empty.\n" +
+	"        as: ' '\n" +
 	"        # Bundle is a named bundle reference from the GSM config mapping file.\n" +
 	"        # Mutually exclusive with Collection/Group and Name.\n" +
 	"        bundle: ' '\n" +
 	"        # Collection is the GSM collection the secret belongs to.\n" +
 	"        # Mutually exclusive with Bundle and Name.\n" +
 	"        collection: ' '\n" +
+	"        # Field is the specific field name within the collection/group.\n" +
+	"        # When set, only this single field is mounted. When omitted, all fields\n" +
+	"        # in the collection/group are auto-discovered.\n" +
+	"        field: ' '\n" +
 	"        # Group is the group name within the collection.\n" +
 	"        # Required when Collection is set.\n" +
 	"        group: ' '\n" +
@@ -2116,12 +2137,19 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"      # You cannot set the Secret and Secrets attributes\n" +
 	"      # at the same time.\n" +
 	"      secrets:\n" +
-	"        - # Bundle is a named bundle reference from the GSM config mapping file.\n" +
+	"        - # As is an optional string under which the secret will be stored on the file system.\n" +
+	"          # Requires Field to be not empty.\n" +
+	"          as: ' '\n" +
+	"          # Bundle is a named bundle reference from the GSM config mapping file.\n" +
 	"          # Mutually exclusive with Collection/Group and Name.\n" +
 	"          bundle: ' '\n" +
 	"          # Collection is the GSM collection the secret belongs to.\n" +
 	"          # Mutually exclusive with Bundle and Name.\n" +
 	"          collection: ' '\n" +
+	"          # Field is the specific field name within the collection/group.\n" +
+	"          # When set, only this single field is mounted. When omitted, all fields\n" +
+	"          # in the collection/group are auto-discovered.\n" +
+	"          field: ' '\n" +
 	"          # Group is the group name within the collection.\n" +
 	"          # Required when Collection is set.\n" +
 	"          group: ' '\n" +


### PR DESCRIPTION
Missed in https://github.com/openshift/ci-tools/pull/5274

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This updates ci-operator’s test secret configuration so CI users can mount GSM-backed credentials using a specific field. The `Secret` type now supports two new optional selectors—`field` (to choose a particular GSM field) and `as` (to optionally mount/alias that selected field).  

Validation was tightened to match the GSM-style configuration rules: `field` is treated as part of the same mutual-exclusion set as other secret selectors (`bundle`, `collection`, `group`, `name`), and `as` is only allowed when `field` is set. Unit tests were expanded to cover both valid and invalid `field`/`as` combinations, including cases where `field` must be required or rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->