### PR TITLE
ci-operator: support mounting dependency images as volumes

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1238,6 +1238,8 @@ type StepDependency struct {
 	Env string `json:"env"`
 	// PullSpec allows the ci-operator user to pass in an external pull-spec that should be used when resolving the dependency
 	PullSpec string `json:"-"`
+	// MountPath is where the dependency image will be mounted as a read-only volume.
+	MountPath string `json:"mount_path,omitempty"`
 }
 
 // StepDNSConfig defines a resource that needs to be acquired prior to execution.

--- a/pkg/steps/multi_stage/gen.go
+++ b/pkg/steps/multi_stage/gen.go
@@ -202,12 +202,14 @@ func (s *multiStageTestStep) generatePods(
 		}...)
 		container.Env = append(container.Env, env...)
 		container.Env = append(container.Env, s.generateParams(step.Environment)...)
-		depEnv, depErrs := s.envForDependencies(step)
+		depEnv, depVolumes, depMounts, depErrs := s.envForDependencies(step)
 		if len(depErrs) != 0 {
 			errs = append(errs, depErrs...)
 			continue
 		}
 		container.Env = append(container.Env, depEnv...)
+		pod.Spec.Volumes = append(pod.Spec.Volumes, depVolumes...)
+		container.VolumeMounts = append(container.VolumeMounts, depMounts...)
 		if owner := s.jobSpec.Owner(); owner != nil {
 			pod.OwnerReferences = append(pod.OwnerReferences, *owner)
 		}
@@ -411,8 +413,10 @@ func (s *multiStageTestStep) generateParams(env []api.StepParameter) []coreapi.E
 	return ret
 }
 
-func (s *multiStageTestStep) envForDependencies(step api.LiteralTestStep) ([]coreapi.EnvVar, []error) {
+func (s *multiStageTestStep) envForDependencies(step api.LiteralTestStep) ([]coreapi.EnvVar, []coreapi.Volume, []coreapi.VolumeMount, []error) {
 	var env []coreapi.EnvVar
+	var volumes []coreapi.Volume
+	var mounts []coreapi.VolumeMount
 	var errs []error
 	var claimRelease *api.ClaimRelease
 	if s.clusterClaim != nil {
@@ -436,8 +440,34 @@ func (s *multiStageTestStep) envForDependencies(step api.LiteralTestStep) ([]cor
 		env = append(env, coreapi.EnvVar{
 			Name: dependency.Env, Value: ref,
 		})
+		if dependency.MountPath != "" {
+			volName := dependencyVolumeName(dependency.Name)
+			volumes = append(volumes, coreapi.Volume{
+				Name: volName,
+				VolumeSource: coreapi.VolumeSource{
+					Image: &coreapi.ImageVolumeSource{
+						Reference: ref,
+						PullPolicy: coreapi.PullIfNotPresent,
+					},
+				},
+			})
+			mounts = append(mounts, coreapi.VolumeMount{
+				Name:      volName,
+				MountPath: dependency.MountPath,
+				ReadOnly:  true,
+			})
+		}
 	}
-	return env, errs
+	return env, volumes, mounts, errs
+}
+
+func dependencyVolumeName(name string) string {
+	sanitized := strings.NewReplacer(":", "-", ".", "-").Replace(name)
+	volName := fmt.Sprintf("dep-%s", sanitized)
+	if len(volName) > 63 {
+		volName = volName[:63]
+	}
+	return volName
 }
 
 func getClusterClaimPodParams(secretVolumeMounts []coreapi.VolumeMount, testName string) ([]coreapi.EnvVar, []coreapi.VolumeMount, error) {

--- a/pkg/steps/multi_stage/gen_test.go
+++ b/pkg/steps/multi_stage/gen_test.go
@@ -708,6 +708,103 @@ func TestAddCSICredentials(t *testing.T) {
 	}
 }
 
+func TestDependencyVolumeName(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "simple tag", input: "installer", expected: "dep-installer"},
+		{name: "stream:tag", input: "stable:installer", expected: "dep-stable-installer"},
+		{name: "dots replaced", input: "release.latest", expected: "dep-release-latest"},
+		{name: "colons and dots", input: "ci.openshift:tests", expected: "dep-ci-openshift-tests"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if actual := dependencyVolumeName(tc.input); actual != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestDependencyImageVolumes(t *testing.T) {
+	testCases := []struct {
+		name            string
+		dependencies    []api.StepDependency
+		expectedVolumes []coreapi.Volume
+		expectedMounts  []coreapi.VolumeMount
+	}{
+		{
+			name: "no mount_path produces no volumes",
+			dependencies: []api.StepDependency{
+				{Name: "src", Env: "SOURCE", PullSpec: "registry.example.com/src@sha256:abc123"},
+			},
+		},
+		{
+			name: "mount_path produces image volume",
+			dependencies: []api.StepDependency{
+				{Name: "installer", Env: "INSTALLER_IMAGE", PullSpec: "registry.example.com/installer@sha256:abc123", MountPath: "/var/run/images/installer"},
+			},
+			expectedVolumes: []coreapi.Volume{{
+				Name: "dep-installer",
+				VolumeSource: coreapi.VolumeSource{
+					Image: &coreapi.ImageVolumeSource{
+						Reference:  "registry.example.com/installer@sha256:abc123",
+						PullPolicy: coreapi.PullIfNotPresent,
+					},
+				},
+			}},
+			expectedMounts: []coreapi.VolumeMount{{
+				Name:      "dep-installer",
+				MountPath: "/var/run/images/installer",
+				ReadOnly:  true,
+			}},
+		},
+		{
+			name: "mixed dependencies with and without mount_path",
+			dependencies: []api.StepDependency{
+				{Name: "src", Env: "SOURCE", PullSpec: "registry.example.com/src@sha256:abc123"},
+				{Name: "stable:installer", Env: "INSTALLER", PullSpec: "registry.example.com/installer@sha256:def456", MountPath: "/opt/installer"},
+			},
+			expectedVolumes: []coreapi.Volume{{
+				Name: "dep-stable-installer",
+				VolumeSource: coreapi.VolumeSource{
+					Image: &coreapi.ImageVolumeSource{
+						Reference:  "registry.example.com/installer@sha256:def456",
+						PullPolicy: coreapi.PullIfNotPresent,
+					},
+				},
+			}},
+			expectedMounts: []coreapi.VolumeMount{{
+				Name:      "dep-stable-installer",
+				MountPath: "/opt/installer",
+				ReadOnly:  true,
+			}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			step := api.LiteralTestStep{
+				As:           "test",
+				Dependencies: tc.dependencies,
+			}
+			s := &multiStageTestStep{}
+			_, volumes, mounts, errs := s.envForDependencies(step)
+			if len(errs) != 0 {
+				t.Fatalf("unexpected errors: %v", errs)
+			}
+			if !equality.Semantic.DeepEqual(volumes, tc.expectedVolumes) {
+				t.Errorf("unexpected volumes: %s", cmp.Diff(tc.expectedVolumes, volumes))
+			}
+			if !equality.Semantic.DeepEqual(mounts, tc.expectedMounts) {
+				t.Errorf("unexpected volume mounts: %s", cmp.Diff(tc.expectedMounts, mounts))
+			}
+		})
+	}
+}
+
 func TestGetClusterClaimPodParams(t *testing.T) {
 	var testCases = []struct {
 		name               string

--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -951,6 +951,37 @@ func validateDependencies(fieldRoot string, dependencies []api.StepDependency) [
 		} else {
 			env.Insert(dependency.Env)
 		}
+		if dependency.MountPath != "" {
+			if !filepath.IsAbs(dependency.MountPath) {
+				errs = append(errs, fmt.Errorf("%s.dependencies[%d].mount_path is not absolute: %s", fieldRoot, i, dependency.MountPath))
+			}
+			for j, other := range dependencies[i+1:] {
+				if other.MountPath == "" {
+					continue
+				}
+				index := i + j + 1
+				if dependency.MountPath == other.MountPath {
+					errs = append(errs, fmt.Errorf("%s.dependencies[%d] and dependencies[%d] mount to the same location (%s)", fieldRoot, i, index, dependency.MountPath))
+					continue
+				}
+				relPath, err := filepath.Rel(other.MountPath, dependency.MountPath)
+				if err != nil {
+					errs = append(errs, fmt.Errorf("%s.dependencies[%d] could not check relative path to dependencies[%d] (%w)", fieldRoot, i, index, err))
+					continue
+				}
+				if !strings.Contains(relPath, "..") {
+					errs = append(errs, fmt.Errorf("%s.dependencies[%d] mounts at %s, which is under dependencies[%d] (%s)", fieldRoot, i, dependency.MountPath, index, other.MountPath))
+				}
+				relPath, err = filepath.Rel(dependency.MountPath, other.MountPath)
+				if err != nil {
+					errs = append(errs, fmt.Errorf("%s.dependencies[%d] could not check relative path to dependencies[%d] (%w)", fieldRoot, index, i, err))
+					continue
+				}
+				if !strings.Contains(relPath, "..") {
+					errs = append(errs, fmt.Errorf("%s.dependencies[%d] mounts at %s, which is under dependencies[%d] (%s)", fieldRoot, index, other.MountPath, i, dependency.MountPath))
+				}
+			}
+		}
 	}
 	return errs
 }

--- a/pkg/validation/test_test.go
+++ b/pkg/validation/test_test.go
@@ -1641,6 +1641,49 @@ func TestValidateDependencies(t *testing.T) {
 				errors.New("root.dependencies[3].name must take the `tag` or `stream:tag` form, not \"src:lol:oops\""),
 			},
 		},
+		{
+			name: "valid dependencies with mount_path",
+			input: []api.StepDependency{
+				{Name: "src", Env: "SOURCE", MountPath: "/var/run/images/src"},
+				{Name: "installer", Env: "INSTALLER", MountPath: "/var/run/images/installer"},
+			},
+		},
+		{
+			name: "dependency without mount_path is valid",
+			input: []api.StepDependency{
+				{Name: "src", Env: "SOURCE"},
+				{Name: "installer", Env: "INSTALLER", MountPath: "/var/run/images/installer"},
+			},
+		},
+		{
+			name: "relative mount_path is invalid",
+			input: []api.StepDependency{
+				{Name: "src", Env: "SOURCE", MountPath: "relative/path"},
+			},
+			output: []error{
+				errors.New("root.dependencies[0].mount_path is not absolute: relative/path"),
+			},
+		},
+		{
+			name: "duplicate mount_path is invalid",
+			input: []api.StepDependency{
+				{Name: "src", Env: "SOURCE", MountPath: "/var/run/images/src"},
+				{Name: "installer", Env: "INSTALLER", MountPath: "/var/run/images/src"},
+			},
+			output: []error{
+				errors.New("root.dependencies[0] and dependencies[1] mount to the same location (/var/run/images/src)"),
+			},
+		},
+		{
+			name: "nested mount_paths are invalid",
+			input: []api.StepDependency{
+				{Name: "src", Env: "SOURCE", MountPath: "/var/run/images"},
+				{Name: "installer", Env: "INSTALLER", MountPath: "/var/run/images/installer"},
+			},
+			output: []error{
+				errors.New("root.dependencies[1] mounts at /var/run/images/installer, which is under dependencies[0] (/var/run/images)"),
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -789,6 +789,8 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                  dependencies:\n" +
 	"                    - # Env is the environment variable that the image's pull spec is exposed with\n" +
 	"                      env: ' '\n" +
+	"                      # MountPath is where the dependency image will be mounted as a read-only volume.\n" +
+	"                      mount_path: ' '\n" +
 	"                      # Name is the tag or stream:tag that this dependency references\n" +
 	"                      name: ' '\n" +
 	"                  # DnsConfig for step's Pod.\n" +
@@ -897,6 +899,8 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                  dependencies:\n" +
 	"                    - # Env is the environment variable that the image's pull spec is exposed with\n" +
 	"                      env: ' '\n" +
+	"                      # MountPath is where the dependency image will be mounted as a read-only volume.\n" +
+	"                      mount_path: ' '\n" +
 	"                      # Name is the tag or stream:tag that this dependency references\n" +
 	"                      name: ' '\n" +
 	"                  # DnsConfig for step's Pod.\n" +
@@ -1005,6 +1009,8 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                  dependencies:\n" +
 	"                    - # Env is the environment variable that the image's pull spec is exposed with\n" +
 	"                      env: ' '\n" +
+	"                      # MountPath is where the dependency image will be mounted as a read-only volume.\n" +
+	"                      mount_path: ' '\n" +
 	"                      # Name is the tag or stream:tag that this dependency references\n" +
 	"                      name: ' '\n" +
 	"                  # DnsConfig for step's Pod.\n" +
@@ -1255,6 +1261,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                  dependencies:\n" +
 	"                    # LiteralTestStep is a full test step definition.\n" +
 	"                    - env: ' '\n" +
+	"                      mount_path: ' '\n" +
 	"                      name: ' '\n" +
 	"                  dnsConfig:\n" +
 	"                    # LiteralTestStep is a full test step definition.\n" +
@@ -1326,6 +1333,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                  dependencies:\n" +
 	"                    # LiteralTestStep is a full test step definition.\n" +
 	"                    - env: ' '\n" +
+	"                      mount_path: ' '\n" +
 	"                      name: ' '\n" +
 	"                  dnsConfig:\n" +
 	"                    # LiteralTestStep is a full test step definition.\n" +
@@ -1397,6 +1405,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                  dependencies:\n" +
 	"                    # LiteralTestStep is a full test step definition.\n" +
 	"                    - env: ' '\n" +
+	"                      mount_path: ' '\n" +
 	"                      name: ' '\n" +
 	"                  dnsConfig:\n" +
 	"                    # LiteralTestStep is a full test step definition.\n" +
@@ -1756,6 +1765,8 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"              dependencies:\n" +
 	"                - # Env is the environment variable that the image's pull spec is exposed with\n" +
 	"                  env: ' '\n" +
+	"                  # MountPath is where the dependency image will be mounted as a read-only volume.\n" +
+	"                  mount_path: ' '\n" +
 	"                  # Name is the tag or stream:tag that this dependency references\n" +
 	"                  name: ' '\n" +
 	"              # DnsConfig for step's Pod.\n" +
@@ -1864,6 +1875,8 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"              dependencies:\n" +
 	"                - # Env is the environment variable that the image's pull spec is exposed with\n" +
 	"                  env: ' '\n" +
+	"                  # MountPath is where the dependency image will be mounted as a read-only volume.\n" +
+	"                  mount_path: ' '\n" +
 	"                  # Name is the tag or stream:tag that this dependency references\n" +
 	"                  name: ' '\n" +
 	"              # DnsConfig for step's Pod.\n" +
@@ -1972,6 +1985,8 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"              dependencies:\n" +
 	"                - # Env is the environment variable that the image's pull spec is exposed with\n" +
 	"                  env: ' '\n" +
+	"                  # MountPath is where the dependency image will be mounted as a read-only volume.\n" +
+	"                  mount_path: ' '\n" +
 	"                  # Name is the tag or stream:tag that this dependency references\n" +
 	"                  name: ' '\n" +
 	"              # DnsConfig for step's Pod.\n" +
@@ -2222,6 +2237,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"              dependencies:\n" +
 	"                # LiteralTestStep is a full test step definition.\n" +
 	"                - env: ' '\n" +
+	"                  mount_path: ' '\n" +
 	"                  name: ' '\n" +
 	"              dnsConfig:\n" +
 	"                # LiteralTestStep is a full test step definition.\n" +
@@ -2293,6 +2309,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"              dependencies:\n" +
 	"                # LiteralTestStep is a full test step definition.\n" +
 	"                - env: ' '\n" +
+	"                  mount_path: ' '\n" +
 	"                  name: ' '\n" +
 	"              dnsConfig:\n" +
 	"                # LiteralTestStep is a full test step definition.\n" +
@@ -2364,6 +2381,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"              dependencies:\n" +
 	"                # LiteralTestStep is a full test step definition.\n" +
 	"                - env: ' '\n" +
+	"                  mount_path: ' '\n" +
 	"                  name: ' '\n" +
 	"              dnsConfig:\n" +
 	"                # LiteralTestStep is a full test step definition.\n" +


### PR DESCRIPTION
Steps can now optionally set mount_path on a dependency to have the dependency image mounted as a read-only Kubernetes image volume at the specified path. This uses the ImageVolume feature (GA in OCP 4.20+/k8s 1.33+) to make dependency image contents directly accessible to the step without requiring the step to pull and extract the image itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

ci-operator now lets CI configs attach a dependency image directly into a step container as a read-only volume by setting `mount_path` on `step.dependencies`. In practice, this means a step can consume files from a dependency image without having to pull/extract them itself, while the existing dependency environment variables still work as before.

The implementation updates multi-stage pod generation to create Kubernetes Image volumes and mounts when `mount_path` is provided, adds validation to ensure mount paths are absolute and don’t conflict or nest under each other, and adds tests for the new volume naming, pod wiring, and validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->