### PR TITLE
Fix readiness probe

### DIFF
--- a/cmd/repo-brancher-controller/health.go
+++ b/cmd/repo-brancher-controller/health.go
@@ -32,9 +32,5 @@ func (h *runtimeHealth) ready(now time.Time) bool {
 	if lastConfigSuccess == 0 || now.Sub(time.Unix(lastConfigSuccess, 0)) > h.maxConfigStaleness {
 		return false
 	}
-	lastGitHubSuccess := h.lastGitHubSuccess.Load()
-	if lastGitHubSuccess == 0 || now.Sub(time.Unix(lastGitHubSuccess, 0)) > h.maxConfigStaleness {
-		return false
-	}
 	return true
 }

--- a/cmd/repo-brancher-controller/health_test.go
+++ b/cmd/repo-brancher-controller/health_test.go
@@ -18,12 +18,12 @@ func TestRuntimeHealthReadiness(t *testing.T) {
 		t.Fatal("healthy runtime should be ready")
 	}
 	if health.ready(time.Now().Add(2 * time.Minute)) {
-		t.Fatal("stale configuration and GitHub success must fail readiness")
+		t.Fatal("stale configuration must fail readiness")
 	}
 
 	health.lastConfigSuccess.Store(now.Unix())
 	health.lastGitHubSuccess.Store(now.Add(-2 * time.Minute).Unix())
-	if health.ready(now) {
-		t.Fatal("stale GitHub success must fail readiness")
+	if !health.ready(now) {
+		t.Fatal("stale GitHub success must not fail readiness when configuration is fresh")
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixes the repo-brancher controller readiness probe so it now reports ready based on the controller’s own health and config freshness, instead of also requiring a recent successful GitHub request. In practice, this makes the service become ready as soon as it has current configuration and the server is healthy, avoiding false-not-ready states when GitHub activity is stale. Updated the health test to match the new readiness semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->