### PR TITLE
Improve logging in repo-brancher-manager + skip promotion criteria

### DIFF
--- a/cmd/repo-brancher-controller/config.go
+++ b/cmd/repo-brancher-controller/config.go
@@ -37,7 +37,7 @@ func loadDesiredState(configDir string, forwardingConfig *forwardingConfig) (map
 		}
 
 		for _, forwarding := range forwardingConfig.ReleaseBranches {
-			if isIgnored(forwarding.Ignore, info.Org, info.Repo) || !api.PromotesOfficialImage(configuration, api.WithoutOKD, forwarding.Source) {
+			if isIgnored(forwarding.Ignore, info.Org, info.Repo) {
 				continue
 			}
 			if info.Branch != "release-"+forwarding.Source && info.Branch != "openshift-"+forwarding.Source {

--- a/cmd/repo-brancher-controller/config_test.go
+++ b/cmd/repo-brancher-controller/config_test.go
@@ -10,14 +10,23 @@ import (
 )
 
 func writeConfig(t *testing.T, root, org, repo, branch string) {
+	writeConfigWithPromotion(t, root, org, repo, branch, false)
+}
+
+func writeConfigWithPromotion(t *testing.T, root, org, repo, branch string, disabled bool) {
 	t.Helper()
 	dir := filepath.Join(root, org, repo)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		t.Fatal(err)
 	}
+	disabledLine := ""
+	if disabled {
+		disabledLine = "    disabled: true\n"
+	}
 	raw := []byte(fmt.Sprintf(`promotion:
   to:
   - name: %q
+%s
     namespace: ocp
 resources:
   '*':
@@ -32,7 +41,7 @@ zz_generated_metadata:
   branch: %s
   org: %s
   repo: %s
-`, "5.0", branch, org, repo))
+`, "5.0", disabledLine, branch, org, repo))
 	path := filepath.Join(dir, fmt.Sprintf("%s-%s-%s.yaml", org, repo, branch))
 	if err := os.WriteFile(path, raw, 0600); err != nil {
 		t.Fatal(err)
@@ -47,6 +56,8 @@ func TestLoadDesiredStateUsesBranchCategoriesAndScopedIgnores(t *testing.T) {
 	writeConfig(t, configDir, "org", "wrong-release", "release-4.23")
 	writeConfig(t, configDir, "ignored-default", "repo", "master")
 	writeConfig(t, configDir, "org", "ignored-release", "release-5.0")
+	writeConfigWithPromotion(t, configDir, "org", "disabled-default", "main", true)
+	writeConfigWithPromotion(t, configDir, "org", "disabled-release", "release-5.0", true)
 
 	rules := &forwardingConfig{
 		DefaultBranch: &defaultBranchForwarding{
@@ -68,6 +79,7 @@ func TestLoadDesiredStateUsesBranchCategoriesAndScopedIgnores(t *testing.T) {
 		{org: "org", repo: "default", source: "main"}:                    sets.New("release-5.0", "release-5.1"),
 		{org: "org", repo: "release", source: "release-5.0"}:             sets.New("release-4.23"),
 		{org: "org", repo: "openshift-release", source: "openshift-5.0"}: sets.New("openshift-4.23"),
+		{org: "org", repo: "disabled-release", source: "release-5.0"}:    sets.New("release-4.23"),
 	}
 	if len(state) != len(want) {
 		t.Fatalf("unexpected desired state: want %v, got %v", want, state)

--- a/cmd/repo-brancher-controller/webhook.go
+++ b/cmd/repo-brancher-controller/webhook.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -13,12 +14,40 @@ type pushEventHandler struct {
 	controller *controller
 }
 
-func (h *pushEventHandler) handle(_ *logrus.Entry, event github.PushEvent) {
+func (h *pushEventHandler) handle(logger *logrus.Entry, event github.PushEvent) {
+	if logger == nil {
+		logger = logrus.NewEntry(logrus.StandardLogger())
+	}
+	logger = logger.WithFields(logrus.Fields{
+		"org":     event.Repo.Owner.Login,
+		"repo":    event.Repo.Name,
+		"ref":     event.Ref,
+		"deleted": event.Deleted,
+	})
 	if event.Deleted || !strings.HasPrefix(event.Ref, "refs/heads/") {
 		webhooksTotal.WithLabelValues("ignored_ref").Inc()
+		logger.Debug("ignored push event")
 		return
 	}
 	keys := h.state.matching(event.Repo.Owner.Login, event.Repo.Name, event.Branch())
+	if len(keys) == 0 {
+		webhooksTotal.WithLabelValues("unconfigured").Inc()
+		logger.WithField("branch", event.Branch()).Debug("push event has no configured forwarding target")
+		return
+	}
 	h.controller.enqueue(keys...)
 	webhooksTotal.WithLabelValues("accepted").Inc()
+	logger.WithFields(logrus.Fields{
+		"branch": event.Branch(),
+		"keys":   repoKeyStrings(keys),
+	}).Info("accepted push event")
+}
+
+func repoKeyStrings(keys []repoKey) []string {
+	out := make([]string, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, key.String())
+	}
+	sort.Strings(out)
+	return out
 }

--- a/cmd/repo-brancher-controller/webhook_test.go
+++ b/cmd/repo-brancher-controller/webhook_test.go
@@ -21,6 +21,7 @@ func TestPushEventHandler(t *testing.T) {
 		wantQueue int
 	}{
 		{name: "source push", event: github.PushEvent{Ref: "refs/heads/main", Repo: github.Repo{Owner: github.User{Login: "org"}, Name: "repo"}}, wantQueue: 1},
+		{name: "unconfigured branch", event: github.PushEvent{Ref: "refs/heads/other", Repo: github.Repo{Owner: github.User{Login: "org"}, Name: "repo"}}},
 		{name: "tag ignored", event: github.PushEvent{Ref: "refs/tags/main", Repo: github.Repo{Owner: github.User{Login: "org"}, Name: "repo"}}},
 		{name: "deleted branch ignored", event: github.PushEvent{Ref: "refs/heads/main", Deleted: true, Repo: github.Repo{Owner: github.User{Login: "org"}, Name: "repo"}}},
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
repo-brancher-controller now emits clearer, more operator-friendly logs for GitHub push events. The push handler records repo/ref/deleted in the log context, debugs when events are ignored due to deletions or non-branch refs, debugs when a branch has no configured forwarding targets, and logs accepted pushes with the matched forwarding keys rendered in a deterministic (sorted) order. It also ensures a usable logger is always available even when the handler is invoked with a nil logger.

In the desired-state configuration loading, the controller’s per-release-branch forwarding logic now only skips forwarding entries when they’re explicitly ignored; it no longer blocks forwarding based on the promotion “official image” check for the forwarding source.

Tests were updated accordingly: webhook coverage now includes an “unconfigured branch” push event to ensure nothing is enqueued, and config tests gained support for generating promotion YAML with a disabled flag to validate the updated desired-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->