### PR TITLE
PowerVS : Create new powervs-sno lease

### DIFF
--- a/pkg/api/clusterprofile.go
+++ b/pkg/api/clusterprofile.go
@@ -115,6 +115,7 @@ const (
 	ClusterProfilePOWERVS7                   ClusterProfile = "powervs-7"
 	ClusterProfilePOWERVS8                   ClusterProfile = "powervs-8"
 	ClusterProfilePOWERVS9                   ClusterProfile = "powervs-9"
+	ClusterProfilePOWERVSSNO                 ClusterProfile = "powervs-sno"
 	ClusterProfileLibvirtPpc64le             ClusterProfile = "libvirt-ppc64le"
 	ClusterProfileLibvirtPpc64leS2S          ClusterProfile = "libvirt-ppc64le-s2s"
 	ClusterProfileLibvirtS390x               ClusterProfile = "libvirt-s390x"
@@ -608,6 +609,8 @@ func (p ClusterProfile) ClusterType() string {
 		return "powervs-8"
 	case ClusterProfilePOWERVS9:
 		return "powervs-9"
+	case ClusterProfilePOWERVSSNO:
+		return "powervs-sno"
 	case ClusterProfileLibvirtPpc64le:
 		return "libvirt-ppc64le"
 	case ClusterProfileLibvirtPpc64leS2S:
@@ -955,6 +958,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "powervs-8-quota-slice"
 	case ClusterProfilePOWERVS9:
 		return "powervs-9-quota-slice"
+	case ClusterProfilePOWERVSSNO:
+		return "powervs-sno-quota-slice"
 	case ClusterProfileLibvirtPpc64le:
 		return "libvirt-ppc64le-quota-slice"
 	case ClusterProfileLibvirtPpc64leS2S:
@@ -1194,7 +1199,7 @@ func LeaseTypeFromClusterType(t string) (string, error) {
 		"ibmcloud-multi-s390x", "nutanix", "nutanix-qe", "nutanix-qe-dis", "nutanix-qe-zone", "nutanix-qe-gpu",
 		"nutanix-qe-flow", "openstack", "openstack-osuosl", "openstack-vexxhost", "openstack-ppc64le",
 		"openstack-nerc-dev", "vsphere", "ovirt", "packet", "packet-edge", "powervc-1", "powervs-multi-1",
-		"powervs-1", "powervs-2", "powervs-3", "powervs-4", "powervs-5", "powervs-6", "powervs-7", "powervs-8", "powervs-9",
+		"powervs-1", "powervs-2", "powervs-3", "powervs-4", "powervs-5", "powervs-6", "powervs-7", "powervs-8", "powervs-9", "powervs-sno",
 		"kubevirt", "aws-cpaas", "osd-ephemeral", "gcp-virtualization", "aws-virtualization",
 		"azure-virtualization", "hypershift-aws", "hypershift-aks", "hypershift-azure",
 		"hypershift-powervs", "hypershift-powervs-cb", "hypershift-gcp", "aws-mco-qe",


### PR DESCRIPTION
Requesting powervs-sno lease within dal14 workspace and quota-slice as 2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds support for a new PowerVS SNO cluster profile in the CI tooling. In practice, this lets CI operators request and classify a `powervs-sno` lease in the `dal14` workspace using `quota-slice 2`, with the API now recognizing the new cluster type and automatically mapping it to the corresponding `powervs-sno-quota-slice` lease type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->