### PR TITLE
Fix CSI volume grouping for multi-collection bundles

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -93,7 +93,7 @@ import (
 	"github.com/openshift/ci-tools/pkg/results"
 	"github.com/openshift/ci-tools/pkg/secrets"
 	"github.com/openshift/ci-tools/pkg/steps"
-	"github.com/openshift/ci-tools/pkg/steps/multi_stage"
+	"github.com/openshift/ci-tools/pkg/steps/csi_secrets"
 	tooldetector "github.com/openshift/ci-tools/pkg/tool-detector"
 	"github.com/openshift/ci-tools/pkg/util"
 	"github.com/openshift/ci-tools/pkg/util/gzip"
@@ -1010,7 +1010,7 @@ func (o *options) Run() (errs []error) {
 		return
 	}
 
-	var gsmConfig *multi_stage.GSMConfiguration
+	var gsmConfig *csi_secrets.GSMConfiguration
 	if o.enableSecretsStoreCSIDriver {
 		var opts []option.ClientOption
 		if o.gsmCredentialsFile != "" {
@@ -1025,7 +1025,7 @@ func (o *options) Run() (errs []error) {
 				logrus.WithError(err).Warn("Failed to close GSM client")
 			}
 		}()
-		gsmConfig = &multi_stage.GSMConfiguration{
+		gsmConfig = &csi_secrets.GSMConfiguration{
 			Config:          &o.gsmConfig,
 			CredentialsFile: o.gsmCredentialsFile,
 			ProjectConfig:   o.gsmProjectConfig,

--- a/pkg/defaults/config.go
+++ b/pkg/defaults/config.go
@@ -17,8 +17,8 @@ import (
 	"github.com/openshift/ci-tools/pkg/release"
 	"github.com/openshift/ci-tools/pkg/secrets"
 	"github.com/openshift/ci-tools/pkg/steps"
+	"github.com/openshift/ci-tools/pkg/steps/csi_secrets"
 	"github.com/openshift/ci-tools/pkg/steps/loggingclient"
-	"github.com/openshift/ci-tools/pkg/steps/multi_stage"
 )
 
 type Config struct {
@@ -45,7 +45,7 @@ type Config struct {
 	IntegratedStreams           map[string]*configresolver.IntegratedStream
 	InjectedTest                bool
 	EnableSecretsStoreCSIDriver bool
-	GSMConfig                   *multi_stage.GSMConfiguration
+	GSMConfig                   *csi_secrets.GSMConfiguration
 	MetricsAgent                *metrics.MetricsAgent
 	SkippedImages               sets.Set[string]
 	params                      *api.DeferredParameters

--- a/pkg/prowgen/podspec.go
+++ b/pkg/prowgen/podspec.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
-	"github.com/openshift/ci-tools/pkg/steps/multi_stage"
+	"github.com/openshift/ci-tools/pkg/steps/csi_secrets"
 	"github.com/openshift/ci-tools/pkg/steps/utils"
 )
 
@@ -537,7 +537,7 @@ var (
 		MountPath: cioperatorapi.GSMConfigMountPath,
 		ReadOnly:  true,
 	}
-	gsmCredentialsVolume = multi_stage.BuildCSIVolume(
+	gsmCredentialsVolume = csi_secrets.BuildCSIVolume(
 		cioperatorapi.GSMCredentialsVolumeMount,
 		cioperatorapi.GSMCiOperatorSPCName)
 	gsmCredentialsVolumeMount = corev1.VolumeMount{

--- a/pkg/steps/csi_secrets/config.go
+++ b/pkg/steps/csi_secrets/config.go
@@ -1,0 +1,23 @@
+package csi_secrets
+
+import (
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	gsm "github.com/openshift/ci-tools/pkg/gsm-secrets"
+)
+
+// GSMConfiguration contains all Google Secret Manager (GSM) related configuration
+// needed for test execution (both multi-stage and container tests).
+type GSMConfiguration struct {
+	Config          *api.GSMConfig
+	CredentialsFile string
+	Client          *secretmanager.Client
+	ProjectConfig   gsm.Config
+}
+
+// CollectionGroupKey identifies a unique (collection, group) pair for caching discovered fields.
+type CollectionGroupKey struct {
+	Collection string
+	Group      string
+}

--- a/pkg/steps/csi_secrets/csi_utils.go
+++ b/pkg/steps/csi_secrets/csi_utils.go
@@ -24,25 +24,29 @@ import (
 const GSMProject = "openshift-ci-secrets"
 const KubernetesDNSLabelLimit = 63
 
+// IsK8sSecretReference returns true if the credential refers to a K8s Secret (has namespace and name).
 func IsK8sSecretReference(c api.CredentialReference) bool {
 	return c.Namespace != "" && c.Name != ""
 }
 
+// IsGSMReference returns true if the credential is a fully resolved GSM reference (has collection, group, and field).
 func IsGSMReference(c api.CredentialReference) bool {
 	return c.Collection != "" && c.Group != "" && c.Field != ""
 }
 
-// GroupCredentialsByCollectionGroupAndMountPath groups credentials by (collection, group, mount_path)
-// to avoid duplicate mount paths, which causes Kubernetes errors.
-func GroupCredentialsByCollectionGroupAndMountPath(credentials []api.CredentialReference) map[string][]api.CredentialReference {
+// GroupCredentialsByMountPath groups resolved credentials by mount_path to produce
+// one CSI volume per unique path. Expects all bundles and auto-discovery to have
+// been resolved into concrete (collection, group, field) tuples beforehand.
+func GroupCredentialsByMountPath(credentials []api.CredentialReference) map[string][]api.CredentialReference {
 	mountGroups := make(map[string][]api.CredentialReference)
 	for _, credential := range credentials {
-		key := fmt.Sprintf("%s:%s:%s", credential.Collection, credential.Group, credential.MountPath)
-		mountGroups[key] = append(mountGroups[key], credential)
+		mountGroups[credential.MountPath] = append(mountGroups[credential.MountPath], credential)
 	}
 	return mountGroups
 }
 
+// BuildGCPSecretsParameter builds the YAML "secrets" parameter for a SecretProviderClass
+// from the given credentials. Each credential maps to a GSM secret path and a mount file name.
 func BuildGCPSecretsParameter(credentials []api.CredentialReference) (string, error) {
 	var secrets []config.Secret
 	for _, credential := range credentials {
@@ -89,28 +93,24 @@ func RestoreForbiddenSymbolsInSecretName(s string) (string, error) {
 	}
 }
 
-// GetSPCName generates a unique SPC name for a set of credentials.
-// All credentials in the input slice must have the same collection, group, and mount path
-// (enforced by GroupCredentialsByCollectionGroupAndMountPath and ValidateNoGroupCollisionsOnMountPath).
-// The hash includes collection, group, mount path, and sorted field names to ensure uniqueness.
+// GetSPCName generates a unique SPC name for a set of credentials that share
+// a mount path. The hash includes the mount path and sorted collection:group:field
+// tuples to ensure uniqueness even when credentials span multiple collections.
 func GetSPCName(namespace string, credentials []api.CredentialReference) string {
 	if len(credentials) == 0 {
 		return strings.ToLower(fmt.Sprintf("%s-empty-spc", namespace))
 	}
-	collection := credentials[0].Collection
-	group := credentials[0].Group
 	mountPath := credentials[0].MountPath
 
 	var parts []string
-	parts = append(parts, collection, group, mountPath)
+	parts = append(parts, mountPath)
 
-	// Sort credential field names for deterministic hashing
-	var credFields []string
+	var credKeys []string
 	for _, cred := range credentials {
-		credFields = append(credFields, cred.Field)
+		credKeys = append(credKeys, fmt.Sprintf("%s:%s:%s", cred.Collection, cred.Group, cred.Field))
 	}
-	sort.Strings(credFields)
-	parts = append(parts, credFields...)
+	sort.Strings(credKeys)
+	parts = append(parts, credKeys...)
 
 	hash := sha256.Sum256([]byte(strings.Join(parts, "-")))
 	hashStr := fmt.Sprintf("%x", hash[:12])
@@ -120,21 +120,14 @@ func GetSPCName(namespace string, credentials []api.CredentialReference) string 
 }
 
 // GetCSIVolumeName generates a deterministic, DNS-compliant name for a CSI volume
-// based on the namespace and credentials. All credentials in the slice must have
-// the same collection, group, and mount path.
-//
-// The name is constructed as "<namespace>-<hash>", where the hash is computed from
-// the collection, group and mountPath. If the resulting name exceeds 63 characters
-// (the Kubernetes DNS label limit), only the hash is used as the name.
+// based on the namespace and mount path. One mount path produces one CSI volume.
 func GetCSIVolumeName(ns string, credentials []api.CredentialReference) string {
 	if len(credentials) == 0 {
 		return strings.ToLower(fmt.Sprintf("%s-empty-vol", ns))
 	}
-	collection := credentials[0].Collection
-	group := credentials[0].Group
 	mountPath := credentials[0].MountPath
 
-	hash := sha256.Sum256([]byte(strings.Join([]string{collection, group, mountPath}, "-")))
+	hash := sha256.Sum256([]byte(mountPath))
 	hashStr := fmt.Sprintf("%x", hash[:8])
 	name := fmt.Sprintf("%s-%s", ns, hashStr)
 
@@ -146,10 +139,12 @@ func GetCSIVolumeName(ns string, credentials []api.CredentialReference) string {
 	return strings.ToLower(name)
 }
 
+// GetCensorMountPath returns the mount path used for sidecar censoring of a GSM secret.
 func GetCensorMountPath(secretName string) string {
 	return fmt.Sprintf("/censor/%s", secretName)
 }
 
+// BuildSecretProviderClass constructs a SecretProviderClass object for the GCP provider.
 func BuildSecretProviderClass(name, namespace, secrets string) *csiapi.SecretProviderClass {
 	return &csiapi.SecretProviderClass{
 		TypeMeta: meta.TypeMeta{
@@ -170,6 +165,7 @@ func BuildSecretProviderClass(name, namespace, secrets string) *csiapi.SecretPro
 	}
 }
 
+// BuildCSIVolume constructs a CSI volume that references the given SecretProviderClass.
 func BuildCSIVolume(name, spcName string) coreapi.Volume {
 	return coreapi.Volume{
 		Name: name,

--- a/pkg/steps/csi_secrets/csi_utils.go
+++ b/pkg/steps/csi_secrets/csi_utils.go
@@ -1,4 +1,4 @@
-package multi_stage
+package csi_secrets
 
 import (
 	"crypto/sha256"
@@ -20,13 +20,21 @@ import (
 	gsmvalidation "github.com/openshift/ci-tools/pkg/gsm-validation"
 )
 
-// GSMproject is the name of the GCP Secret Manager project where the secrets are stored.
-const GSMproject = "openshift-ci-secrets"
+// GSMProject is the name of the GCP Secret Manager project where the secrets are stored.
+const GSMProject = "openshift-ci-secrets"
 const KubernetesDNSLabelLimit = 63
 
-// groupCredentialsByCollectionGroupAndMountPath groups credentials by (collection, group, mount_path)
+func IsK8sSecretReference(c api.CredentialReference) bool {
+	return c.Namespace != "" && c.Name != ""
+}
+
+func IsGSMReference(c api.CredentialReference) bool {
+	return c.Collection != "" && c.Group != "" && c.Field != ""
+}
+
+// GroupCredentialsByCollectionGroupAndMountPath groups credentials by (collection, group, mount_path)
 // to avoid duplicate mount paths, which causes Kubernetes errors.
-func groupCredentialsByCollectionGroupAndMountPath(credentials []api.CredentialReference) map[string][]api.CredentialReference {
+func GroupCredentialsByCollectionGroupAndMountPath(credentials []api.CredentialReference) map[string][]api.CredentialReference {
 	mountGroups := make(map[string][]api.CredentialReference)
 	for _, credential := range credentials {
 		key := fmt.Sprintf("%s:%s:%s", credential.Collection, credential.Group, credential.MountPath)
@@ -35,7 +43,7 @@ func groupCredentialsByCollectionGroupAndMountPath(credentials []api.CredentialR
 	return mountGroups
 }
 
-func buildGCPSecretsParameter(credentials []api.CredentialReference) (string, error) {
+func BuildGCPSecretsParameter(credentials []api.CredentialReference) (string, error) {
 	var secrets []config.Secret
 	for _, credential := range credentials {
 		gsmSecretName := gsm.GetGSMSecretName(credential.Collection, credential.Group, credential.Field)
@@ -43,12 +51,12 @@ func buildGCPSecretsParameter(credentials []api.CredentialReference) (string, er
 		if credential.As != "" {
 			mountName = credential.As
 		}
-		mountName, err := restoreForbiddenSymbolsInSecretName(mountName)
+		mountName, err := RestoreForbiddenSymbolsInSecretName(mountName)
 		if err != nil {
 			return "", fmt.Errorf("invalid mount name '%s': %w", mountName, err)
 		}
 		secrets = append(secrets, config.Secret{
-			ResourceName: fmt.Sprintf("projects/%s/secrets/%s/versions/latest", GSMproject, gsmSecretName),
+			ResourceName: fmt.Sprintf("projects/%s/secrets/%s/versions/latest", GSMProject, gsmSecretName),
 			FileName:     mountName,
 		})
 	}
@@ -59,9 +67,9 @@ func buildGCPSecretsParameter(credentials []api.CredentialReference) (string, er
 	return string(secretsYaml), nil
 }
 
-// restoreForbiddenSymbolsInSecretName replaces all replacement substrings with the original symbols,
+// RestoreForbiddenSymbolsInSecretName replaces all replacement substrings with the original symbols,
 // e.g. '--dot--awscreds' to '.awscreds'
-func restoreForbiddenSymbolsInSecretName(s string) (string, error) {
+func RestoreForbiddenSymbolsInSecretName(s string) (string, error) {
 	// This is an unfortunate workaround needed for the initial migration.
 	// Google Secret Manager doesn't support dots in Secret names. Due to migration from Vault,
 	// where we had to shard each (multi key-value) Vault secret into multiple ones in GSM,
@@ -81,11 +89,11 @@ func restoreForbiddenSymbolsInSecretName(s string) (string, error) {
 	}
 }
 
-// getSPCName generates a unique SPC name for a set of credentials.
+// GetSPCName generates a unique SPC name for a set of credentials.
 // All credentials in the input slice must have the same collection, group, and mount path
-// (enforced by groupCredentialsByCollectionGroupAndMountPath and ValidateNoGroupCollisionsOnMountPath).
+// (enforced by GroupCredentialsByCollectionGroupAndMountPath and ValidateNoGroupCollisionsOnMountPath).
 // The hash includes collection, group, mount path, and sorted field names to ensure uniqueness.
-func getSPCName(namespace string, credentials []api.CredentialReference) string {
+func GetSPCName(namespace string, credentials []api.CredentialReference) string {
 	if len(credentials) == 0 {
 		return strings.ToLower(fmt.Sprintf("%s-empty-spc", namespace))
 	}
@@ -111,14 +119,14 @@ func getSPCName(namespace string, credentials []api.CredentialReference) string 
 	return strings.ToLower(name)
 }
 
-// getCSIVolumeName generates a deterministic, DNS-compliant name for a CSI volume
+// GetCSIVolumeName generates a deterministic, DNS-compliant name for a CSI volume
 // based on the namespace and credentials. All credentials in the slice must have
 // the same collection, group, and mount path.
 //
 // The name is constructed as "<namespace>-<hash>", where the hash is computed from
 // the collection, group and mountPath. If the resulting name exceeds 63 characters
 // (the Kubernetes DNS label limit), only the hash is used as the name.
-func getCSIVolumeName(ns string, credentials []api.CredentialReference) string {
+func GetCSIVolumeName(ns string, credentials []api.CredentialReference) string {
 	if len(credentials) == 0 {
 		return strings.ToLower(fmt.Sprintf("%s-empty-vol", ns))
 	}
@@ -138,11 +146,11 @@ func getCSIVolumeName(ns string, credentials []api.CredentialReference) string {
 	return strings.ToLower(name)
 }
 
-func getCensorMountPath(secretName string) string {
+func GetCensorMountPath(secretName string) string {
 	return fmt.Sprintf("/censor/%s", secretName)
 }
 
-func buildSecretProviderClass(name, namespace, secrets string) *csiapi.SecretProviderClass {
+func BuildSecretProviderClass(name, namespace, secrets string) *csiapi.SecretProviderClass {
 	return &csiapi.SecretProviderClass{
 		TypeMeta: meta.TypeMeta{
 			Kind:       "SecretProviderClass",

--- a/pkg/steps/csi_secrets/csi_utils_test.go
+++ b/pkg/steps/csi_secrets/csi_utils_test.go
@@ -1,4 +1,4 @@
-package multi_stage
+package csi_secrets
 
 import (
 	"fmt"
@@ -107,9 +107,9 @@ func TestGroupCredentialsByCollectionGroupAndMountPath(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := groupCredentialsByCollectionGroupAndMountPath(tc.credentials)
+			result := GroupCredentialsByCollectionGroupAndMountPath(tc.credentials)
 			if diff := cmp.Diff(tc.expected, result); diff != "" {
-				t.Errorf("groupCredentialsByCollectionGroupAndMountPath() mismatch (-want +got):\n%s", diff)
+				t.Errorf("GroupCredentialsByCollectionGroupAndMountPath() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -133,7 +133,7 @@ func TestBuildGCPSecretsParameter(t *testing.T) {
 			},
 			expected: []config.Secret{
 				{
-					ResourceName: fmt.Sprintf("projects/%s/secrets/collection1__group1__cred1/versions/latest", GSMproject),
+					ResourceName: fmt.Sprintf("projects/%s/secrets/collection1__group1__cred1/versions/latest", GSMProject),
 					FileName:     "cred1",
 				},
 			},
@@ -146,11 +146,11 @@ func TestBuildGCPSecretsParameter(t *testing.T) {
 			},
 			expected: []config.Secret{
 				{
-					ResourceName: fmt.Sprintf("projects/%s/secrets/collection1__group1__cred1/versions/latest", GSMproject),
+					ResourceName: fmt.Sprintf("projects/%s/secrets/collection1__group1__cred1/versions/latest", GSMProject),
 					FileName:     "cred1",
 				},
 				{
-					ResourceName: fmt.Sprintf("projects/%s/secrets/collection2__group2__cred2/versions/latest", GSMproject),
+					ResourceName: fmt.Sprintf("projects/%s/secrets/collection2__group2__cred2/versions/latest", GSMProject),
 					FileName:     "cred2",
 				},
 			},
@@ -159,7 +159,7 @@ func TestBuildGCPSecretsParameter(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			yamlString, err := buildGCPSecretsParameter(tc.credentials)
+			yamlString, err := BuildGCPSecretsParameter(tc.credentials)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -171,7 +171,7 @@ func TestBuildGCPSecretsParameter(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.expected, actual); diff != "" {
-				t.Errorf("buildGCPSecretsParameter() mismatch (-want +got):\n%s", diff)
+				t.Errorf("BuildGCPSecretsParameter() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -246,9 +246,9 @@ func TestGetSPCName(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := getSPCName(tc.namespace, tc.credentials)
+			result := GetSPCName(tc.namespace, tc.credentials)
 			if result != tc.expected {
-				t.Errorf("getSPCName() = %v, want %v", result, tc.expected)
+				t.Errorf("GetSPCName() = %v, want %v", result, tc.expected)
 			}
 		})
 	}
@@ -321,12 +321,12 @@ func TestCSIVolumeName(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := getCSIVolumeName(tc.namespace, tc.credentials)
+			result := GetCSIVolumeName(tc.namespace, tc.credentials)
 			if result != tc.expected {
-				t.Errorf("getCSIVolumeName() = %v, want %v", result, tc.expected)
+				t.Errorf("GetCSIVolumeName() = %v, want %v", result, tc.expected)
 			}
 			if len(result) > KubernetesDNSLabelLimit {
-				t.Errorf("getCSIVolumeName() result exceeds Kubernetes label char limit (%d chars): %v", len(result), result)
+				t.Errorf("GetCSIVolumeName() result exceeds Kubernetes label char limit (%d chars): %v", len(result), result)
 			}
 		})
 	}
@@ -339,7 +339,6 @@ func TestReplaceForbiddenSymbolsInCredentialName(t *testing.T) {
 		expected    string
 		expectError bool
 	}{
-		// Valid cases - letters, numbers, dashes, dots, and underscores are allowed
 		{
 			name:        "valid secret name with letters only",
 			secretName:  "credential",
@@ -364,7 +363,6 @@ func TestReplaceForbiddenSymbolsInCredentialName(t *testing.T) {
 			expected:    "MySecret-123",
 			expectError: false,
 		},
-		// Valid cases - replacement strings should be converted to dots and underscores
 		{
 			name:        "secret with dot replacement should work",
 			secretName:  fmt.Sprintf("%scredential", gsmvalidation.DotReplacementString),
@@ -449,7 +447,6 @@ func TestReplaceForbiddenSymbolsInCredentialName(t *testing.T) {
 			expected:    "some_key-secret",
 			expectError: false,
 		},
-		// Invalid cases - forbidden characters that are not allowed
 		{
 			name:        "secret with special characters should fail validation",
 			secretName:  "secret@domain.com",
@@ -489,7 +486,7 @@ func TestReplaceForbiddenSymbolsInCredentialName(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := restoreForbiddenSymbolsInSecretName(tc.secretName)
+			result, err := RestoreForbiddenSymbolsInSecretName(tc.secretName)
 
 			if tc.expectError {
 				if err == nil {

--- a/pkg/steps/csi_secrets/csi_utils_test.go
+++ b/pkg/steps/csi_secrets/csi_utils_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
-func TestGroupCredentialsByCollectionGroupAndMountPath(t *testing.T) {
+func TestGroupCredentialsByMountPath(t *testing.T) {
 	testCases := []struct {
 		name        string
 		credentials []api.CredentialReference
@@ -32,58 +32,58 @@ func TestGroupCredentialsByCollectionGroupAndMountPath(t *testing.T) {
 				{Collection: "collection1", Group: "group1", Field: "cred1", MountPath: "/tmp/cred1"},
 			},
 			expected: map[string][]api.CredentialReference{
-				"collection1:group1:/tmp/cred1": {
+				"/tmp/cred1": {
 					{Collection: "collection1", Group: "group1", Field: "cred1", MountPath: "/tmp/cred1"},
 				},
 			},
 		},
 		{
-			name: "usual scenario: credentials with different collections, groups and paths",
+			name: "usual scenario: credentials with different mount paths stay separate",
 			credentials: []api.CredentialReference{
 				{Collection: "collection1", Group: "group1", Field: "cred1", MountPath: "/tmp/cred1"},
 				{Collection: "collection2", Group: "group2", Field: "cred2", MountPath: "/tmp/cred2"},
 			},
 			expected: map[string][]api.CredentialReference{
-				"collection1:group1:/tmp/cred1": {
+				"/tmp/cred1": {
 					{Collection: "collection1", Group: "group1", Field: "cred1", MountPath: "/tmp/cred1"},
 				},
-				"collection2:group2:/tmp/cred2": {
+				"/tmp/cred2": {
 					{Collection: "collection2", Group: "group2", Field: "cred2", MountPath: "/tmp/cred2"},
 				},
 			},
 		},
 		{
-			name: "usual scenario: credentials with same collection but different group and mount paths",
+			name: "usual scenario: same mount path groups together regardless of collection or group",
 			credentials: []api.CredentialReference{
 				{Collection: "my-creds", Group: "aws", Field: "key1", MountPath: "/tmp/aws"},
 				{Collection: "my-creds", Group: "aws", Field: "different-key", MountPath: "/tmp/aws"},
 				{Collection: "my-creds", Group: "gcp", Field: "key2", MountPath: "/tmp/gcp"},
 			},
 			expected: map[string][]api.CredentialReference{
-				"my-creds:aws:/tmp/aws": {
+				"/tmp/aws": {
 					{Collection: "my-creds", Group: "aws", Field: "key1", MountPath: "/tmp/aws"},
 					{Collection: "my-creds", Group: "aws", Field: "different-key", MountPath: "/tmp/aws"},
 				},
-				"my-creds:gcp:/tmp/gcp": {
+				"/tmp/gcp": {
 					{Collection: "my-creds", Group: "gcp", Field: "key2", MountPath: "/tmp/gcp"},
 				},
 			},
 		},
 		{
-			name: "usual scenario: credentials with same collection, group and path",
+			name: "usual scenario: same collection, group and path",
 			credentials: []api.CredentialReference{
 				{Collection: "collection1", Group: "group1", Field: "cred1", MountPath: "/tmp/shared"},
 				{Collection: "collection1", Group: "group1", Field: "cred2", MountPath: "/tmp/shared"},
 			},
 			expected: map[string][]api.CredentialReference{
-				"collection1:group1:/tmp/shared": {
+				"/tmp/shared": {
 					{Collection: "collection1", Group: "group1", Field: "cred1", MountPath: "/tmp/shared"},
 					{Collection: "collection1", Group: "group1", Field: "cred2", MountPath: "/tmp/shared"},
 				},
 			},
 		},
 		{
-			name: "usual scenario: mixed grouping - some grouped together, some separate",
+			name: "usual scenario: multi-collection bundle: different collections at same path merge into one group",
 			credentials: []api.CredentialReference{
 				{Collection: "colours", Group: "primary", Field: "red", MountPath: "/tmp/path"},
 				{Collection: "colours", Group: "primary", Field: "blue", MountPath: "/tmp/path"},
@@ -91,14 +91,12 @@ func TestGroupCredentialsByCollectionGroupAndMountPath(t *testing.T) {
 				{Collection: "shapes", Group: "angular", Field: "square", MountPath: "/tmp/other"},
 			},
 			expected: map[string][]api.CredentialReference{
-				"colours:primary:/tmp/path": {
+				"/tmp/path": {
 					{Collection: "colours", Group: "primary", Field: "red", MountPath: "/tmp/path"},
 					{Collection: "colours", Group: "primary", Field: "blue", MountPath: "/tmp/path"},
-				},
-				"shapes:round:/tmp/path": {
 					{Collection: "shapes", Group: "round", Field: "circle", MountPath: "/tmp/path"},
 				},
-				"shapes:angular:/tmp/other": {
+				"/tmp/other": {
 					{Collection: "shapes", Group: "angular", Field: "square", MountPath: "/tmp/other"},
 				},
 			},
@@ -107,9 +105,9 @@ func TestGroupCredentialsByCollectionGroupAndMountPath(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := GroupCredentialsByCollectionGroupAndMountPath(tc.credentials)
+			result := GroupCredentialsByMountPath(tc.credentials)
 			if diff := cmp.Diff(tc.expected, result); diff != "" {
-				t.Errorf("GroupCredentialsByCollectionGroupAndMountPath() mismatch (-want +got):\n%s", diff)
+				t.Errorf("GroupCredentialsByMountPath() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -190,7 +188,7 @@ func TestGetSPCName(t *testing.T) {
 			credentials: []api.CredentialReference{
 				{Collection: "collection1", Group: "group1", Field: "cred1", MountPath: "/tmp/cred1"},
 			},
-			expected: "test-ns-37fbca68ecf3629da44421f3-spc",
+			expected: "test-ns-413eed400e7af60b8833c3f8-spc",
 		},
 		{
 			name:      "typical ci-operator namespace",
@@ -198,16 +196,16 @@ func TestGetSPCName(t *testing.T) {
 			credentials: []api.CredentialReference{
 				{Collection: "collection1", Group: "group1", Field: "cred1", MountPath: "/tmp/cred1"},
 			},
-			expected: "ci-op-abc123def456-37fbca68ecf3629da44421f3-spc",
+			expected: "ci-op-abc123def456-413eed400e7af60b8833c3f8-spc",
 		},
 		{
-			name:      "multiple credentials same collection group and mount path",
+			name:      "multiple credentials same mount path",
 			namespace: "test-ns",
 			credentials: []api.CredentialReference{
 				{Collection: "collection1", Group: "group1", Field: "cred1", MountPath: "/tmp/shared"},
 				{Collection: "collection1", Group: "group1", Field: "cred2", MountPath: "/tmp/shared"},
 			},
-			expected: "test-ns-0dac9a0bb0cfa2cd7454405a-spc",
+			expected: "test-ns-3282fd6f77af324290aa5447-spc",
 		},
 		{
 			name:      "different fields produce different hash",
@@ -215,7 +213,7 @@ func TestGetSPCName(t *testing.T) {
 			credentials: []api.CredentialReference{
 				{Collection: "colours", Group: "primary", Field: "red", MountPath: "/tmp/path"},
 			},
-			expected: "test-ns-57f5da70d2e3196fac95df08-spc",
+			expected: "test-ns-260b2418a28eeaa5a9e3a995-spc",
 		},
 		{
 			name:      "different groups produce different hash (aws)",
@@ -223,7 +221,7 @@ func TestGetSPCName(t *testing.T) {
 			credentials: []api.CredentialReference{
 				{Collection: "my-creds", Group: "aws", Field: "access-key", MountPath: "/tmp/aws"},
 			},
-			expected: "test-ns-1347c8e8837d7e97560e7150-spc",
+			expected: "test-ns-c133d70a71fa6d3410fc8889-spc",
 		},
 		{
 			name:      "different groups produce different hash (gcp)",
@@ -231,16 +229,26 @@ func TestGetSPCName(t *testing.T) {
 			credentials: []api.CredentialReference{
 				{Collection: "my-creds", Group: "gcp", Field: "access-key", MountPath: "/tmp/gcp"},
 			},
-			expected: "test-ns-33eddd4dbdaacb84bff886db-spc",
+			expected: "test-ns-baddf8f68cf0aafe2acd532e-spc",
 		},
 		{
-			name:      "fields are sorted for deterministic hashing",
+			name:      "credential keys are sorted for deterministic hashing",
 			namespace: "test-ns",
 			credentials: []api.CredentialReference{
 				{Collection: "colours", Group: "primary", Field: "blue", MountPath: "/tmp/path"},
 				{Collection: "colours", Group: "primary", Field: "red", MountPath: "/tmp/path"},
 			},
-			expected: "test-ns-9f663213b58aa5ec3db559e4-spc",
+			expected: "test-ns-cfe2f25c28f9af63ee0c82cc-spc",
+		},
+		{
+			name:      "multi-collection credentials at same mount path produce single hash",
+			namespace: "test-ns",
+			credentials: []api.CredentialReference{
+				{Collection: "col-a", Group: "grp-x", Field: "login", MountPath: "/var/bundle"},
+				{Collection: "col-a", Group: "grp-x", Field: "pswd", MountPath: "/var/bundle"},
+				{Collection: "col-b", Group: "grp-y", Field: "config", MountPath: "/var/bundle"},
+			},
+			expected: "test-ns-6f9da35a0c07b54ee330ab7b-spc",
 		},
 	}
 
@@ -267,7 +275,7 @@ func TestCSIVolumeName(t *testing.T) {
 			credentials: []api.CredentialReference{
 				{Collection: "coll1", Group: "default", Field: "field1", MountPath: "/tmp/cred1"},
 			},
-			expected: "test-ns-3194a3eba8e37c2a",
+			expected: "test-ns-a6ea5e284a092d64",
 		},
 		{
 			name:      "mount path with dots",
@@ -275,7 +283,7 @@ func TestCSIVolumeName(t *testing.T) {
 			credentials: []api.CredentialReference{
 				{Collection: "coll1", Group: "default", Field: "field1", MountPath: "/tmp/cred.with.dots"},
 			},
-			expected: "test-ns-314371647aefa581",
+			expected: "test-ns-b8aa56363fadb89b",
 		},
 		{
 			name:      "mount path with underscores",
@@ -283,7 +291,7 @@ func TestCSIVolumeName(t *testing.T) {
 			credentials: []api.CredentialReference{
 				{Collection: "coll1", Group: "default", Field: "field1", MountPath: "/tmp/cred_with_underscores"},
 			},
-			expected: "test-ns-4c64a633af543812",
+			expected: "test-ns-09b39d03e50b0a50",
 		},
 		{
 			name:      "long names stay within 63 char limit",
@@ -291,7 +299,7 @@ func TestCSIVolumeName(t *testing.T) {
 			credentials: []api.CredentialReference{
 				{Collection: "some-long-collection-name", Group: "default", Field: "field1", MountPath: "/long/mount/path/that/exceeds/kubernetes/limits"},
 			},
-			expected: "long-namespace-name-within-limits-057ce95edd368edd",
+			expected: "long-namespace-name-within-limits-758f3a0a3e8edb80",
 		},
 		{
 			name:      "long namespace triggers hash-only mode",
@@ -299,23 +307,15 @@ func TestCSIVolumeName(t *testing.T) {
 			credentials: []api.CredentialReference{
 				{Collection: "collection", Group: "default", Field: "field1", MountPath: "/tmp"},
 			},
-			expected: "644c2cb4c1712501c5cab0651185bac2",
+			expected: "e9671acd244849c57167c658fa2f9697",
 		},
 		{
-			name:      "different groups produce different volume names (aws)",
+			name:      "same mount path produces same volume name regardless of collection/group",
 			namespace: "test-ns",
 			credentials: []api.CredentialReference{
 				{Collection: "my-creds", Group: "aws", Field: "key", MountPath: "/tmp/secrets"},
 			},
-			expected: "test-ns-1cb1b8a131a84b72",
-		},
-		{
-			name:      "different groups produce different volume names (gcp)",
-			namespace: "test-ns",
-			credentials: []api.CredentialReference{
-				{Collection: "my-creds", Group: "gcp", Field: "key", MountPath: "/tmp/secrets"},
-			},
-			expected: "test-ns-122de8ec25d37ef5",
+			expected: "test-ns-203f6fcff3e34ef1",
 		},
 	}
 

--- a/pkg/steps/csi_secrets/gsm_bundle_resolver.go
+++ b/pkg/steps/csi_secrets/gsm_bundle_resolver.go
@@ -12,41 +12,40 @@ import (
 	gsm "github.com/openshift/ci-tools/pkg/gsm-secrets"
 )
 
-// ValidateNoGroupCollisionsOnMountPath ensures that different groups within the same collection
-// don't share a mount path, which could cause file name collisions.
-//
-// Example of invalid configuration:
-//   - collection: my-creds, group: aws, field: access-key, mount_path: /tmp/secrets
-//   - collection: my-creds, group: gcp, field: access-key, mount_path: /tmp/secrets
-//
-// Both would try to create /tmp/secrets/access-key.
-// Expects the credentials to already have been resolved into concrete (collection, group, field) tuples.
-func ValidateNoGroupCollisionsOnMountPath(credentials []api.CredentialReference) error {
-	type collectionMountKey struct {
-		collection string
-		mountPath  string
-	}
-	mountPathGroups := make(map[collectionMountKey]map[string]bool)
-
+// ValidateNoFileCollisionsOnMountPath ensures that no two credentials at the same
+// mount path produce the same file name. Checks across all collections and groups.
+// Expects credentials to already have been resolved into concrete (collection, group, field) tuples.
+func ValidateNoFileCollisionsOnMountPath(credentials []api.CredentialReference) error {
+	byMountPath := make(map[string][]api.CredentialReference)
 	for _, cred := range credentials {
-		key := collectionMountKey{
-			collection: cred.Collection,
-			mountPath:  cred.MountPath,
-		}
-		if mountPathGroups[key] == nil {
-			mountPathGroups[key] = make(map[string]bool)
-		}
-		mountPathGroups[key][cred.Group] = true
+		byMountPath[cred.MountPath] = append(byMountPath[cred.MountPath], cred)
 	}
 
-	for key, groups := range mountPathGroups {
-		if len(groups) > 1 {
-			var groupList []string
-			for group := range groups {
-				groupList = append(groupList, group)
+	for mountPath, creds := range byMountPath {
+		type credSource struct {
+			collection, group, field string
+		}
+		seenFiles := make(map[string]credSource)
+		for _, cred := range creds {
+			fileName := cred.Field
+			if cred.As != "" {
+				fileName = cred.As
 			}
-			return fmt.Errorf("multiple groups (%v) found for collection=%s, mount_path=%s - different groups in the same collection must use different mount paths to avoid file name collisions",
-				groupList, key.collection, key.mountPath)
+			restored, err := RestoreForbiddenSymbolsInSecretName(fileName)
+			if err != nil {
+				return fmt.Errorf("invalid field name %q at mount_path %s: %w", fileName, mountPath, err)
+			}
+			src := credSource{cred.Collection, cred.Group, cred.Field}
+			if existing, ok := seenFiles[restored]; ok {
+				return fmt.Errorf(
+					"file name collision at mount_path=%s: %s/%s/%s and %s/%s/%s both produce file %q",
+					mountPath,
+					existing.collection, existing.group, existing.field,
+					src.collection, src.group, src.field,
+					restored,
+				)
+			}
+			seenFiles[restored] = src
 		}
 	}
 	return nil

--- a/pkg/steps/csi_secrets/gsm_bundle_resolver.go
+++ b/pkg/steps/csi_secrets/gsm_bundle_resolver.go
@@ -1,4 +1,4 @@
-package multi_stage
+package csi_secrets
 
 import (
 	"context"
@@ -11,11 +11,6 @@ import (
 	"github.com/openshift/ci-tools/pkg/api"
 	gsm "github.com/openshift/ci-tools/pkg/gsm-secrets"
 )
-
-type collectionGroupKey struct {
-	collection string
-	group      string
-}
 
 // ValidateNoGroupCollisionsOnMountPath ensures that different groups within the same collection
 // don't share a mount path, which could cause file name collisions.
@@ -79,14 +74,13 @@ func ResolveCredentialReferences(
 	gsmConfig *api.GSMConfig,
 	gsmClient gsm.SecretManagerClient,
 	gsmProjectConfig gsm.Config,
-	discoveredFields map[collectionGroupKey][]string,
+	discoveredFields map[CollectionGroupKey][]string,
 ) ([]api.CredentialReference, error) {
 	var resolvedCredentials []api.CredentialReference
 	var errs []error
 
-	// Track discovered fields to avoid redundant GSM calls
 	if discoveredFields == nil {
-		discoveredFields = make(map[collectionGroupKey][]string)
+		discoveredFields = make(map[CollectionGroupKey][]string)
 	}
 
 	for _, cred := range credentials {
@@ -135,7 +129,7 @@ func ResolveCredentialReferences(
 				errs = append(errs, fmt.Errorf("auto-discovery for %s__%s requires GSM client, but client is not initialized", cred.Collection, cred.Group))
 				break
 			}
-			key := collectionGroupKey{
+			key := CollectionGroupKey{
 				cred.Collection,
 				cred.Group,
 			}
@@ -187,7 +181,7 @@ func expandBundle(
 	bundle *api.GSMBundle,
 	gsmClient gsm.SecretManagerClient,
 	gsmProjectConfig gsm.Config,
-	discoveredFields map[collectionGroupKey][]string,
+	discoveredFields map[CollectionGroupKey][]string,
 ) ([]api.CredentialReference, error) {
 	var resolvedCredentials []api.CredentialReference
 
@@ -196,7 +190,7 @@ func expandBundle(
 			if gsmClient == nil {
 				return nil, fmt.Errorf("bundle auto-discovery for %s__%s requires GSM client, but client is not initialized", secretEntry.Collection, secretEntry.Group)
 			}
-			key := collectionGroupKey{
+			key := CollectionGroupKey{
 				secretEntry.Collection,
 				secretEntry.Group,
 			}

--- a/pkg/steps/csi_secrets/gsm_bundle_resolver_test.go
+++ b/pkg/steps/csi_secrets/gsm_bundle_resolver_test.go
@@ -481,7 +481,7 @@ func TestExpandBundle(t *testing.T) {
 	}
 }
 
-func TestValidateNoGroupCollisionsOnMountPath(t *testing.T) {
+func TestValidateNoFileCollisionsOnMountPath(t *testing.T) {
 	for _, tc := range []struct {
 		name        string
 		credentials []api.CredentialReference
@@ -492,99 +492,72 @@ func TestValidateNoGroupCollisionsOnMountPath(t *testing.T) {
 			credentials: []api.CredentialReference{},
 		},
 		{
-			name: "only one credential",
+			name: "single credential",
 			credentials: []api.CredentialReference{
-				{
-					Collection: "test-collection",
-					Field:      "key",
-					Group:      "aws",
-					MountPath:  "path`",
-				},
+				{Collection: "col", Group: "grp", Field: "key", MountPath: "/tmp/secrets"},
 			},
 		},
 		{
-			name: "same collection and group but different mount paths",
+			name: "same field name at different mount paths is ok",
 			credentials: []api.CredentialReference{
-				{
-					Collection: "test-collection",
-					Field:      "key",
-					Group:      "aws",
-					MountPath:  "/tmp/aws-secrets",
-				},
-				{
-					Collection: "test-collection",
-					Field:      "key",
-					Group:      "gcp",
-					MountPath:  "/tmp/gcp-secrets",
-				},
+				{Collection: "col", Group: "aws", Field: "key", MountPath: "/tmp/aws"},
+				{Collection: "col", Group: "gcp", Field: "key", MountPath: "/tmp/gcp"},
 			},
 		},
 		{
-			name: "same collection and group and same mount path",
+			name: "different field names at same mount path is ok",
 			credentials: []api.CredentialReference{
-				{
-					Collection: "test-collection",
-					Field:      "key",
-					Group:      "aws",
-					MountPath:  "/tmp/secrets",
-				},
-				{
-					Collection: "test-collection",
-					Field:      "key",
-					Group:      "gcp",
-					MountPath:  "/tmp/secrets",
-				},
+				{Collection: "col-a", Group: "grp1", Field: "login", MountPath: "/tmp/secrets"},
+				{Collection: "col-b", Group: "grp2", Field: "password", MountPath: "/tmp/secrets"},
+			},
+		},
+		{
+			name: "same field name from different collections at same path collides",
+			credentials: []api.CredentialReference{
+				{Collection: "col-a", Group: "grp1", Field: "key", MountPath: "/tmp/secrets"},
+				{Collection: "col-b", Group: "grp2", Field: "key", MountPath: "/tmp/secrets"},
 			},
 			expectError: true,
 		},
 		{
-			name: "different collections with same groups",
+			name: "same field name from different groups in same collection collides",
 			credentials: []api.CredentialReference{
-				{
-					Collection: "test-collection",
-					Field:      "something",
-					Group:      "aws",
-					MountPath:  "/tmp/secrets",
-				},
-				{
-					Collection: "another-collection",
-					Field:      "key",
-					Group:      "aws",
-					MountPath:  "/tmp/secrets",
-				},
-			},
-		},
-		{
-			name: "multiple fields, one collision",
-			credentials: []api.CredentialReference{
-				{
-					Collection: "collection1",
-					Field:      "key",
-					Group:      "aws",
-					MountPath:  "/tmp/secrets",
-				},
-				{
-					Collection: "collection1",
-					Field:      "password",
-					Group:      "aws",
-					MountPath:  "/tmp/secrets",
-				},
-				{
-					Collection: "collection1",
-					Field:      "key",
-					Group:      "gcp",
-					MountPath:  "/tmp/secrets",
-				},
+				{Collection: "col", Group: "aws", Field: "key", MountPath: "/tmp/secrets"},
+				{Collection: "col", Group: "gcp", Field: "key", MountPath: "/tmp/secrets"},
 			},
 			expectError: true,
+		},
+		{
+			name: "`as` rename that collides with another field",
+			credentials: []api.CredentialReference{
+				{Collection: "col", Group: "grp", Field: "original", MountPath: "/tmp/secrets"},
+				{Collection: "col", Group: "grp", Field: "renamed", As: "original", MountPath: "/tmp/secrets"},
+			},
+			expectError: true,
+		},
+		{
+			name: "denormalized name collision via --dot--",
+			credentials: []api.CredentialReference{
+				{Collection: "col-a", Group: "grp", Field: "config--dot--yaml", MountPath: "/tmp/secrets"},
+				{Collection: "col-b", Group: "grp", Field: "config--dot--yaml", MountPath: "/tmp/secrets"},
+			},
+			expectError: true,
+		},
+		{
+			name: "multi-collection bundle with unique field names is ok",
+			credentials: []api.CredentialReference{
+				{Collection: "col-a", Group: "grp-x", Field: "login", MountPath: "/var/bundle"},
+				{Collection: "col-a", Group: "grp-x", Field: "pswd", MountPath: "/var/bundle"},
+				{Collection: "col-b", Group: "grp-y", Field: "token", MountPath: "/var/bundle"},
+			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			actualErr := ValidateNoGroupCollisionsOnMountPath(tc.credentials)
+			actualErr := ValidateNoFileCollisionsOnMountPath(tc.credentials)
 			if tc.expectError && actualErr == nil {
 				t.Fatal("expected error but got none")
 			}
-			if tc.expectError == false && actualErr != nil {
+			if !tc.expectError && actualErr != nil {
 				t.Fatalf("expected no error but got: %v", actualErr)
 			}
 		})

--- a/pkg/steps/csi_secrets/gsm_bundle_resolver_test.go
+++ b/pkg/steps/csi_secrets/gsm_bundle_resolver_test.go
@@ -1,4 +1,4 @@
-package multi_stage
+package csi_secrets
 
 import (
 	"context"
@@ -15,8 +15,6 @@ import (
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
-// fakeGSMClient is a test double that should never be called
-// (discoveredFields cache should prevent actual API calls)
 type fakeGSMClient struct{}
 
 func (f *fakeGSMClient) ListSecrets(ctx context.Context, req *secretmanagerpb.ListSecretsRequest,
@@ -60,7 +58,7 @@ func TestResolveCredentialReferences(t *testing.T) {
 		name             string
 		credentials      []api.CredentialReference
 		gsmConfig        *api.GSMConfig
-		discoveredFields map[collectionGroupKey][]string
+		discoveredFields map[CollectionGroupKey][]string
 		expected         []api.CredentialReference
 		expectedError    error
 	}{
@@ -116,8 +114,8 @@ func TestResolveCredentialReferences(t *testing.T) {
 				},
 			},
 			gsmConfig: &api.GSMConfig{},
-			discoveredFields: map[collectionGroupKey][]string{
-				{collection: "my-creds", group: "aws"}: {"token", "password"},
+			discoveredFields: map[CollectionGroupKey][]string{
+				{Collection: "my-creds", Group: "aws"}: {"token", "password"},
 			},
 			expected: []api.CredentialReference{
 				{Collection: "my-creds", Group: "aws", Field: "token", MountPath: "/tmp/aws"},
@@ -175,8 +173,8 @@ func TestResolveCredentialReferences(t *testing.T) {
 					},
 				},
 			},
-			discoveredFields: map[collectionGroupKey][]string{
-				{collection: "my-creds", group: "aws"}: {"discovered-key-1", "discovered-key-2"},
+			discoveredFields: map[CollectionGroupKey][]string{
+				{Collection: "my-creds", Group: "aws"}: {"discovered-key-1", "discovered-key-2"},
 			},
 			expected: []api.CredentialReference{
 				{Collection: "my-creds", Group: "aws", Field: "discovered-key-1", MountPath: "/tmp/aws"},
@@ -232,8 +230,8 @@ func TestResolveCredentialReferences(t *testing.T) {
 					},
 				},
 			},
-			discoveredFields: map[collectionGroupKey][]string{
-				{collection: "auto", group: "group2"}: {"auto-field-1", "auto-field-2"},
+			discoveredFields: map[CollectionGroupKey][]string{
+				{Collection: "auto", Group: "group2"}: {"auto-field-1", "auto-field-2"},
 			},
 			expected: []api.CredentialReference{
 				{Collection: "bundle-creds", Group: "g1", Field: "bundle-field", MountPath: "/tmp/bundle"},
@@ -396,7 +394,7 @@ func TestExpandBundle(t *testing.T) {
 	for _, tc := range []struct {
 		name             string
 		bundle           *api.GSMBundle
-		discoveredFields map[collectionGroupKey][]string
+		discoveredFields map[CollectionGroupKey][]string
 		expected         []api.CredentialReference
 	}{
 		{
@@ -418,7 +416,7 @@ func TestExpandBundle(t *testing.T) {
 				{Collection: "my-creds", Group: "aws", Field: "access-key"},
 				{Collection: "my-creds", Group: "aws", Field: "secret-key", As: "renamed-secret"},
 			},
-			discoveredFields: map[collectionGroupKey][]string{},
+			discoveredFields: map[CollectionGroupKey][]string{},
 		},
 		{
 			name: "bundle without explicit fields",
@@ -431,8 +429,8 @@ func TestExpandBundle(t *testing.T) {
 					},
 				},
 			},
-			discoveredFields: map[collectionGroupKey][]string{
-				{collection: "my-creds", group: "aws"}: {"token", "password", "url"},
+			discoveredFields: map[CollectionGroupKey][]string{
+				{Collection: "my-creds", Group: "aws"}: {"token", "password", "url"},
 			},
 			expected: []api.CredentialReference{
 				{Collection: "my-creds", Group: "aws", Field: "token"},
@@ -459,8 +457,8 @@ func TestExpandBundle(t *testing.T) {
 					},
 				},
 			},
-			discoveredFields: map[collectionGroupKey][]string{
-				{collection: "my-creds", group: "aws"}: {"token", "password", "url"},
+			discoveredFields: map[CollectionGroupKey][]string{
+				{Collection: "my-creds", Group: "aws"}: {"token", "password", "url"},
 			},
 			expected: []api.CredentialReference{
 				{Collection: "my-creds", Group: "aws", Field: "token"},

--- a/pkg/steps/multi_stage/gen.go
+++ b/pkg/steps/multi_stage/gen.go
@@ -648,7 +648,7 @@ func addCredentials(credentials []api.CredentialReference, pod *coreapi.Pod, use
 		addK8sSecretVolumes(k8sSecretCreds)
 
 		// Add GSM credentials as CSI volumes
-		collectionMountGroups := csi_secrets.GroupCredentialsByCollectionGroupAndMountPath(gsmCreds)
+		collectionMountGroups := csi_secrets.GroupCredentialsByMountPath(gsmCreds)
 		for _, credentials := range collectionMountGroups {
 			mountPath := credentials[0].MountPath
 

--- a/pkg/steps/multi_stage/gen.go
+++ b/pkg/steps/multi_stage/gen.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	base_steps "github.com/openshift/ci-tools/pkg/steps"
+	"github.com/openshift/ci-tools/pkg/steps/csi_secrets"
 	"github.com/openshift/ci-tools/pkg/steps/utils"
 	podsutils "github.com/openshift/ci-tools/pkg/util"
 )
@@ -637,9 +638,9 @@ func addCredentials(credentials []api.CredentialReference, pod *coreapi.Pod, use
 		var k8sSecretCreds []api.CredentialReference
 		var gsmCreds []api.CredentialReference
 		for _, cred := range credentials {
-			if isK8sSecretReference(cred) {
+			if csi_secrets.IsK8sSecretReference(cred) {
 				k8sSecretCreds = append(k8sSecretCreds, cred)
-			} else if isGSMReference(cred) {
+			} else if csi_secrets.IsGSMReference(cred) {
 				gsmCreds = append(gsmCreds, cred)
 			}
 		}
@@ -647,12 +648,12 @@ func addCredentials(credentials []api.CredentialReference, pod *coreapi.Pod, use
 		addK8sSecretVolumes(k8sSecretCreds)
 
 		// Add GSM credentials as CSI volumes
-		collectionMountGroups := groupCredentialsByCollectionGroupAndMountPath(gsmCreds)
+		collectionMountGroups := csi_secrets.GroupCredentialsByCollectionGroupAndMountPath(gsmCreds)
 		for _, credentials := range collectionMountGroups {
 			mountPath := credentials[0].MountPath
 
-			csiVolumeName := getCSIVolumeName(pod.Namespace, credentials)
-			csiVolume := BuildCSIVolume(csiVolumeName, getSPCName(pod.Namespace, credentials))
+			csiVolumeName := csi_secrets.GetCSIVolumeName(pod.Namespace, credentials)
+			csiVolume := csi_secrets.BuildCSIVolume(csiVolumeName, csi_secrets.GetSPCName(pod.Namespace, credentials))
 			pod.Spec.Volumes = append(pod.Spec.Volumes, csiVolume)
 			pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, coreapi.VolumeMount{
 				Name:      csiVolumeName,

--- a/pkg/steps/multi_stage/gen_test.go
+++ b/pkg/steps/multi_stage/gen_test.go
@@ -21,6 +21,7 @@ import (
 	prowdapi "sigs.k8s.io/prow/pkg/pod-utils/downwardapi"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/steps/csi_secrets"
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
@@ -574,20 +575,20 @@ func TestAddCSICredentials(t *testing.T) {
 						{
 							VolumeMounts: []coreapi.VolumeMount{
 								{
-									Name: getCSIVolumeName("pod-ns", []api.CredentialReference{{Collection: "ns", Group: "default", Field: "field1", MountPath: "/tmp"}}), MountPath: "/tmp",
+									Name: csi_secrets.GetCSIVolumeName("pod-ns", []api.CredentialReference{{Collection: "ns", Group: "default", Field: "field1", MountPath: "/tmp"}}), MountPath: "/tmp",
 								},
 							},
 						},
 					},
 					Volumes: []coreapi.Volume{
 						{
-							Name: getCSIVolumeName("pod-ns", []api.CredentialReference{{Collection: "ns", Group: "default", Field: "field1", MountPath: "/tmp"}}),
+							Name: csi_secrets.GetCSIVolumeName("pod-ns", []api.CredentialReference{{Collection: "ns", Group: "default", Field: "field1", MountPath: "/tmp"}}),
 							VolumeSource: coreapi.VolumeSource{
 								CSI: &coreapi.CSIVolumeSource{
 									Driver:   "secrets-store.csi.k8s.io",
 									ReadOnly: &readOnly,
 									VolumeAttributes: map[string]string{
-										"secretProviderClass": getSPCName("pod-ns", []api.CredentialReference{{Collection: "ns", Group: "default", Field: "field1", MountPath: "/tmp"}}),
+										"secretProviderClass": csi_secrets.GetSPCName("pod-ns", []api.CredentialReference{{Collection: "ns", Group: "default", Field: "field1", MountPath: "/tmp"}}),
 									},
 								},
 							},
@@ -619,33 +620,33 @@ func TestAddCSICredentials(t *testing.T) {
 						{
 							VolumeMounts: []coreapi.VolumeMount{
 								{
-									Name: getCSIVolumeName("pod-ns", []api.CredentialReference{{Collection: "ns", Group: "default", Field: "field1", MountPath: "/tmp"}}), MountPath: "/tmp"},
+									Name: csi_secrets.GetCSIVolumeName("pod-ns", []api.CredentialReference{{Collection: "ns", Group: "default", Field: "field1", MountPath: "/tmp"}}), MountPath: "/tmp"},
 								{
-									Name: getCSIVolumeName("pod-ns", []api.CredentialReference{{Collection: "other", Group: "default", Field: "field2", MountPath: "/tamp"}}), MountPath: "/tamp"},
+									Name: csi_secrets.GetCSIVolumeName("pod-ns", []api.CredentialReference{{Collection: "other", Group: "default", Field: "field2", MountPath: "/tamp"}}), MountPath: "/tamp"},
 							},
 						},
 					},
 					Volumes: []coreapi.Volume{
 						{
-							Name: getCSIVolumeName("pod-ns", []api.CredentialReference{{Collection: "ns", Group: "default", Field: "field1", MountPath: "/tmp"}}),
+							Name: csi_secrets.GetCSIVolumeName("pod-ns", []api.CredentialReference{{Collection: "ns", Group: "default", Field: "field1", MountPath: "/tmp"}}),
 							VolumeSource: coreapi.VolumeSource{
 								CSI: &coreapi.CSIVolumeSource{
 									Driver:   "secrets-store.csi.k8s.io",
 									ReadOnly: &readOnly,
 									VolumeAttributes: map[string]string{
-										"secretProviderClass": getSPCName("pod-ns", []api.CredentialReference{{Collection: "ns", Group: "default", Field: "field1", MountPath: "/tmp"}}),
+										"secretProviderClass": csi_secrets.GetSPCName("pod-ns", []api.CredentialReference{{Collection: "ns", Group: "default", Field: "field1", MountPath: "/tmp"}}),
 									},
 								},
 							},
 						},
 						{
-							Name: getCSIVolumeName("pod-ns", []api.CredentialReference{{Collection: "other", Group: "default", Field: "field2", MountPath: "/tamp"}}),
+							Name: csi_secrets.GetCSIVolumeName("pod-ns", []api.CredentialReference{{Collection: "other", Group: "default", Field: "field2", MountPath: "/tamp"}}),
 							VolumeSource: coreapi.VolumeSource{
 								CSI: &coreapi.CSIVolumeSource{
 									Driver:   "secrets-store.csi.k8s.io",
 									ReadOnly: &readOnly,
 									VolumeAttributes: map[string]string{
-										"secretProviderClass": getSPCName("pod-ns", []api.CredentialReference{{Collection: "other", Group: "default", Field: "field2", MountPath: "/tamp"}}),
+										"secretProviderClass": csi_secrets.GetSPCName("pod-ns", []api.CredentialReference{{Collection: "other", Group: "default", Field: "field2", MountPath: "/tamp"}}),
 									},
 								},
 							},
@@ -673,17 +674,17 @@ func TestAddCSICredentials(t *testing.T) {
 				},
 				Spec: coreapi.PodSpec{
 					Containers: []coreapi.Container{{VolumeMounts: []coreapi.VolumeMount{
-						{Name: getCSIVolumeName("pod-ns", []api.CredentialReference{{Collection: "test-ns", Group: "default", Field: "hive-hive-credentials", MountPath: "/tmp"}}), MountPath: "/tmp"},
+						{Name: csi_secrets.GetCSIVolumeName("pod-ns", []api.CredentialReference{{Collection: "test-ns", Group: "default", Field: "hive-hive-credentials", MountPath: "/tmp"}}), MountPath: "/tmp"},
 					}}},
 					Volumes: []coreapi.Volume{
 						{
-							Name: getCSIVolumeName("pod-ns", []api.CredentialReference{{Collection: "test-ns", Group: "default", Field: "hive-hive-credentials", MountPath: "/tmp"}}),
+							Name: csi_secrets.GetCSIVolumeName("pod-ns", []api.CredentialReference{{Collection: "test-ns", Group: "default", Field: "hive-hive-credentials", MountPath: "/tmp"}}),
 							VolumeSource: coreapi.VolumeSource{
 								CSI: &coreapi.CSIVolumeSource{
 									Driver:   "secrets-store.csi.k8s.io",
 									ReadOnly: &readOnly,
 									VolumeAttributes: map[string]string{
-										"secretProviderClass": getSPCName("pod-ns", []api.CredentialReference{{Collection: "test-ns", Group: "default", Field: "hive-hive-credentials", MountPath: "/tmp"}}),
+										"secretProviderClass": csi_secrets.GetSPCName("pod-ns", []api.CredentialReference{{Collection: "test-ns", Group: "default", Field: "hive-hive-credentials", MountPath: "/tmp"}}),
 									},
 								},
 							},

--- a/pkg/steps/multi_stage/init.go
+++ b/pkg/steps/multi_stage/init.go
@@ -77,7 +77,7 @@ func (s *multiStageTestStep) resolveCredentials(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to resolve credentials for step %s: %w", step.As, err)
 		}
-		if err := csi_secrets.ValidateNoGroupCollisionsOnMountPath(resolvedCredentials); err != nil {
+		if err := csi_secrets.ValidateNoFileCollisionsOnMountPath(resolvedCredentials); err != nil {
 			return fmt.Errorf("invalid credentials for step %s: %w", step.As, err)
 		}
 		step.Credentials = resolvedCredentials
@@ -145,18 +145,28 @@ func (s *multiStageTestStep) createCredentials(ctx context.Context, credentials 
 // to fetch the appropriate secrets from GCP. This is done before
 // the individual steps are run to make sure the appropriate
 // SecretProviderClasses already exist and are available for the test pods.
+// The credentials parameter is used only for sidecar censoring SPCs;
+// volume SPCs are derived per-step to match addCredentials() grouping.
 func (s *multiStageTestStep) createSPCs(ctx context.Context, credentials []api.CredentialReference) error {
 	logrus.Infof("Creating SPCs for actual credential usage...")
 	spcsToCreate := map[string]*csiapi.SecretProviderClass{}
-	collectionMountGroups := csi_secrets.GroupCredentialsByCollectionGroupAndMountPath(credentials)
-
-	for _, credentials := range collectionMountGroups {
-		spcName := csi_secrets.GetSPCName(s.jobSpec.Namespace(), credentials)
-		secrets, err := csi_secrets.BuildGCPSecretsParameter(credentials)
-		if err != nil {
-			return fmt.Errorf("could not marshal secrets for mount path %s: %w", credentials[0].MountPath, err)
+	// Create volume SPCs per-step so the SPC names match what addCredentials
+	// computes per-pod (it only sees one step's credentials at a time).
+	for _, step := range s.getAllStepPtrs() {
+		var stepGSMCreds []api.CredentialReference
+		for _, cred := range step.Credentials {
+			if csi_secrets.IsGSMReference(cred) {
+				stepGSMCreds = append(stepGSMCreds, cred)
+			}
 		}
-		spcsToCreate[spcName] = csi_secrets.BuildSecretProviderClass(spcName, s.jobSpec.Namespace(), secrets)
+		for _, creds := range csi_secrets.GroupCredentialsByMountPath(stepGSMCreds) {
+			spcName := csi_secrets.GetSPCName(s.jobSpec.Namespace(), creds)
+			secrets, err := csi_secrets.BuildGCPSecretsParameter(creds)
+			if err != nil {
+				return fmt.Errorf("could not marshal secrets for mount path %s: %w", creds[0].MountPath, err)
+			}
+			spcsToCreate[spcName] = csi_secrets.BuildSecretProviderClass(spcName, s.jobSpec.Namespace(), secrets)
+		}
 	}
 
 	// Create SPCs for sidecar censoring; each credential gets its own SPC.

--- a/pkg/steps/multi_stage/init.go
+++ b/pkg/steps/multi_stage/init.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openshift/ci-tools/pkg/api"
 	gsm "github.com/openshift/ci-tools/pkg/gsm-secrets"
 	"github.com/openshift/ci-tools/pkg/kubernetes"
+	"github.com/openshift/ci-tools/pkg/steps/csi_secrets"
 	"github.com/openshift/ci-tools/pkg/util"
 )
 
@@ -29,14 +30,6 @@ var (
 	// OpenShift namespaces.
 	uidRangeRegexp = regexp.MustCompile(`^(\d+)/\d+`)
 )
-
-func isK8sSecretReference(c api.CredentialReference) bool {
-	return c.Namespace != "" && c.Name != ""
-}
-
-func isGSMReference(c api.CredentialReference) bool {
-	return c.Collection != "" && c.Group != "" && c.Field != ""
-}
 
 // getAllStepPtrs returns pointers to all steps (pre, test, post) to allow in-place modification.
 func (s *multiStageTestStep) getAllStepPtrs() []*api.LiteralTestStep {
@@ -71,9 +64,9 @@ func (s *multiStageTestStep) createSharedDirSecret(ctx context.Context) error {
 func (s *multiStageTestStep) resolveCredentials(ctx context.Context) error {
 	allStepPtrs := s.getAllStepPtrs()
 
-	discoveredFields := make(map[collectionGroupKey][]string)
+	discoveredFields := make(map[csi_secrets.CollectionGroupKey][]string)
 	for _, step := range allStepPtrs {
-		resolvedCredentials, err := ResolveCredentialReferences(
+		resolvedCredentials, err := csi_secrets.ResolveCredentialReferences(
 			ctx,
 			step.Credentials,
 			s.gsm.Config,
@@ -84,7 +77,7 @@ func (s *multiStageTestStep) resolveCredentials(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to resolve credentials for step %s: %w", step.As, err)
 		}
-		if err := ValidateNoGroupCollisionsOnMountPath(resolvedCredentials); err != nil {
+		if err := csi_secrets.ValidateNoGroupCollisionsOnMountPath(resolvedCredentials); err != nil {
 			return fmt.Errorf("invalid credentials for step %s: %w", step.As, err)
 		}
 		step.Credentials = resolvedCredentials
@@ -102,9 +95,9 @@ func (s *multiStageTestStep) separateCredentialsByType() ([]api.CredentialRefere
 
 	for _, step := range allStepPtrs {
 		for _, credential := range step.Credentials {
-			if isK8sSecretReference(credential) {
+			if csi_secrets.IsK8sSecretReference(credential) {
 				k8sSecretCredentials = append(k8sSecretCredentials, credential)
-			} else if isGSMReference(credential) {
+			} else if csi_secrets.IsGSMReference(credential) {
 				gsmCredentials = append(gsmCredentials, credential)
 			}
 		}
@@ -155,15 +148,15 @@ func (s *multiStageTestStep) createCredentials(ctx context.Context, credentials 
 func (s *multiStageTestStep) createSPCs(ctx context.Context, credentials []api.CredentialReference) error {
 	logrus.Infof("Creating SPCs for actual credential usage...")
 	spcsToCreate := map[string]*csiapi.SecretProviderClass{}
-	collectionMountGroups := groupCredentialsByCollectionGroupAndMountPath(credentials)
+	collectionMountGroups := csi_secrets.GroupCredentialsByCollectionGroupAndMountPath(credentials)
 
 	for _, credentials := range collectionMountGroups {
-		spcName := getSPCName(s.jobSpec.Namespace(), credentials)
-		secrets, err := buildGCPSecretsParameter(credentials)
+		spcName := csi_secrets.GetSPCName(s.jobSpec.Namespace(), credentials)
+		secrets, err := csi_secrets.BuildGCPSecretsParameter(credentials)
 		if err != nil {
 			return fmt.Errorf("could not marshal secrets for mount path %s: %w", credentials[0].MountPath, err)
 		}
-		spcsToCreate[spcName] = buildSecretProviderClass(spcName, s.jobSpec.Namespace(), secrets)
+		spcsToCreate[spcName] = csi_secrets.BuildSecretProviderClass(spcName, s.jobSpec.Namespace(), secrets)
 	}
 
 	// Create SPCs for sidecar censoring; each credential gets its own SPC.
@@ -176,17 +169,17 @@ func (s *multiStageTestStep) createSPCs(ctx context.Context, credentials []api.C
 		}
 		seenCredentials[fullSecretName] = true
 
-		censorMountPath := getCensorMountPath(fullSecretName) //arbitrary mount path for uniqueness
+		censorMountPath := csi_secrets.GetCensorMountPath(fullSecretName) //arbitrary mount path for uniqueness
 		censoredCredential := credential
 		censoredCredential.MountPath = censorMountPath
 		individualCredentials := []api.CredentialReference{censoredCredential}
-		spcName := getSPCName(s.jobSpec.Namespace(), individualCredentials)
+		spcName := csi_secrets.GetSPCName(s.jobSpec.Namespace(), individualCredentials)
 
-		secrets, err := buildGCPSecretsParameter(individualCredentials)
+		secrets, err := csi_secrets.BuildGCPSecretsParameter(individualCredentials)
 		if err != nil {
 			return fmt.Errorf("could not marshal secrets for censored credential %s: %w", fullSecretName, err)
 		}
-		spcsToCreate[spcName] = buildSecretProviderClass(spcName, s.jobSpec.Namespace(), secrets)
+		spcsToCreate[spcName] = csi_secrets.BuildSecretProviderClass(spcName, s.jobSpec.Namespace(), secrets)
 	}
 
 	for name := range spcsToCreate {

--- a/pkg/steps/multi_stage/init_test.go
+++ b/pkg/steps/multi_stage/init_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	gsm "github.com/openshift/ci-tools/pkg/gsm-secrets"
+	"github.com/openshift/ci-tools/pkg/steps/csi_secrets"
 	"github.com/openshift/ci-tools/pkg/steps/loggingclient"
 	"github.com/openshift/ci-tools/pkg/testhelper"
 	testhelper_kube "github.com/openshift/ci-tools/pkg/testhelper/kubernetes"
@@ -65,8 +66,8 @@ func TestCreateSPCs(t *testing.T) {
 	credential2 := api.CredentialReference{Collection: "test-2", Group: "group2", Field: "credential2", MountPath: "/tmp/path2"}
 
 	newGroupedSPC := func(ns string, credentials []api.CredentialReference) csiapi.SecretProviderClass {
-		secret, _ := buildGCPSecretsParameter(credentials)
-		spc := buildSecretProviderClass(getSPCName(ns, credentials), ns, secret)
+		secret, _ := csi_secrets.BuildGCPSecretsParameter(credentials)
+		spc := csi_secrets.BuildSecretProviderClass(csi_secrets.GetSPCName(ns, credentials), ns, secret)
 		// Set ResourceVersion for fake client compatibility
 		spc.ResourceVersion = "1"
 		return *spc
@@ -77,9 +78,9 @@ func TestCreateSPCs(t *testing.T) {
 		censorMountPath := fmt.Sprintf("/censor/%s", fullSecretName)
 		credential := api.CredentialReference{Collection: collection, Group: group, Field: field, MountPath: censorMountPath}
 		credentials := []api.CredentialReference{credential}
-		secret, _ := buildGCPSecretsParameter(credentials)
+		secret, _ := csi_secrets.BuildGCPSecretsParameter(credentials)
 
-		spc := buildSecretProviderClass(getSPCName(ns, credentials), ns, secret)
+		spc := csi_secrets.BuildSecretProviderClass(csi_secrets.GetSPCName(ns, credentials), ns, secret)
 		// Set ResourceVersion for fake client compatibility
 		spc.ResourceVersion = "1"
 		return *spc
@@ -160,7 +161,7 @@ func TestCreateSPCs(t *testing.T) {
 				jobSpec:                     &api.JobSpec{},
 				client:                      fakeClient,
 				enableSecretsStoreCSIDriver: true,
-				gsm: &GSMConfiguration{
+				gsm: &csi_secrets.GSMConfiguration{
 					Config: &api.GSMConfig{},
 					ProjectConfig: gsm.Config{
 						ProjectIdString: "test-project",

--- a/pkg/steps/multi_stage/multi_stage.go
+++ b/pkg/steps/multi_stage/multi_stage.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	"github.com/sirupsen/logrus"
 
 	coreapi "k8s.io/api/core/v1"
@@ -30,6 +29,7 @@ import (
 	"github.com/openshift/ci-tools/pkg/junit"
 	"github.com/openshift/ci-tools/pkg/kubernetes"
 	"github.com/openshift/ci-tools/pkg/results"
+	"github.com/openshift/ci-tools/pkg/steps/csi_secrets"
 	"github.com/openshift/ci-tools/pkg/steps/loggingclient"
 	"github.com/openshift/ci-tools/pkg/steps/utils"
 )
@@ -51,19 +51,6 @@ type vpnConf struct {
 	WaitTimeout *string `json:"wait_timeout"`
 	// Runtime data for the step, not present in the configuration.
 	namespaceUID int64
-}
-
-// GSMConfiguration contains all Google Secret Manager (GSM) related configuration
-// needed for multi-stage test execution.
-type GSMConfiguration struct {
-	// Config contains bundle and secret definitions from gsm-config.yaml file
-	Config *api.GSMConfig
-	// CredentialsFile is the path to the GSM service account credentials
-	CredentialsFile string
-	// Client is the initialized Google Secret Manager client
-	Client *secretmanager.Client
-	// ProjectConfig contains GSM project metadata (ID and number)
-	ProjectConfig gsm.Config
 }
 
 const (
@@ -129,7 +116,7 @@ type multiStageTestStep struct {
 	cancelObservers                  func(context.CancelFunc)
 	nodeArchitecture                 api.NodeArchitecture
 	enableSecretsStoreCSIDriver      bool
-	gsm                              *GSMConfiguration
+	gsm                              *csi_secrets.GSMConfiguration
 	requireNestedPodman              bool
 	leaseProxyServerAvailable        bool
 	leaseProxyClientConfigMapBackoff wait.Backoff
@@ -149,7 +136,7 @@ func MultiStageTestStep(
 	targetAdditionalSuffix string,
 	cancelObservers func(context.CancelFunc),
 	enableSecretsStoreCSIDriver bool,
-	gsmConfig *GSMConfiguration,
+	gsmConfig *csi_secrets.GSMConfiguration,
 	leaseProxyServerAvailable bool,
 	leaseProxyClientConfigMapBackoff wait.Backoff,
 ) api.Step {
@@ -168,7 +155,7 @@ func newMultiStageTestStep(
 	targetAdditionalSuffix string,
 	cancelObservers func(context.CancelFunc),
 	enableSecretsStoreCSIDriver bool,
-	gsmConfig *GSMConfiguration,
+	gsmConfig *csi_secrets.GSMConfiguration,
 	leaseProxyServerAvailable bool,
 	leaseProxyClientConfigMapBackoff wait.Backoff,
 ) *multiStageTestStep {
@@ -627,7 +614,7 @@ func (s *multiStageTestStep) addCredentialsToCensoring(secretVolumes []coreapi.V
 	for _, step := range append(s.pre, append(s.test, s.post...)...) {
 		for _, credential := range step.Credentials {
 			// Skip K8s Secret credentials - they're already censored by secretsForCensoring()
-			if !isGSMReference(credential) {
+			if !csi_secrets.IsGSMReference(credential) {
 				continue
 			}
 			fullSecretName := gsm.GetGSMSecretName(credential.Collection, credential.Group, credential.Field)
@@ -639,13 +626,13 @@ func (s *multiStageTestStep) addCredentialsToCensoring(secretVolumes []coreapi.V
 
 			// Create individual SPC name for censoring - each credential
 			// had its SPC already created in init.go's createSPCs function
-			censorMountPath := getCensorMountPath(fullSecretName)
+			censorMountPath := csi_secrets.GetCensorMountPath(fullSecretName)
 			censoredCredential := credential
 			censoredCredential.MountPath = censorMountPath
 			individualCredentials := []api.CredentialReference{censoredCredential}
-			spcName := getSPCName(s.jobSpec.Namespace(), individualCredentials)
+			spcName := csi_secrets.GetSPCName(s.jobSpec.Namespace(), individualCredentials)
 
-			secretVolumes = append(secretVolumes, BuildCSIVolume(volumeName, spcName))
+			secretVolumes = append(secretVolumes, csi_secrets.BuildCSIVolume(volumeName, spcName))
 			secretVolumeMounts = append(secretVolumeMounts, coreapi.VolumeMount{
 				Name:      volumeName,
 				MountPath: getMountPath(fullSecretName),

--- a/pkg/steps/multi_stage/multi_stage_test.go
+++ b/pkg/steps/multi_stage/multi_stage_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift/ci-tools/pkg/api"
 	gsm "github.com/openshift/ci-tools/pkg/gsm-secrets"
 	"github.com/openshift/ci-tools/pkg/steps"
+	"github.com/openshift/ci-tools/pkg/steps/csi_secrets"
 	"github.com/openshift/ci-tools/pkg/steps/loggingclient"
 )
 
@@ -223,7 +224,7 @@ func TestAddCredentialsToCensoring(t *testing.T) {
 	newVolume := func(index int, collection, group, field string) coreapi.Volume {
 		readOnly := true
 		fullSecretName := gsm.GetGSMSecretName(collection, group, field)
-		censorMountPath := getCensorMountPath(fullSecretName)
+		censorMountPath := csi_secrets.GetCensorMountPath(fullSecretName)
 		individualCredentials := []api.CredentialReference{
 			{
 				Collection: collection,
@@ -240,7 +241,7 @@ func TestAddCredentialsToCensoring(t *testing.T) {
 					Driver:   "secrets-store.csi.k8s.io",
 					ReadOnly: &readOnly,
 					VolumeAttributes: map[string]string{
-						"secretProviderClass": getSPCName("test", individualCredentials),
+						"secretProviderClass": csi_secrets.GetSPCName("test", individualCredentials),
 					},
 				},
 			},


### PR DESCRIPTION
When a GSM bundle references secrets from multiple collections (or groups), `ResolveCredentialReferences` expands them into credentials that all share the bundle's single `mount_path`. The previous grouping function keyed on `(collection, group, mount_path)`, which split these into separate CSI volumes at the same path — Kubernetes rejects duplicate mount paths.

This is the same class of bug fixed in #4619 (pre-group/field era). The grouping key was `(collection, mount_path)` then, later widened to `(collection, group, mount_path)`. That was safe when each credential had its own mount path, but breaks now that bundles can span collection boundaries.

**Fix:** group by `mount_path` only. A single SPC can reference secrets from any number of GSM collections — each object entry has its own full GSM path. Collection/group boundaries don't require separate volumes.

### Example: multi-collection bundle

A bundle with entries from two different collections:

```yaml
# gsm-config.yaml
- name: my-bundle
  gsm_secrets:
    - collection: team-a          # collection A
      group: aws-creds
      fields:
        - name: access-key
        - name: secret-key
    - collection: team-b          # collection B
      group: gcp-creds
      fields:
        - name: sa-key--dot--json
```

A test mounts it at a single path:

```yaml
secrets:
  - bundle: my-bundle
    mount_path: /var/secrets
```

After resolution, 3 credentials all have `mount_path: /var/secrets`:

```
collection=team-a  group=aws-creds  field=access-key       mount=/var/secrets
collection=team-a  group=aws-creds  field=secret-key       mount=/var/secrets
collection=team-b  group=gcp-creds  field=sa-key--dot--json mount=/var/secrets
```

**Before (broken):** grouped by `(collection:group:mount_path)` → 2 groups → 2 CSI volumes at `/var/secrets` → K8s error: `mount path must be unique`

```
Group 1: "team-a:aws-creds:/var/secrets"  → SPC with [access-key, secret-key]  → CSI volume at /var/secrets
Group 2: "team-b:gcp-creds:/var/secrets"  → SPC with [sa-key.json]             → CSI volume at /var/secrets  ← DUPLICATE
```

**After (fixed):** grouped by `mount_path` only → 1 group → 1 CSI volume

```
Group 1: "/var/secrets" → SPC with [access-key, secret-key, sa-key.json] → CSI volume at /var/secrets  ← OK
```

The pod sees three files: `/var/secrets/access-key`, `/var/secrets/secret-key`, `/var/secrets/sa-key.json`

### Example: file name collision detection

The new `ValidateNoFileCollisionsOnMountPath` catches actual file name collisions regardless of collection/group:

```
collection=col-a  group=grp-1  field=config  mount=/var/secrets
collection=col-b  group=grp-2  field=config  mount=/var/secrets
→ ERROR: file name collision at mount_path=/var/secrets: col-a/grp-1/config and col-b/grp-2/config both produce file "config"
```

The old check only looked within the same collection, so this cross-collection collision would have been missed.

### Changes

- `GroupCredentialsByCollectionGroupAndMountPath` → `GroupCredentialsByMountPath` — key on mount path only
- `GetSPCName` — hash `(mountPath, sorted collection:group:field tuples)` instead of `(collection, group, mountPath, fields)`
- `GetCSIVolumeName` — hash `(mountPath)` instead of `(collection, group, mountPath)`
- `ValidateNoGroupCollisionsOnMountPath` → `ValidateNoFileCollisionsOnMountPath` — check actual file name collisions across all credentials at the same mount path, regardless of collection/group
- Update all callers and tests

Co-Authored-By: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes how CI generates and validates CSI-mounted Google Secret Manager secrets for GSM multi-collection/multi-group bundles in multi-stage Prow jobs.

Practically, when a single bundle resolves to multiple GSM (collection, group, field) credentials that all use the same Kubernetes `mountPath`, CI now groups CSI volumes purely by `mountPath` (not by `(collection, group, mountPath)`), preventing Kubernetes rejections caused by duplicate mounts at the same path.

To keep generated Kubernetes resources deterministic and consistent under the new grouping:
- `GetSPCName` now hashes `mountPath` plus sorted `(collection:group:field)` tuples.
- `GetCSIVolumeName` uses a hash derived from `mountPath` (then combines it with namespace for the final DNS-safe name).

Validation was renamed and strengthened:
- `ValidateNoGroupCollisionsOnMountPath` → `ValidateNoFileCollisionsOnMountPath`
- It checks for actual filename collisions at each `mountPath` after computing the effective file name (`As` if set, otherwise `Field`) and denormalizing forbidden symbols back to the mounted filename, across all collections/groups sharing that mount path.

Implementation-wise, CSI GSM credential handling was centralized and rewired to `pkg/steps/csi_secrets`, and all affected generators/callers/tests (ci-operator, prowgen, and multi-stage initialization/CSI volume/SPC generation) were updated to use the new grouping, naming, resolution (`ResolveCredentialReferences`), and collision validation logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->