### PR TITLE
fix(aws-sts): add EC2 snapshot permissions for minted CI users

### DIFF
--- a/hack/aws-sts-roles/target-role.cf
+++ b/hack/aws-sts-roles/target-role.cf
@@ -116,6 +116,17 @@ Resources:
                   - "servicequotas:Get*"
                   - "servicequotas:List*"
                 Resource: "*"
+        - PolicyName: ci-user-permission-boundary
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: EC2Snapshots
+                Effect: Allow
+                Action:
+                  - "ec2:CreateSnapshot"
+                  - "ec2:DescribeSnapshots"
+                  - "ec2:DeleteSnapshot"
+                Resource: "*"
 
 Outputs:
   RoleArn:


### PR DESCRIPTION
- Add `ci-user-permission-boundary` inline policy with EC2 snapshot create/describe/delete actions for minted CI users
- Add explicit `iam:PutUserPolicy` on the target role so CCO can attach policies to minted users

https://redhat-internal.slack.com/archives/CBN38N3MW/p1783356991822999?thread_ts=1783354331.075049&cid=CBN38N3MW

/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR updates the AWS STS target role template (`hack/aws-sts-roles/target-role.cf`, `CITargetRole`, used by CCO) by adding a new inline policy (`ci-user-permission-boundary`) to serve as the permission boundary for minted CI users.

Practically, CI user provisioning via CCO can now apply this boundary to allow EC2 snapshot lifecycle operations—`ec2:CreateSnapshot`, `ec2:DescribeSnapshots`, and `ec2:DeleteSnapshot` on all snapshot resources—supporting CI workflows that require snapshot creation, inspection, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->