### PR TITLE
Remove duplicate collection/group check for container test secrets

### DIFF
--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -249,8 +249,6 @@ func (v *Validator) validateTestStepConfiguration(
 
 		seenNames := sets.New[string]()
 		seenBundles := sets.New[string]()
-		type collectionGroup struct{ collection, group string }
-		seenCollectionGroups := sets.New[collectionGroup]()
 		for i, secret := range test.Secrets {
 			isGSM := secret.IsGSMReference() || secret.IsBundleReference()
 			hasGSMFields := secret.Collection != "" || secret.Group != "" || secret.Bundle != "" || secret.Field != "" || secret.As != ""
@@ -270,11 +268,10 @@ func (v *Validator) validateTestStepConfiguration(
 					}
 					seenBundles.Insert(secret.Bundle)
 				} else if secret.IsGSMReference() {
-					key := collectionGroup{secret.Collection, secret.Group}
-					if seenCollectionGroups.Has(key) {
-						validationErrors = append(validationErrors, fmt.Errorf("%s.secrets[%d]: duplicate collection/group reference %s/%s", fieldRootN, i, secret.Collection, secret.Group))
-					}
-					seenCollectionGroups.Insert(key)
+					// No duplicate check — same (collection, group) at different
+					// mount paths is valid (e.g. auto-discovery at one path and
+					// explicit field at another). Runtime validation
+					// (ValidateNoFileCollisionsOnMountPath) catches real collisions.
 				} else if secret.Collection != "" {
 					validationErrors = append(validationErrors, fmt.Errorf("%s.secrets[%d].group: is required when `collection` is set", fieldRootN, i))
 				} else if secret.Group != "" {

--- a/pkg/validation/test_test.go
+++ b/pkg/validation/test_test.go
@@ -592,7 +592,7 @@ func TestValidateTests(t *testing.T) {
 			expectedError: errors.New(`tests[0].secrets[1]: duplicate bundle reference "my-bundle"`),
 		},
 		{
-			id: "invalid duplicate collection group secrets",
+			id: "same collection/group at different paths is valid",
 			tests: []api.TestStepConfiguration{
 				{
 					As:                         "unit",
@@ -604,7 +604,6 @@ func TestValidateTests(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("tests[0].secrets[1]: duplicate collection/group reference col/grp"),
 		},
 		{
 			id:       "non-literal test is invalid in fully-resolved configuration",


### PR DESCRIPTION
The validation rejected multiple `secrets:` entries with the same `(collection, group)` pair, even when they had different mount paths. This was added as a conservative guard when only auto-discovery existed, but now with explicit `field` and `as` support, the same `(collection, group)` at different paths is valid — e.g. auto-discovery at one path and an explicit field at another.

Runtime validation (`ValidateNoFileCollisionsOnMountPath`) catches actual file name collisions at the same mount path, so the config-time duplicate check is unnecessary and blocks legitimate configurations.

Co-Authored-By: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Container test secret validation now allows the same GSM/Bundle `(collection, group)` to be used more than once when each secret mounts at a different path. In practice, this removes an overly strict config-time rejection in ci-operator test configuration, so CI jobs can reference the same secret source from multiple locations as long as the mount paths do not conflict.

The validation still rejects real collisions where files would overlap at the same mount path, which is handled at runtime. Existing checks for duplicate bundle references and duplicate secret names remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->