### PR TITLE
Enhance the logic of rpm-server when the IST was changed

### DIFF
--- a/pkg/steps/rpm_server.go
+++ b/pkg/steps/rpm_server.go
@@ -196,8 +196,23 @@ fi
 		deployment.OwnerReferences = append(deployment.OwnerReferences, *owner)
 	}
 
-	if err := s.client.Create(ctx, deployment); err != nil && !kerrors.IsAlreadyExists(err) {
-		return fmt.Errorf("could not create RPM repo server deployment: %w", err)
+	existingDeployment := &appsapi.Deployment{}
+	err := s.client.Get(ctx, ctrlruntimeclient.ObjectKey{
+		Namespace: s.jobSpec.Namespace(),
+		Name:      RPMRepoName,
+	}, existingDeployment)
+	if err != nil {
+		if existingDeployment.Spec.Template.Spec.Containers[0].Image != ist.Image.DockerImageReference {
+			if err := s.client.Update(ctx, deployment); err != nil {
+				return fmt.Errorf("could not update RPM repo server deployment: %w", err)
+			}
+		}
+	} else if kerrors.IsNotFound(err) {
+		if err := s.client.Create(ctx, deployment); err != nil {
+			return fmt.Errorf("could not create RPM repo server deployment: %w", err)
+		}
+	} else {
+		return fmt.Errorf("could not get RPM repo server deployment: %w", err)
 	}
 
 	service := &coreapi.Service{


### PR DESCRIPTION
We found some cases were an old RPM Server deployment exists but the RPM repo was replaced, instead of deleting the entire namespace we simply update the deployment with the new IST.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This updates the RPM server step so it can handle an existing deployment when the RPM repository image changes.

In practical terms, instead of failing over to a namespace cleanup/create-only flow, `rpm-server` now checks whether the repo `Deployment` already exists in the job namespace. If it does, it compares the current container image with the new IST and updates the deployment only when the image has changed; if it doesn’t exist, it creates it. This makes RPM server reconciliation more resilient for CI jobs when the underlying repository image is replaced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->