### PR TITLE
ensure the rpm repo deployment, fix the image difference

### DIFF
--- a/pkg/steps/rpm_server.go
+++ b/pkg/steps/rpm_server.go
@@ -196,8 +196,8 @@ fi
 		deployment.OwnerReferences = append(deployment.OwnerReferences, *owner)
 	}
 
-	if err := s.client.Create(ctx, deployment); err != nil && !kerrors.IsAlreadyExists(err) {
-		return fmt.Errorf("could not create RPM repo server deployment: %w", err)
+	if err := s.ensureRPMRepoDeployment(ctx, deployment, ist.Image.DockerImageReference); err != nil {
+		return err
 	}
 
 	service := &coreapi.Service{
@@ -240,6 +240,29 @@ fi
 		return fmt.Errorf("could not wait for RPM repo server to deploy: %w", err)
 	}
 	return waitForRouteReachable(ctx, s.client, s.jobSpec.Namespace(), route.Name, "http")
+}
+
+func (s *rpmServerStep) ensureRPMRepoDeployment(ctx context.Context, deployment *appsapi.Deployment, desiredImage string) error {
+	existing := &appsapi.Deployment{}
+	key := ctrlruntimeclient.ObjectKey{Namespace: deployment.Namespace, Name: deployment.Name}
+	if err := s.client.Get(ctx, key, existing); err != nil {
+		if kerrors.IsNotFound(err) {
+			if err := s.client.Create(ctx, deployment); err != nil {
+				return fmt.Errorf("could not create RPM repo server deployment: %w", err)
+			}
+			return nil
+		}
+		return fmt.Errorf("could not get RPM repo server deployment: %w", err)
+	}
+
+	if existing.Spec.Template.Spec.Containers[0].Image == desiredImage {
+		return nil
+	}
+	existing.Spec.Template.Spec.Containers[0].Image = desiredImage
+	if err := s.client.Update(ctx, existing); err != nil {
+		return fmt.Errorf("could not update RPM repo server deployment: %w", err)
+	}
+	return nil
 }
 
 func waitForDeployment(ctx context.Context, client ctrlruntimeclient.Client, name string) error {

--- a/pkg/steps/rpm_server_test.go
+++ b/pkg/steps/rpm_server_test.go
@@ -1,11 +1,15 @@
 package steps
 
 import (
+	"context"
 	"testing"
 
+	appsapi "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	prowapi "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 	"sigs.k8s.io/prow/pkg/pod-utils/downwardapi"
@@ -17,6 +21,233 @@ import (
 	"github.com/openshift/ci-tools/pkg/testhelper"
 	"github.com/openshift/ci-tools/pkg/util"
 )
+
+func TestEnsureRPMRepoDeployment(t *testing.T) {
+	testCases := []struct {
+		name       string
+		existing   *appsapi.Deployment
+		deployment *appsapi.Deployment
+		want       *appsapi.Deployment
+	}{
+		{
+			name: "creates when missing",
+			deployment: &appsapi.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      RPMRepoName,
+				},
+				Spec: appsapi.DeploymentSpec{
+					Replicas: ptr.To(int32(1)),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{AppLabel: RPMRepoName},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{AppLabel: RPMRepoName},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:  RPMRepoName,
+								Image: "registry/ci-op-ns/pipeline@sha256:new",
+							}},
+						},
+					},
+				},
+			},
+			want: &appsapi.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      RPMRepoName,
+				},
+				Spec: appsapi.DeploymentSpec{
+					Replicas: ptr.To(int32(1)),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{AppLabel: RPMRepoName},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{AppLabel: RPMRepoName},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:  RPMRepoName,
+								Image: "registry/ci-op-ns/pipeline@sha256:new",
+							}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "unchanged when same image",
+			existing: &appsapi.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      RPMRepoName,
+				},
+				Spec: appsapi.DeploymentSpec{
+					Replicas: ptr.To(int32(1)),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{AppLabel: RPMRepoName},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{AppLabel: RPMRepoName},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:  RPMRepoName,
+								Image: "registry/ci-op-ns/pipeline@sha256:new",
+							}},
+						},
+					},
+				},
+			},
+			deployment: &appsapi.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      RPMRepoName,
+				},
+				Spec: appsapi.DeploymentSpec{
+					Replicas: ptr.To(int32(1)),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{AppLabel: RPMRepoName},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{AppLabel: RPMRepoName},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:  RPMRepoName,
+								Image: "registry/ci-op-ns/pipeline@sha256:new",
+							}},
+						},
+					},
+				},
+			},
+			want: &appsapi.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      RPMRepoName,
+				},
+				Spec: appsapi.DeploymentSpec{
+					Replicas: ptr.To(int32(1)),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{AppLabel: RPMRepoName},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{AppLabel: RPMRepoName},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:  RPMRepoName,
+								Image: "registry/ci-op-ns/pipeline@sha256:new",
+							}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "updates when image differs",
+			existing: &appsapi.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      RPMRepoName,
+				},
+				Spec: appsapi.DeploymentSpec{
+					Replicas: ptr.To(int32(1)),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{AppLabel: RPMRepoName},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{AppLabel: RPMRepoName},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:  RPMRepoName,
+								Image: "registry/ci-op-ns/pipeline@sha256:old",
+							}},
+						},
+					},
+				},
+			},
+			deployment: &appsapi.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      RPMRepoName,
+				},
+				Spec: appsapi.DeploymentSpec{
+					Replicas: ptr.To(int32(1)),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{AppLabel: RPMRepoName},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{AppLabel: RPMRepoName},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:  RPMRepoName,
+								Image: "registry/ci-op-ns/pipeline@sha256:new",
+							}},
+						},
+					},
+				},
+			},
+			want: &appsapi.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      RPMRepoName,
+				},
+				Spec: appsapi.DeploymentSpec{
+					Replicas: ptr.To(int32(1)),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{AppLabel: RPMRepoName},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{AppLabel: RPMRepoName},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:  RPMRepoName,
+								Image: "registry/ci-op-ns/pipeline@sha256:new",
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			builder := fakectrlruntimeclient.NewClientBuilder()
+			if tc.existing != nil {
+				builder = builder.WithRuntimeObjects(tc.existing)
+			}
+			client := loggingclient.New(builder.Build(), nil)
+			jobSpec := &api.JobSpec{}
+			jobSpec.SetNamespace("ns")
+			step := &rpmServerStep{client: client, jobSpec: jobSpec}
+
+			desiredImage := tc.deployment.Spec.Template.Spec.Containers[0].Image
+			if err := step.ensureRPMRepoDeployment(context.Background(), tc.deployment, desiredImage); err != nil {
+				t.Fatalf("ensureRPMRepoDeployment() error = %v", err)
+			}
+
+			got := &appsapi.Deployment{}
+			if err := client.Get(context.Background(), ctrlruntimeclient.ObjectKey{Namespace: "ns", Name: RPMRepoName}, got); err != nil {
+				t.Fatalf("Get() error = %v", err)
+			}
+			testhelper.Diff(t, "deployment", got, tc.want, testhelper.RuntimeObjectIgnoreRvTypeMeta)
+		})
+	}
+}
 
 func TestRPMServerStepProvides(t *testing.T) {
 	ns := "ns"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated the RPM server deployment reconciliation in `pkg/steps/rpm_server.go` so CI runs reliably provision (and keep consistent) the RPM repo Kubernetes `Deployment`. Instead of attempting a create with “AlreadyExists” ignored, the step now checks for an existing `Deployment` in the target namespace/name, creates it only when missing, and reconciles the first container image when it differs—leaving the deployment untouched when the image already matches. This prevents image drift and makes subsequent CI deployments more deterministic.

Added unit coverage in `pkg/steps/rpm_server_test.go` for the three reconciliation paths: create when absent, no-op when the image matches, and update when the image differs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->