### PR TITLE
Konflux: Validate Cluster Profile

### DIFF
--- a/cmd/check-cluster-profiles-config/main.go
+++ b/cmd/check-cluster-profiles-config/main.go
@@ -115,6 +115,17 @@ func main() {
 }
 
 func writeConfig(configPath string, profiles api.ClusterProfiles) error {
+	// Resolved clusters are computed at runtime and they should not be marshaled.
+	for i := range profiles.Items {
+		profile := &profiles.Items[i]
+		for j := range profile.Owners {
+			owner := &profile.Owners[j]
+			if owner.Konflux != nil {
+				owner.Konflux.ClustersResolved = nil
+			}
+		}
+	}
+
 	bytes, err := yaml.Marshal(&profiles)
 	if err != nil {
 		return fmt.Errorf("marshal profiles: %w", err)

--- a/pkg/api/clusterprofile.go
+++ b/pkg/api/clusterprofile.go
@@ -105,7 +105,7 @@ type ClusterProfileKonfluxOwner struct {
 	Tenant           string   `yaml:"tenant,omitempty" json:"tenant,omitempty"`
 	Clusters         []string `yaml:"clusters,omitempty" json:"clusters,omitempty"`
 	ClusterGroups    []string `yaml:"cluster_groups,omitempty" json:"cluster_groups,omitempty"`
-	ClustersResolved []string `yaml:"-" json:"-"`
+	ClustersResolved []string `yaml:"clusters_resolved,omitempty" json:"clusters_resolved,omitempty"`
 }
 
 type ClusterProfileOwners struct {

--- a/pkg/api/ephemeralcluster/v1/ci.openshift.io_ephemeralclusters.yaml
+++ b/pkg/api/ephemeralcluster/v1/ci.openshift.io_ephemeralclusters.yaml
@@ -494,3 +494,5 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/pkg/api/ephemeralcluster/v1/ci.openshift.io_ephemeralclusterstatuses.yaml
+++ b/pkg/api/ephemeralcluster/v1/ci.openshift.io_ephemeralclusterstatuses.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.0
+  name: ephemeralclusterstatuses.ci.openshift.io
+spec:
+  group: ci.openshift.io
+  names:
+    kind: EphemeralClusterStatus
+    listKind: EphemeralClusterStatusList
+    plural: ephemeralclusterstatuses
+    singular: ephemeralclusterstatus
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          conditions:
+            items:
+              description: EphemeralClusterCondition contains details for the current
+                condition of this EphemeralCluster.
+              properties:
+                lastTransitionTime:
+                  description: Last time the condition transitioned from one status
+                    to another.
+                  format: date-time
+                  type: string
+                message:
+                  description: Human-readable message indicating details about last
+                    transition.
+                  type: string
+                reason:
+                  description: Unique, one-word, CamelCase reason for the condition's
+                    last transition.
+                  type: string
+                status:
+                  description: Status is the status of the condition.
+                  type: string
+                type:
+                  description: Type is the type of the condition.
+                  type: string
+              required:
+              - status
+              - type
+              type: object
+            type: array
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          phase:
+            description: Phase is an high level description of where the ephemeral
+              cluster is in its lifecycle
+            type: string
+          prowJobId:
+            type: string
+          prowJobURL:
+            type: string
+          secretRef:
+            description: |-
+              SecretRef is the name of the Secret containing credentials to access the
+              ephemeral cluster. The Secret is in the same namespace as the EphemeralCluster
+              and contains a "kubeconfig" key and optionally a "kubeAdminPassword" key.
+            type: string
+        required:
+        - metadata
+        - phase
+        type: object
+    served: true
+    storage: true

--- a/pkg/api/ephemeralcluster/v1/types.go
+++ b/pkg/api/ephemeralcluster/v1/types.go
@@ -7,16 +7,20 @@ import (
 )
 
 const (
-	CIOperatorJobsGenerateFailureReason    = "CIOperatorJobsGenerateFailure"
-	ProwJobFailureReason                   = "ProwJobFailure"
-	ProwJobCompletedReason                 = "ProwJobCompleted"
-	TooManyProwJobsBoundReason             = "TooManyProwJobsBound"
-	SecretsFetchFailureReason              = "SecretsFetchFailure"
-	CreateTestCompletedSecretFailureReason = "CreateTestCompletedSecretFailure"
+	CIOperatorJobsGenerateFailureReason     = "CIOperatorJobsGenerateFailure"
+	ProwJobFailureReason                    = "ProwJobFailure"
+	ProwJobCompletedReason                  = "ProwJobCompleted"
+	TooManyProwJobsBoundReason              = "TooManyProwJobsBound"
+	SecretsFetchFailureReason               = "SecretsFetchFailure"
+	CreateTestCompletedSecretFailureReason  = "CreateTestCompletedSecretFailure"
+	EphemeralClusterValidationFailureReason = "EphemeralClusterValidationFailure"
 
 	CIOperatorNSNotFoundMsg = "ci-operator NS not found"
 	KubeconfigNotReadyMsg   = "kubeconfig not ready"
 	HiveSecretsNotReadyMsg  = "hive secrets not ready"
+
+	KonfluxClusterLabel = "ephemeralcluster.ci.openshift.io/konflux-cluster"
+	KonfluxTenantLabel  = "ephemeralcluster.ci.openshift.io/konflux-tenant"
 )
 
 // EphemeralClusterCondition is a valid value for EphemeralClusterCondition.Type
@@ -61,6 +65,7 @@ const (
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=ec
+// +kubebuilder:subresource:status
 type EphemeralCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
@@ -68,6 +73,20 @@ type EphemeralCluster struct {
 	// +kubebuilder:validation:Required
 	Spec   EphemeralClusterSpec   `json:"spec"`
 	Status EphemeralClusterStatus `json:"status,omitempty"`
+}
+
+func (ec *EphemeralCluster) KonfluxCluster() string {
+	if value, ok := ec.Labels[KonfluxClusterLabel]; ok {
+		return value
+	}
+	return ""
+}
+
+func (ec *EphemeralCluster) KonfluxTenant() string {
+	if value, ok := ec.Labels[KonfluxTenantLabel]; ok {
+		return value
+	}
+	return ""
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/ephemeralcluster/prowjobreconciler_test.go
+++ b/pkg/controller/ephemeralcluster/prowjobreconciler_test.go
@@ -76,6 +76,15 @@ func TestReconcileProwJob(t *testing.T) {
 		}
 		return bldr
 	}
+	addStatusSubresourceObjs := func(bldr *fake.ClientBuilder, objs ...ctrlclient.Object) *fake.ClientBuilder {
+		for _, obj := range objs {
+			if !reflect.ValueOf(obj).IsNil() {
+				bldr = bldr.WithStatusSubresource(obj)
+			}
+		}
+		return bldr
+	}
+
 	fakeNow := fakeNow(t)
 	scheme := fakeScheme(t)
 
@@ -249,7 +258,8 @@ func TestReconcileProwJob(t *testing.T) {
 			bldr := fake.NewClientBuilder().
 				WithInterceptorFuncs(tc.interceptors).
 				WithScheme(scheme)
-			client := addObjs(bldr, tc.pj, tc.ec).Build()
+			bldr = addObjs(bldr, tc.pj, tc.ec)
+			client := addStatusSubresourceObjs(bldr, tc.ec).Build()
 
 			clients := make(map[string]ctrlclient.Client)
 			if tc.buildClients != nil {

--- a/pkg/controller/ephemeralcluster/reconciler.go
+++ b/pkg/controller/ephemeralcluster/reconciler.go
@@ -19,7 +19,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -172,7 +171,10 @@ func AddToManager(log *logrus.Entry, mgr manager.Manager, allManagers map[string
 
 	if err := ctrlbldr.ControllerManagedBy(mgr).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
-		WithEventFilter(predicate.NewPredicateFuncs(ECPredicateFilter)).
+		WithEventFilter(predicate.And(
+			predicate.GenerationChangedPredicate{},
+			predicate.NewPredicateFuncs(ECPredicateFilter),
+		)).
 		For(&ephemeralclusterv1.EphemeralCluster{}).
 		Complete(&r); err != nil {
 		return fmt.Errorf("build controller: %w", err)
@@ -239,8 +241,8 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	var requeueAfter time.Duration
+	// This is a stop-polling condition: if the PJ is in a final state there is nothing to do.
 	if isFinalState := r.reportProwJobFinalState(&pj, &observedStatus); !isFinalState {
-		// This is a stop-polling condition: if the PJ is in a final state there is nothing to do.
 		requeueAfter = r.polling()
 	}
 
@@ -345,7 +347,55 @@ func (r *reconciler) injectCLIIntoBaseImages(baseImages map[string]api.ImageStre
 	return longestName
 }
 
+func (r *reconciler) validateEphemeralCluster(log *logrus.Entry, ec *ephemeralclusterv1.EphemeralCluster) error {
+	log.Info("Validating the Ephemeral Cluster")
+
+	// When the cluser claim is set, there is no need to validate the cluster profile.
+	if ec.Spec.CIOperator.Test.ClusterClaim != nil {
+		return nil
+	}
+
+	clusterProfileName := ec.Spec.CIOperator.Test.ClusterProfile
+	if clusterProfileName == "" {
+		log.Error("Cluster profile has not been set")
+		return errors.New("cluster profile has not been set")
+	}
+
+	log = log.WithField("cluster_profile", clusterProfileName)
+
+	clusterProfile, err := r.clusterProfileResolver(clusterProfileName)
+	if err != nil {
+		log.WithError(err).Error("Failed to resolve cluster profile")
+		return fmt.Errorf("resolve cluster profile %s: %w", clusterProfileName, err)
+	}
+
+	cluster, tenant := ec.KonfluxCluster(), ec.KonfluxTenant()
+	for _, owner := range clusterProfile.Owners {
+		if k := owner.Konflux; k != nil {
+			if tenant == k.Tenant && slices.Contains(k.ClustersResolved, cluster) {
+				log.WithField("cluster", cluster).WithField("tenant", tenant).Info("Cluster profile is valid")
+				return nil
+			}
+		}
+	}
+
+	log.WithError(err).Errorf("Konflux cluster %q and tenant %q don't own the cluster profile", cluster, tenant)
+	return fmt.Errorf("konflux cluster %q and tenant %q don't own the cluster profile %q", cluster, tenant, clusterProfileName)
+}
+
 func (r *reconciler) handleCreateProwJob(ctx context.Context, log *logrus.Entry, ec *ephemeralclusterv1.EphemeralCluster, observedStatus *ephemeralclusterv1.EphemeralClusterStatus) (reconcile.Result, error) {
+	log.Info("Starting the procedure to create a ProwJob")
+
+	if err := r.validateEphemeralCluster(log, ec); err != nil {
+		upsertCondition(observedStatus, ephemeralclusterv1.ProwJobCreating, ephemeralclusterv1.ConditionFalse, r.now(), ephemeralclusterv1.EphemeralClusterValidationFailureReason, err.Error())
+		observedStatus.Phase = ephemeralclusterv1.EphemeralClusterFailed
+		if updateErr := r.updateEphemeralClusterStatus(ctx, ec, observedStatus); updateErr != nil {
+			msg := utilerrors.NewAggregate([]error{updateErr, err}).Error()
+			return reconcile.Result{}, errors.New(msg)
+		}
+		return reconcile.Result{}, reconcile.TerminalError(fmt.Errorf("validate ephemeral cluster: %w", err))
+	}
+
 	pjsForEC := prowv1.ProwJobList{}
 	listOpts := []ctrlruntimeclient.ListOption{
 		ctrlruntimeclient.MatchingLabels{EphemeralClusterLabel: ec.Name},
@@ -362,7 +412,12 @@ func (r *reconciler) handleCreateProwJob(ctx context.Context, log *logrus.Entry,
 		log.Error(TooManyPJsBoundErrMsg)
 		upsertCondition(observedStatus, ephemeralclusterv1.ProwJobCreating, ephemeralclusterv1.ConditionFalse, r.now(), ephemeralclusterv1.TooManyProwJobsBoundReason, TooManyPJsBoundErrMsg)
 		observedStatus.Phase = ephemeralclusterv1.EphemeralClusterFailed
-		return reconcile.Result{}, reconcile.TerminalError(errors.New("too many ProwJobs associated"))
+		err := errors.New("too many ProwJobs associated")
+		if updateErr := r.updateEphemeralClusterStatus(ctx, ec, observedStatus); updateErr != nil {
+			msg := utilerrors.NewAggregate([]error{updateErr, err}).Error()
+			return reconcile.Result{}, errors.New(msg)
+		}
+		return reconcile.Result{}, reconcile.TerminalError(err)
 	}
 
 	// This is another case that should be very unlikely to happen. We expect this controller
@@ -378,7 +433,7 @@ func (r *reconciler) handleCreateProwJob(ctx context.Context, log *logrus.Entry,
 
 	log.Info("ProwJob doesn't exist, creating")
 	err := r.createProwJob(ctx, log, ec)
-	if updateErr := r.updateEphemeralCluster(ctx, ec); updateErr != nil {
+	if updateErr := r.updateEphemeralClusterWithStatus(ctx, ec); updateErr != nil {
 		msg := utilerrors.NewAggregate([]error{updateErr, err}).Error()
 		return reconcile.Result{}, errors.New(msg)
 	}
@@ -623,7 +678,9 @@ func (r *reconciler) updateEphemeralClusterStatus(ctx context.Context, ec *ephem
 
 	if !cmp.Equal(&ec.Status, observedStatus, cmpECStatusOpts...) {
 		ec.Status = *observedStatus
-		return r.updateEphemeralCluster(ctx, ec)
+		if err := r.masterClient.Status().Update(ctx, ec); err != nil {
+			return fmt.Errorf("update ephemeral cluster status: %w", err)
+		}
 	}
 	return nil
 }
@@ -632,6 +689,23 @@ func (r *reconciler) updateEphemeralCluster(ctx context.Context, ec *ephemeralcl
 	if err := r.masterClient.Update(ctx, ec); err != nil {
 		return fmt.Errorf("update ephemeral cluster: %w", err)
 	}
+	return nil
+}
+
+func (r *reconciler) updateEphemeralClusterWithStatus(ctx context.Context, ec *ephemeralclusterv1.EphemeralCluster) error {
+	// Save the status since the ec resource has the `status` subresource. The apiserver will
+	// persist only the `.spec` stanza and return object with the old status. This means
+	// we lose our status, therefore a deep copy here is needed.
+	ecStatus := ec.Status.DeepCopy()
+	if err := r.masterClient.Update(ctx, ec); err != nil {
+		return fmt.Errorf("update ephemeral cluster: %w", err)
+	}
+
+	ec.Status = *ecStatus
+	if err := r.masterClient.Status().Update(ctx, ec); err != nil {
+		return fmt.Errorf("update ephemeral cluster and status: %w", err)
+	}
+
 	return nil
 }
 
@@ -653,7 +727,7 @@ func (r *reconciler) createCredentialsSecret(
 		return fmt.Errorf("check credentials secret: %w", err)
 	}
 	if err == nil {
-		if !v1.IsControlledBy(&existing, ec) {
+		if !metav1.IsControlledBy(&existing, ec) {
 			return fmt.Errorf("credentials secret %s/%s exists but is not owned by ephemeralcluster %s (uid=%s)",
 				ec.Namespace, secretName, ec.Name, ec.UID)
 		}
@@ -661,7 +735,7 @@ func (r *reconciler) createCredentialsSecret(
 	}
 
 	secret := &corev1.Secret{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: ec.Namespace,
 		},

--- a/pkg/controller/ephemeralcluster/reconciler_test.go
+++ b/pkg/controller/ephemeralcluster/reconciler_test.go
@@ -13,7 +13,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -157,7 +156,24 @@ func TestCreateProwJob(t *testing.T) {
 
 	fakeRegistryAgent := fakeRegistryAgent{
 		clusterProfiles: map[string]*api.ClusterProfile{
-			"aws": {ClusterType: "aws"},
+			"aws": {
+				ClusterType: "aws",
+				Owners: []api.ClusterProfileOwners{{
+					Konflux: &api.ClusterProfileKonfluxOwner{
+						Tenant:           "ktenant",
+						ClustersResolved: []string{"kcluster"},
+					},
+				}},
+			},
+			"aws-2": {
+				ClusterType: "aws",
+				Owners: []api.ClusterProfileOwners{{
+					Konflux: &api.ClusterProfileKonfluxOwner{
+						Tenant:           "ktenant",
+						ClustersResolved: []string{"kcluster"},
+					},
+				}},
+			},
 		},
 	}
 
@@ -175,6 +191,10 @@ func TestCreateProwJob(t *testing.T) {
 			name: "An EphemeralCluster request creates a ProwJob",
 			ec: ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						ephemeralclusterv1.KonfluxClusterLabel: "kcluster",
+						ephemeralclusterv1.KonfluxTenantLabel:  "ktenant",
+					},
 					Namespace: "ns",
 					Name:      "ec",
 				},
@@ -216,32 +236,15 @@ func TestCreateProwJob(t *testing.T) {
 			name: "Invalid cluster profile",
 			ec: ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						ephemeralclusterv1.KonfluxClusterLabel: "foo",
+						ephemeralclusterv1.KonfluxTenantLabel:  "bar",
+					},
 					Namespace: "ns",
 					Name:      "ec",
 				},
 				Spec: ephemeralclusterv1.EphemeralClusterSpec{
 					CIOperator: ephemeralclusterv1.CIOperatorSpec{
-						BuildRootImage: &api.BuildRootImageConfiguration{
-							ImageStreamTagReference: &api.ImageStreamTagReference{
-								Namespace: "ocp",
-								Name:      "4.20",
-								Tag:       "cli",
-							},
-						},
-						BaseImages: map[string]api.ImageStreamTagReference{
-							"upi-installer": {
-								Namespace: "ocp",
-								Name:      "4.20",
-								Tag:       "upi-installer",
-							},
-						},
-						ExternalImages: map[string]api.ExternalImage{
-							"fedora": {Registry: "quay.io/fedora/fedora:43"},
-						},
-						Releases: map[string]api.UnresolvedRelease{
-							"initial": {Integration: &api.Integration{Name: "4.17", Namespace: "ocp"}},
-							"latest":  {Integration: &api.Integration{Name: "4.17", Namespace: "ocp"}},
-						},
 						Test: ephemeralclusterv1.TestSpec{
 							Workflow:       "test-workflow",
 							Env:            map[string]string{"foo": "bar"},
@@ -252,7 +255,31 @@ func TestCreateProwJob(t *testing.T) {
 			},
 			req:     reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "ec"}},
 			wantRes: reconcile.Result{},
-			wantErr: errors.New(`terminal error: generate jobs: new prowjob builder: resolve cluster profile "aws-2": cluster profile "aws-2" not found`),
+			wantErr: errors.New(`terminal error: validate ephemeral cluster: konflux cluster "foo" and tenant "bar" don't own the cluster profile "aws-2"`),
+		},
+		{
+			name: "Cluster profile is not set",
+			ec: ephemeralclusterv1.EphemeralCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						ephemeralclusterv1.KonfluxClusterLabel: "foo",
+						ephemeralclusterv1.KonfluxTenantLabel:  "bar",
+					},
+					Namespace: "ns",
+					Name:      "ec",
+				},
+				Spec: ephemeralclusterv1.EphemeralClusterSpec{
+					CIOperator: ephemeralclusterv1.CIOperatorSpec{
+						Test: ephemeralclusterv1.TestSpec{
+							Workflow: "test-workflow",
+							Env:      map[string]string{"foo": "bar"},
+						},
+					},
+				},
+			},
+			req:     reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "ec"}},
+			wantRes: reconcile.Result{},
+			wantErr: errors.New(`terminal error: validate ephemeral cluster: cluster profile has not been set`),
 		},
 		{
 			name: "Hive cluster request creates a ProwJob",
@@ -281,9 +308,8 @@ func TestCreateProwJob(t *testing.T) {
 							"fedora": {Registry: "quay.io/fedora/fedora:43"},
 						},
 						Test: ephemeralclusterv1.TestSpec{
-							Workflow:       "generic-claim",
-							Env:            map[string]string{"foo": "bar"},
-							ClusterProfile: "aws",
+							Workflow: "generic-claim",
+							Env:      map[string]string{"foo": "bar"},
 							ClusterClaim: &api.ClusterClaim{
 								As:           "claim",
 								Product:      "ocp",
@@ -305,6 +331,10 @@ func TestCreateProwJob(t *testing.T) {
 			name: "Handle invalid prow config",
 			ec: ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						ephemeralclusterv1.KonfluxClusterLabel: "kcluster",
+						ephemeralclusterv1.KonfluxTenantLabel:  "ktenant",
+					},
 					Namespace: "ns",
 					Name:      "ec",
 				},
@@ -315,7 +345,8 @@ func TestCreateProwJob(t *testing.T) {
 							"latest":  {Integration: &api.Integration{Name: "4.17", Namespace: "ocp"}},
 						},
 						Test: ephemeralclusterv1.TestSpec{
-							Workflow: "test-workflow",
+							Workflow:       "test-workflow",
+							ClusterProfile: "aws",
 						},
 					},
 				},
@@ -337,6 +368,10 @@ func TestCreateProwJob(t *testing.T) {
 			name: "Fail to create a ProwJob",
 			ec: ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						ephemeralclusterv1.KonfluxClusterLabel: "kcluster",
+						ephemeralclusterv1.KonfluxTenantLabel:  "ktenant",
+					},
 					Namespace: "ns",
 					Name:      "ec",
 				},
@@ -347,7 +382,8 @@ func TestCreateProwJob(t *testing.T) {
 							"latest":  {Integration: &api.Integration{Name: "4.17", Namespace: "ocp"}},
 						},
 						Test: ephemeralclusterv1.TestSpec{
-							Workflow: "test-workflow",
+							Workflow:       "test-workflow",
+							ClusterProfile: "aws",
 						},
 					},
 				},
@@ -366,13 +402,18 @@ func TestCreateProwJob(t *testing.T) {
 			name: "Invalid ci-operator configuration",
 			ec: ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						ephemeralclusterv1.KonfluxClusterLabel: "kcluster",
+						ephemeralclusterv1.KonfluxTenantLabel:  "ktenant",
+					},
 					Namespace: "ns",
 					Name:      "ec",
 				},
 				Spec: ephemeralclusterv1.EphemeralClusterSpec{
 					CIOperator: ephemeralclusterv1.CIOperatorSpec{
 						Test: ephemeralclusterv1.TestSpec{
-							Workflow: "test-workflow",
+							Workflow:       "test-workflow",
+							ClusterProfile: "aws",
 						},
 					},
 				},
@@ -385,13 +426,18 @@ func TestCreateProwJob(t *testing.T) {
 			name: "Invalid ci-operator configuration and fail to update EC",
 			ec: ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						ephemeralclusterv1.KonfluxClusterLabel: "kcluster",
+						ephemeralclusterv1.KonfluxTenantLabel:  "ktenant",
+					},
 					Namespace: "ns",
 					Name:      "ec",
 				},
 				Spec: ephemeralclusterv1.EphemeralClusterSpec{
 					CIOperator: ephemeralclusterv1.CIOperatorSpec{
 						Test: ephemeralclusterv1.TestSpec{
-							Workflow: "test-workflow",
+							Workflow:       "test-workflow",
+							ClusterProfile: "aws",
 						},
 					},
 				},
@@ -410,9 +456,18 @@ func TestCreateProwJob(t *testing.T) {
 			name: "Several PJ for the same EC raises an error",
 			ec: ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						ephemeralclusterv1.KonfluxClusterLabel: "kcluster",
+						ephemeralclusterv1.KonfluxTenantLabel:  "ktenant",
+					},
 					Namespace: "ns",
 					Name:      "ec",
 				},
+				Spec: ephemeralclusterv1.EphemeralClusterSpec{CIOperator: ephemeralclusterv1.CIOperatorSpec{
+					Test: ephemeralclusterv1.TestSpec{
+						ClusterProfile: "aws",
+					},
+				}},
 			},
 			pjs: []ctrlclient.Object{
 				&prowv1.ProwJob{ObjectMeta: metav1.ObjectMeta{
@@ -432,7 +487,19 @@ func TestCreateProwJob(t *testing.T) {
 		{
 			name: "PJ found but was not bound to the EC",
 			ec: ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "ec"},
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						ephemeralclusterv1.KonfluxClusterLabel: "kcluster",
+						ephemeralclusterv1.KonfluxTenantLabel:  "ktenant",
+					},
+					Namespace: "ns",
+					Name:      "ec",
+				},
+				Spec: ephemeralclusterv1.EphemeralClusterSpec{CIOperator: ephemeralclusterv1.CIOperatorSpec{
+					Test: ephemeralclusterv1.TestSpec{
+						ClusterProfile: "aws",
+					},
+				}},
 			},
 			pjs: []ctrlclient.Object{&prowv1.ProwJob{ObjectMeta: metav1.ObjectMeta{
 				Labels:    map[string]string{EphemeralClusterLabel: "ec"},
@@ -452,6 +519,7 @@ func TestCreateProwJob(t *testing.T) {
 
 			client := clientBldr.
 				WithObjects(&tc.ec).
+				WithStatusSubresource(&tc.ec).
 				WithScheme(scheme).
 				WithInterceptorFuncs(tc.interceptors).
 				Build()
@@ -1388,6 +1456,7 @@ func TestReconcile(t *testing.T) {
 
 			client := fake.NewClientBuilder().
 				WithObjects(tc.ec).
+				WithStatusSubresource(tc.ec).
 				WithObjects(tc.objs...).
 				WithScheme(scheme).
 				Build()
@@ -1442,7 +1511,7 @@ func TestReconcile(t *testing.T) {
 				if diff := cmp.Diff(tc.wantSecret.Data, gotSecret.Data); diff != "" {
 					t.Errorf("unexpected credentials secret data: %s", diff)
 				}
-				if !v1.IsControlledBy(&gotSecret, tc.ec) {
+				if !metav1.IsControlledBy(&gotSecret, tc.ec) {
 					t.Errorf("credentials secret %s/%s is not controlled by ephemeralcluster %s",
 						gotSecret.Namespace, gotSecret.Name, tc.ec.Name)
 				}
@@ -1555,6 +1624,7 @@ func TestDeleteProwJob(t *testing.T) {
 
 			bldr := fake.NewClientBuilder().
 				WithObjects(tc.ec).
+				WithStatusSubresource(tc.ec).
 				WithScheme(scheme)
 
 			if tc.pj != nil {

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
@@ -2,9 +2,12 @@ metadata:
   creationTimestamp: null
   finalizers:
   - ephemeralcluster.ci.openshift.io/dependent-prowjob
+  labels:
+    ephemeralcluster.ci.openshift.io/konflux-cluster: kcluster
+    ephemeralcluster.ci.openshift.io/konflux-tenant: ktenant
   name: ec
   namespace: ns
-  resourceVersion: "1000"
+  resourceVersion: "1001"
 spec:
   ciOperator:
     baseImages:

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Cluster_profile_is_not_set.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Cluster_profile_is_not_set.yaml
@@ -9,15 +9,13 @@ metadata:
 spec:
   ciOperator:
     test:
-      clusterProfile: aws-2
       env:
         foo: bar
       workflow: test-workflow
 status:
   conditions:
   - lastTransitionTime: "2025-04-02T12:12:12Z"
-    message: konflux cluster "foo" and tenant "bar" don't own the cluster profile
-      "aws-2"
+    message: cluster profile has not been set
     reason: EphemeralClusterValidationFailure
     status: "False"
     type: ProwJobCreating

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Fail_to_create_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Fail_to_create_a_ProwJob.yaml
@@ -1,8 +1,11 @@
 metadata:
   creationTimestamp: null
+  labels:
+    ephemeralcluster.ci.openshift.io/konflux-cluster: kcluster
+    ephemeralcluster.ci.openshift.io/konflux-tenant: ktenant
   name: ec
   namespace: ns
-  resourceVersion: "1000"
+  resourceVersion: "1001"
 spec:
   ciOperator:
     releases:
@@ -15,6 +18,7 @@ spec:
           name: "4.17"
           namespace: ocp
     test:
+      clusterProfile: aws
       workflow: test-workflow
 status:
   conditions:

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Handle_invalid_prow_config.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Handle_invalid_prow_config.yaml
@@ -1,8 +1,11 @@
 metadata:
   creationTimestamp: null
+  labels:
+    ephemeralcluster.ci.openshift.io/konflux-cluster: kcluster
+    ephemeralcluster.ci.openshift.io/konflux-tenant: ktenant
   name: ec
   namespace: ns
-  resourceVersion: "1000"
+  resourceVersion: "1001"
 spec:
   ciOperator:
     releases:
@@ -15,6 +18,7 @@ spec:
           name: "4.17"
           namespace: ocp
     test:
+      clusterProfile: aws
       workflow: test-workflow
 status:
   conditions:

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Hive_cluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Hive_cluster_request_creates_a_ProwJob.yaml
@@ -4,7 +4,7 @@ metadata:
   - ephemeralcluster.ci.openshift.io/dependent-prowjob
   name: ec
   namespace: ns
-  resourceVersion: "1000"
+  resourceVersion: "1001"
 spec:
   ciOperator:
     baseImages:
@@ -38,7 +38,6 @@ spec:
         product: ocp
         timeout: 0s
         version: "4.22"
-      clusterProfile: aws
       env:
         foo: bar
       workflow: generic-claim

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Invalid_ci_operator_configuration.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Invalid_ci_operator_configuration.yaml
@@ -1,11 +1,15 @@
 metadata:
   creationTimestamp: null
+  labels:
+    ephemeralcluster.ci.openshift.io/konflux-cluster: kcluster
+    ephemeralcluster.ci.openshift.io/konflux-tenant: ktenant
   name: ec
   namespace: ns
-  resourceVersion: "1000"
+  resourceVersion: "1001"
 spec:
   ciOperator:
     test:
+      clusterProfile: aws
       workflow: test-workflow
 status:
   conditions:

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Invalid_ci_operator_configuration_and_fail_to_update_EC.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Invalid_ci_operator_configuration_and_fail_to_update_EC.yaml
@@ -1,11 +1,15 @@
 metadata:
   creationTimestamp: null
+  labels:
+    ephemeralcluster.ci.openshift.io/konflux-cluster: kcluster
+    ephemeralcluster.ci.openshift.io/konflux-tenant: ktenant
   name: ec
   namespace: ns
   resourceVersion: "999"
 spec:
   ciOperator:
     test:
+      clusterProfile: aws
       workflow: test-workflow
 status:
   phase: ""

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_PJ_found_but_was_not_bound_to_the_EC.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_PJ_found_but_was_not_bound_to_the_EC.yaml
@@ -1,11 +1,15 @@
 metadata:
   creationTimestamp: null
+  labels:
+    ephemeralcluster.ci.openshift.io/konflux-cluster: kcluster
+    ephemeralcluster.ci.openshift.io/konflux-tenant: ktenant
   name: ec
   namespace: ns
   resourceVersion: "1000"
 spec:
   ciOperator:
-    test: {}
+    test:
+      clusterProfile: aws
 status:
   phase: ""
   prowJobId: pj

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Several_PJ_for_the_same_EC_raises_an_error.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Several_PJ_for_the_same_EC_raises_an_error.yaml
@@ -1,10 +1,20 @@
 metadata:
   creationTimestamp: null
+  labels:
+    ephemeralcluster.ci.openshift.io/konflux-cluster: kcluster
+    ephemeralcluster.ci.openshift.io/konflux-tenant: ktenant
   name: ec
   namespace: ns
-  resourceVersion: "999"
+  resourceVersion: "1000"
 spec:
   ciOperator:
-    test: {}
+    test:
+      clusterProfile: aws
 status:
-  phase: ""
+  conditions:
+  - lastTransitionTime: "2025-04-02T12:12:12Z"
+    message: Too many ProwJobs bound, this is a bug
+    reason: TooManyProwJobsBound
+    status: "False"
+    type: ProwJobCreating
+  phase: Failed

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Cluster_profile_is_not_set.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Cluster_profile_is_not_set.yaml
@@ -1,0 +1,2 @@
+items: []
+metadata: {}

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Hive_cluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Hive_cluster_request_creates_a_ProwJob.yaml
@@ -7,8 +7,6 @@ items:
       prow.k8s.io/job: ephemeralcluster-ci-org-repo-branch-cluster-provisioning
     creationTimestamp: null
     labels:
-      ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/ephemeral-cluster: ec
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -93,7 +91,6 @@ items:
                 version: "4.22"
               cron: '@yearly'
               steps:
-                cluster_profile: aws
                 env:
                   foo: bar
                 test:


### PR DESCRIPTION
Introduce a new policy on the EphemeralCluster objects that rely on cluster profile for provisioning a cluster:
- The cluster profile's owners list must contain the cluster and tenant pair the EphemeralCluster is coming from, or the request is considered invalid.
- If the cluster profile is not set at all, the EphemeralCluster request is rejected.