### PR TITLE
Remove the --cluster-profile-set-details flag from ci-operator-checkconfig

### DIFF
--- a/cmd/ci-operator-checkconfig/main.go
+++ b/cmd/ci-operator-checkconfig/main.go
@@ -40,14 +40,11 @@ func (o *options) parse() error {
 	var registryDir string
 	var profilesConfigPath string
 	var clusterClaimConfigPath string
-	var clusterProfileSetDetailsPath string
 
 	fs := flag.NewFlagSet("", flag.ExitOnError)
-
 	fs.StringVar(&registryDir, "registry", "", "Path to the step registry directory")
 	fs.StringVar(&profilesConfigPath, "cluster-profiles-config", "", "Path to the cluster profile config file")
 	fs.StringVar(&clusterClaimConfigPath, "cluster-claim-owners-config", "", "Path to the cluster claim owners config file")
-	fs.StringVar(&clusterProfileSetDetailsPath, "cluster-profile-set-details", "", "Path to the cluster profile set details file")
 	o.Options.Bind(fs)
 
 	if err := fs.Parse(os.Args[1:]); err != nil {


### PR DESCRIPTION
Not needed anymore since https://github.com/openshift/ci-tools/pull/5294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

`ci-operator-checkconfig` no longer accepts the `--cluster-profile-set-details` flag, reflecting that the extra cluster profile details are no longer needed after the upstream `ci-tools` changes. For CI operators, this is a cleanup-only change to the checkconfig CLI: the tool still supports the existing registry, cluster profiles config, and cluster claim owners config inputs, but without the removed flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->