### PR TITLE
DPTP-5001: fix(prpqr): set OauthTokenSecret on decoration config for private repos

### DIFF
--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -656,7 +656,7 @@ func (r *reconciler) generateProwjob(ciopConfig *api.ReleaseBuildConfiguration,
 			jobBaseGen.PodSpec.Add(prowgen.ShardArgs(shardCount, shardIndex))
 		}
 		if private {
-			jobBaseGen.PodSpec.Add(prowgen.GitHubToken(false))
+			jobBaseGen.PodSpec.Add(prowgen.GitHubToken(true))
 		}
 
 		// Avoid sharing when we run the same job multiple times.

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -686,6 +686,10 @@ func (r *reconciler) generateProwjob(ciopConfig *api.ReleaseBuildConfiguration,
 		periodic.DecorationConfig.Timeout = &prowv1.Duration{Duration: r.defaultAggregatorJobTimeout}
 		if private {
 			periodic.Hidden = true
+			periodic.DecorationConfig.OauthTokenSecret = &prowv1.OauthTokenSecret{
+				Key:  api.OauthTokenSecretKey,
+				Name: api.OauthTokenSecretName,
+			}
 		}
 		break
 	}

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_private_repo_aggregated_sets_aggregator_hidden.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_private_repo_aggregated_sets_aggregator_hidden.yaml
@@ -138,6 +138,9 @@
     agent: kubernetes
     cluster: build02
     decoration_config:
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
       skip_cloning: true
       timeout: 6h0m0s
     extra_refs:
@@ -241,6 +244,9 @@
     agent: kubernetes
     cluster: build02
     decoration_config:
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
       skip_cloning: true
       timeout: 6h0m0s
     extra_refs:

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_private_repo_aggregated_sets_aggregator_hidden.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_private_repo_aggregated_sets_aggregator_hidden.yaml
@@ -200,9 +200,6 @@
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: github-credentials-openshift-ci-robot-private-git-cloner
-        secret:
-          secretName: github-credentials-openshift-ci-robot-private-git-cloner
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
@@ -306,9 +303,6 @@
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: github-credentials-openshift-ci-robot-private-git-cloner
-        secret:
-          secretName: github-credentials-openshift-ci-robot-private-git-cloner
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_private_repo_sets_hidden_and_injects_credentials.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_private_repo_sets_hidden_and_injects_credentials.yaml
@@ -24,6 +24,9 @@
     agent: kubernetes
     cluster: build02
     decoration_config:
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
       skip_cloning: true
       timeout: 6h0m0s
     extra_refs:

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_private_repo_sets_hidden_and_injects_credentials.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_private_repo_sets_hidden_and_injects_credentials.yaml
@@ -85,9 +85,6 @@
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: github-credentials-openshift-ci-robot-private-git-cloner
-        secret:
-          secretName: github-credentials-openshift-ci-robot-private-git-cloner
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher


### PR DESCRIPTION
## Summary

- Set `OauthTokenSecret` on the ProwJob `DecorationConfig` when PRPQR targets a private repo, so Prow's clonerefs init container can authenticate when cloning `ExtraRefs`
- The existing `--oauth-token-path` volume mount only serves ci-operator's internal clones; clonerefs needs the decoration-level secret separately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated PRPQR-generated periodic ProwJobs for private repositories so the `clonerefs` init container can authenticate when cloning `extraRefs`. In `pkg/controller/prpqr_reconciler`, the private path now injects a GitHub token (`GitHubToken(true)`) for the generated periodic jobs and, critically, sets `spec.decoration_config.oauth_token_secret` (key `oauth`, name `github-credentials-openshift-ci-robot-private-git-cloner`) on the periodic decoration config. The jobs remain hidden (`spec.hidden: true`). Test fixtures were updated to use the decoration-level OAuth token secret and remove the previous explicit pod volume wiring for that secret.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->