### PR TITLE
feat(pod-scaler): log authoritative decrease apply audit

### DIFF
--- a/cmd/pod-scaler/admission.go
+++ b/cmd/pod-scaler/admission.go
@@ -969,6 +969,13 @@ func applyAuthoritativeLimitDecrease(recommended, configured *corev1.ResourceReq
 				}).Infof("authoritative %s decrease dry-run", target.resourceType)
 				continue
 			}
+			fieldLogger.WithFields(logrus.Fields{
+				"event":            "authoritative_decrease_applied",
+				"workloadClass":    workloadClass,
+				"set_to":           determined.String(),
+				"reduction_pct":    (1.0 - determined.AsApproximateFloat64()/configuredFloat) * 100,
+				"reduction_capped": reductionCapped,
+			}).Infof("authoritative %s decrease applied", target.resourceType)
 			(*target.configuredList)[field] = determined
 		}
 	}


### PR DESCRIPTION
Log `authoritative_decrease_applied` with `set_to` when authoritative mode mutates pod resources, matching dry-run audit fields for savings tracking.


```
> {"component":"pod-scaler admission","configured":"4","determined":"500m","event":"authoritative_decrease_applied","field":"cpu","level":"info","msg":"authoritative request decrease applied","reduction_capped":true,"reduction_pct":25,"resource":"request","set_to":"3","time":"2026-07-09T16:30:00Z","workloadClass":"prowjob","workloadName":"branch-ci-openshift-builder-release-4.12-images","workloadType":"build"}
> {"component":"pod-scaler admission","configured":"8Gi","determined":"2Gi","event":"authoritative_decrease_applied","field":"memory","level":"info","msg":"authoritative request decrease applied","reduction_capped":true,"reduction_pct":25,"resource":"request","set_to":"6Gi","time":"2026-07-09T16:30:00Z","workloadClass":"prowjob","workloadName":"branch-ci-openshift-console-release-4.12-images","workloadType":"build"}
```