### PR TITLE
Konflux: Get cluster and tenant from annotations

### DIFF
--- a/cmd/dptp-controller-manager/main.go
+++ b/cmd/dptp-controller-manager/main.go
@@ -117,9 +117,10 @@ type serviceAccountSecretRefresherOptions struct {
 }
 
 type ephemeralClusterProvisionerOptions struct {
-	pollingRaw  string
-	polling     time.Duration
-	cliISTagRef string
+	pollingRaw        string
+	polling           time.Duration
+	cliISTagRef       string
+	privilegedTenants flagutil.Strings
 }
 
 func newOpts() (*options, error) {
@@ -150,6 +151,7 @@ func newOpts() (*options, error) {
 	fs.StringVar(&opts.promotionReconcilerOptions.sinceRaw, "promotionReconcilerOptions.since", "360h", "The image stream tags to reconcile if it is younger than a relative duration like 5s, 2m, or 3h. Defaults to 360h, i.e., 15 days")
 	fs.StringVar(&opts.ephemeralClusterProvisinerOptions.pollingRaw, "ephemeralClusterProvisionerOptions.polling", "1m", "Set how often the reconciler checks for the ephemeral cluster before it gets provisioned.")
 	fs.StringVar(&opts.ephemeralClusterProvisinerOptions.cliISTagRef, "ephemeralClusterProvisionerOptions.cliISTagRef", "ocp/4.21:cli", "Set the cli image into the ci-operator base images in the form of `<namespace>/<name>:<tag>`. Defaults to `ocp/4.21:cli`.")
+	fs.Var(&opts.ephemeralClusterProvisinerOptions.privilegedTenants, "ephemeralClusterProvisionerOptions.privilegedTenants", "Konflux tenants that are allowed to use any cluster profile. Can be passed multiple times.")
 	fs.BoolVar(&opts.dryRun, "dry-run", true, "Whether to run the controller-manager with dry-run")
 	fs.StringVar(&opts.releaseRepoGitSyncPath, "release-repo-git-sync-path", "", "Path to release repository dir")
 	if err := fs.Parse(os.Args[1:]); err != nil {
@@ -552,7 +554,8 @@ func main() {
 		log := logrus.NewEntry(logrus.StandardLogger())
 		if err := ephemeralcluster.AddToManager(log, mgr, allManagers, configAgent, registryAgent,
 			ephemeralcluster.WithPolling(opts.ephemeralClusterProvisinerOptions.polling),
-			ephemeralcluster.WithCLIISTagRef(opts.ephemeralClusterProvisinerOptions.cliISTagRef)); err != nil {
+			ephemeralcluster.WithCLIISTagRef(opts.ephemeralClusterProvisinerOptions.cliISTagRef),
+			ephemeralcluster.WithPrivilegedTenants(opts.ephemeralClusterProvisinerOptions.privilegedTenants.Strings())); err != nil {
 			logrus.WithError(err).Fatalf("Failed to construct the %s controller", ephemeralcluster.ControllerName)
 		}
 	}

--- a/pkg/api/ephemeralcluster/v1/types.go
+++ b/pkg/api/ephemeralcluster/v1/types.go
@@ -19,8 +19,8 @@ const (
 	KubeconfigNotReadyMsg   = "kubeconfig not ready"
 	HiveSecretsNotReadyMsg  = "hive secrets not ready"
 
-	KonfluxClusterLabel = "ephemeralcluster.ci.openshift.io/konflux-cluster"
-	KonfluxTenantLabel  = "ephemeralcluster.ci.openshift.io/konflux-tenant"
+	KonfluxClusterAnnotation = "ephemeralcluster.ci.openshift.io/konflux-cluster"
+	KonfluxTenantAnnotation  = "ephemeralcluster.ci.openshift.io/konflux-tenant"
 )
 
 // EphemeralClusterCondition is a valid value for EphemeralClusterCondition.Type
@@ -76,14 +76,14 @@ type EphemeralCluster struct {
 }
 
 func (ec *EphemeralCluster) KonfluxCluster() string {
-	if value, ok := ec.Labels[KonfluxClusterLabel]; ok {
+	if value, ok := ec.Annotations[KonfluxClusterAnnotation]; ok {
 		return value
 	}
 	return ""
 }
 
 func (ec *EphemeralCluster) KonfluxTenant() string {
-	if value, ok := ec.Labels[KonfluxTenantLabel]; ok {
+	if value, ok := ec.Annotations[KonfluxTenantAnnotation]; ok {
 		return value
 	}
 	return ""

--- a/pkg/controller/ephemeralcluster/reconciler.go
+++ b/pkg/controller/ephemeralcluster/reconciler.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 	ctrlbldr "sigs.k8s.io/controller-runtime/pkg/builder"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -73,7 +74,8 @@ var (
 	}
 
 	defaultReconcilerOpts = reconcilerOptions{
-		polling: 3 * time.Second,
+		polling:           3 * time.Second,
+		privilegedTenants: sets.New[string](),
 	}
 
 	isTagRegexp = regexp.MustCompile(`(?P<Namespace>.+)/(?P<Name>.+)\:(?P<Tag>.+)`)
@@ -90,8 +92,9 @@ func (bc buildClients) forCluster(cluster string) (ctrlruntimeclient.Client, err
 }
 
 type reconcilerOptions struct {
-	polling     time.Duration
-	cliISTagRef string
+	polling           time.Duration
+	cliISTagRef       string
+	privilegedTenants sets.Set[string]
 }
 
 type ReconcilerOption func(*reconcilerOptions)
@@ -102,10 +105,17 @@ func WithPolling(polling time.Duration) ReconcilerOption {
 	}
 }
 
-// Set the image stream tag reference for the `cli` image in the form of `ocp/4.22:cli`.
+// WithCLIISTagRef sets the image stream tag reference for the `cli` image in the form of `ocp/4.22:cli`.
 func WithCLIISTagRef(isTagRef string) ReconcilerOption {
 	return func(o *reconcilerOptions) {
 		o.cliISTagRef = isTagRef
+	}
+}
+
+// WithPrivilegedTenants sets a list of tenants that are allowed to use any cluster profile.
+func WithPrivilegedTenants(tenants []string) ReconcilerOption {
+	return func(o *reconcilerOptions) {
+		o.privilegedTenants.Insert(tenants...)
 	}
 }
 
@@ -129,11 +139,12 @@ type reconciler struct {
 	prowConfigAgent        *prowconfig.Agent
 	clusterProfileResolver prowgen.ClusterProfileResolver
 	scheme                 *runtime.Scheme
+	cliISTagRef            api.ImageStreamTagReference
+	privilegedTenants      sets.Set[string]
 
 	// Mock for testing
-	now         func() time.Time
-	polling     func() time.Duration
-	cliISTagRef api.ImageStreamTagReference
+	now     func() time.Time
+	polling func() time.Duration
 }
 
 func ECPredicateFilter(object ctrlruntimeclient.Object) bool {
@@ -167,6 +178,7 @@ func AddToManager(log *logrus.Entry, mgr manager.Manager, allManagers map[string
 		now:                    time.Now,
 		polling:                func() time.Duration { return defaultReconcilerOpts.polling },
 		cliISTagRef:            cliISTagRef,
+		privilegedTenants:      defaultReconcilerOpts.privilegedTenants,
 	}
 
 	if err := ctrlbldr.ControllerManagedBy(mgr).
@@ -370,16 +382,23 @@ func (r *reconciler) validateEphemeralCluster(log *logrus.Entry, ec *ephemeralcl
 	}
 
 	cluster, tenant := ec.KonfluxCluster(), ec.KonfluxTenant()
+	log = log.WithField("cluster", cluster).WithField("tenant", tenant)
+
+	if r.privilegedTenants.Has(tenant) {
+		log.Warn("Cluster profile is valid and owned by a privileged tenant")
+		return nil
+	}
+
 	for _, owner := range clusterProfile.Owners {
 		if k := owner.Konflux; k != nil {
 			if tenant == k.Tenant && slices.Contains(k.ClustersResolved, cluster) {
-				log.WithField("cluster", cluster).WithField("tenant", tenant).Info("Cluster profile is valid")
+				log.Info("Cluster profile is valid")
 				return nil
 			}
 		}
 	}
 
-	log.WithError(err).Errorf("Konflux cluster %q and tenant %q don't own the cluster profile", cluster, tenant)
+	log.Error("Konflux cluster and tenant don't own this cluster profile")
 	return fmt.Errorf("konflux cluster %q and tenant %q don't own the cluster profile %q", cluster, tenant, clusterProfileName)
 }
 

--- a/pkg/controller/ephemeralcluster/reconciler_test.go
+++ b/pkg/controller/ephemeralcluster/reconciler_test.go
@@ -191,9 +191,9 @@ func TestCreateProwJob(t *testing.T) {
 			name: "An EphemeralCluster request creates a ProwJob",
 			ec: ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						ephemeralclusterv1.KonfluxClusterLabel: "kcluster",
-						ephemeralclusterv1.KonfluxTenantLabel:  "ktenant",
+					Annotations: map[string]string{
+						ephemeralclusterv1.KonfluxClusterAnnotation: "kcluster",
+						ephemeralclusterv1.KonfluxTenantAnnotation:  "ktenant",
 					},
 					Namespace: "ns",
 					Name:      "ec",
@@ -236,9 +236,9 @@ func TestCreateProwJob(t *testing.T) {
 			name: "Invalid cluster profile",
 			ec: ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						ephemeralclusterv1.KonfluxClusterLabel: "foo",
-						ephemeralclusterv1.KonfluxTenantLabel:  "bar",
+					Annotations: map[string]string{
+						ephemeralclusterv1.KonfluxClusterAnnotation: "foo",
+						ephemeralclusterv1.KonfluxTenantAnnotation:  "bar",
 					},
 					Namespace: "ns",
 					Name:      "ec",
@@ -261,9 +261,9 @@ func TestCreateProwJob(t *testing.T) {
 			name: "Cluster profile is not set",
 			ec: ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						ephemeralclusterv1.KonfluxClusterLabel: "foo",
-						ephemeralclusterv1.KonfluxTenantLabel:  "bar",
+					Annotations: map[string]string{
+						ephemeralclusterv1.KonfluxClusterAnnotation: "foo",
+						ephemeralclusterv1.KonfluxTenantAnnotation:  "bar",
 					},
 					Namespace: "ns",
 					Name:      "ec",
@@ -331,9 +331,9 @@ func TestCreateProwJob(t *testing.T) {
 			name: "Handle invalid prow config",
 			ec: ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						ephemeralclusterv1.KonfluxClusterLabel: "kcluster",
-						ephemeralclusterv1.KonfluxTenantLabel:  "ktenant",
+					Annotations: map[string]string{
+						ephemeralclusterv1.KonfluxClusterAnnotation: "kcluster",
+						ephemeralclusterv1.KonfluxTenantAnnotation:  "ktenant",
 					},
 					Namespace: "ns",
 					Name:      "ec",
@@ -368,9 +368,9 @@ func TestCreateProwJob(t *testing.T) {
 			name: "Fail to create a ProwJob",
 			ec: ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						ephemeralclusterv1.KonfluxClusterLabel: "kcluster",
-						ephemeralclusterv1.KonfluxTenantLabel:  "ktenant",
+					Annotations: map[string]string{
+						ephemeralclusterv1.KonfluxClusterAnnotation: "kcluster",
+						ephemeralclusterv1.KonfluxTenantAnnotation:  "ktenant",
 					},
 					Namespace: "ns",
 					Name:      "ec",
@@ -402,9 +402,9 @@ func TestCreateProwJob(t *testing.T) {
 			name: "Invalid ci-operator configuration",
 			ec: ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						ephemeralclusterv1.KonfluxClusterLabel: "kcluster",
-						ephemeralclusterv1.KonfluxTenantLabel:  "ktenant",
+					Annotations: map[string]string{
+						ephemeralclusterv1.KonfluxClusterAnnotation: "kcluster",
+						ephemeralclusterv1.KonfluxTenantAnnotation:  "ktenant",
 					},
 					Namespace: "ns",
 					Name:      "ec",
@@ -426,9 +426,9 @@ func TestCreateProwJob(t *testing.T) {
 			name: "Invalid ci-operator configuration and fail to update EC",
 			ec: ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						ephemeralclusterv1.KonfluxClusterLabel: "kcluster",
-						ephemeralclusterv1.KonfluxTenantLabel:  "ktenant",
+					Annotations: map[string]string{
+						ephemeralclusterv1.KonfluxClusterAnnotation: "kcluster",
+						ephemeralclusterv1.KonfluxTenantAnnotation:  "ktenant",
 					},
 					Namespace: "ns",
 					Name:      "ec",
@@ -456,9 +456,9 @@ func TestCreateProwJob(t *testing.T) {
 			name: "Several PJ for the same EC raises an error",
 			ec: ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						ephemeralclusterv1.KonfluxClusterLabel: "kcluster",
-						ephemeralclusterv1.KonfluxTenantLabel:  "ktenant",
+					Annotations: map[string]string{
+						ephemeralclusterv1.KonfluxClusterAnnotation: "kcluster",
+						ephemeralclusterv1.KonfluxTenantAnnotation:  "ktenant",
 					},
 					Namespace: "ns",
 					Name:      "ec",
@@ -488,9 +488,9 @@ func TestCreateProwJob(t *testing.T) {
 			name: "PJ found but was not bound to the EC",
 			ec: ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						ephemeralclusterv1.KonfluxClusterLabel: "kcluster",
-						ephemeralclusterv1.KonfluxTenantLabel:  "ktenant",
+					Annotations: map[string]string{
+						ephemeralclusterv1.KonfluxClusterAnnotation: "kcluster",
+						ephemeralclusterv1.KonfluxTenantAnnotation:  "ktenant",
 					},
 					Namespace: "ns",
 					Name:      "ec",

--- a/pkg/controller/ephemeralcluster/reconciler_test.go
+++ b/pkg/controller/ephemeralcluster/reconciler_test.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -194,6 +195,50 @@ func TestCreateProwJob(t *testing.T) {
 					Annotations: map[string]string{
 						ephemeralclusterv1.KonfluxClusterAnnotation: "kcluster",
 						ephemeralclusterv1.KonfluxTenantAnnotation:  "ktenant",
+					},
+					Namespace: "ns",
+					Name:      "ec",
+				},
+				Spec: ephemeralclusterv1.EphemeralClusterSpec{
+					CIOperator: ephemeralclusterv1.CIOperatorSpec{
+						BuildRootImage: &api.BuildRootImageConfiguration{
+							ImageStreamTagReference: &api.ImageStreamTagReference{
+								Namespace: "ocp",
+								Name:      "4.20",
+								Tag:       "cli",
+							},
+						},
+						BaseImages: map[string]api.ImageStreamTagReference{
+							"upi-installer": {
+								Namespace: "ocp",
+								Name:      "4.20",
+								Tag:       "upi-installer",
+							},
+						},
+						ExternalImages: map[string]api.ExternalImage{
+							"fedora": {Registry: "quay.io/fedora/fedora:43"},
+						},
+						Releases: map[string]api.UnresolvedRelease{
+							"initial": {Integration: &api.Integration{Name: "4.17", Namespace: "ocp"}},
+							"latest":  {Integration: &api.Integration{Name: "4.17", Namespace: "ocp"}},
+						},
+						Test: ephemeralclusterv1.TestSpec{
+							Workflow:       "test-workflow",
+							Env:            map[string]string{"foo": "bar"},
+							ClusterProfile: "aws",
+						},
+					},
+				},
+			},
+			req:     reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "ec"}},
+			wantRes: reconcile.Result{RequeueAfter: pollingTime},
+		},
+		{
+			name: "Privileged tenant",
+			ec: ephemeralclusterv1.EphemeralCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ephemeralclusterv1.KonfluxTenantAnnotation: "ktenant-privileged",
 					},
 					Namespace: "ns",
 					Name:      "ec",
@@ -538,6 +583,7 @@ func TestCreateProwJob(t *testing.T) {
 				newProwJob:             newProwJobFaker("foobar", fakeNow),
 				prowConfigAgent:        prowConfigAgent(pc),
 				clusterProfileResolver: clusterProfileResolverAdapter(&fakeRegistryAgent),
+				privilegedTenants:      sets.New("ktenant-privileged"),
 			}
 
 			gotRes, gotErr := r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.ec.Name, Namespace: tc.ec.Namespace}})

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
@@ -1,10 +1,10 @@
 metadata:
+  annotations:
+    ephemeralcluster.ci.openshift.io/konflux-cluster: kcluster
+    ephemeralcluster.ci.openshift.io/konflux-tenant: ktenant
   creationTimestamp: null
   finalizers:
   - ephemeralcluster.ci.openshift.io/dependent-prowjob
-  labels:
-    ephemeralcluster.ci.openshift.io/konflux-cluster: kcluster
-    ephemeralcluster.ci.openshift.io/konflux-tenant: ktenant
   name: ec
   namespace: ns
   resourceVersion: "1001"

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Cluster_profile_is_not_set.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Cluster_profile_is_not_set.yaml
@@ -1,8 +1,8 @@
 metadata:
-  creationTimestamp: null
-  labels:
+  annotations:
     ephemeralcluster.ci.openshift.io/konflux-cluster: foo
     ephemeralcluster.ci.openshift.io/konflux-tenant: bar
+  creationTimestamp: null
   name: ec
   namespace: ns
   resourceVersion: "1000"

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Fail_to_create_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Fail_to_create_a_ProwJob.yaml
@@ -1,8 +1,8 @@
 metadata:
-  creationTimestamp: null
-  labels:
+  annotations:
     ephemeralcluster.ci.openshift.io/konflux-cluster: kcluster
     ephemeralcluster.ci.openshift.io/konflux-tenant: ktenant
+  creationTimestamp: null
   name: ec
   namespace: ns
   resourceVersion: "1001"

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Handle_invalid_prow_config.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Handle_invalid_prow_config.yaml
@@ -1,8 +1,8 @@
 metadata:
-  creationTimestamp: null
-  labels:
+  annotations:
     ephemeralcluster.ci.openshift.io/konflux-cluster: kcluster
     ephemeralcluster.ci.openshift.io/konflux-tenant: ktenant
+  creationTimestamp: null
   name: ec
   namespace: ns
   resourceVersion: "1001"

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Invalid_ci_operator_configuration.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Invalid_ci_operator_configuration.yaml
@@ -1,8 +1,8 @@
 metadata:
-  creationTimestamp: null
-  labels:
+  annotations:
     ephemeralcluster.ci.openshift.io/konflux-cluster: kcluster
     ephemeralcluster.ci.openshift.io/konflux-tenant: ktenant
+  creationTimestamp: null
   name: ec
   namespace: ns
   resourceVersion: "1001"

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Invalid_ci_operator_configuration_and_fail_to_update_EC.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Invalid_ci_operator_configuration_and_fail_to_update_EC.yaml
@@ -1,8 +1,8 @@
 metadata:
-  creationTimestamp: null
-  labels:
+  annotations:
     ephemeralcluster.ci.openshift.io/konflux-cluster: kcluster
     ephemeralcluster.ci.openshift.io/konflux-tenant: ktenant
+  creationTimestamp: null
   name: ec
   namespace: ns
   resourceVersion: "999"

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Invalid_cluster_profile.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Invalid_cluster_profile.yaml
@@ -1,8 +1,8 @@
 metadata:
-  creationTimestamp: null
-  labels:
+  annotations:
     ephemeralcluster.ci.openshift.io/konflux-cluster: foo
     ephemeralcluster.ci.openshift.io/konflux-tenant: bar
+  creationTimestamp: null
   name: ec
   namespace: ns
   resourceVersion: "1000"

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_PJ_found_but_was_not_bound_to_the_EC.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_PJ_found_but_was_not_bound_to_the_EC.yaml
@@ -1,8 +1,8 @@
 metadata:
-  creationTimestamp: null
-  labels:
+  annotations:
     ephemeralcluster.ci.openshift.io/konflux-cluster: kcluster
     ephemeralcluster.ci.openshift.io/konflux-tenant: ktenant
+  creationTimestamp: null
   name: ec
   namespace: ns
   resourceVersion: "1000"

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Privileged_tenant.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Privileged_tenant.yaml
@@ -1,0 +1,48 @@
+metadata:
+  annotations:
+    ephemeralcluster.ci.openshift.io/konflux-tenant: ktenant-privileged
+  creationTimestamp: null
+  finalizers:
+  - ephemeralcluster.ci.openshift.io/dependent-prowjob
+  name: ec
+  namespace: ns
+  resourceVersion: "1001"
+spec:
+  ciOperator:
+    baseImages:
+      upi-installer:
+        name: "4.20"
+        namespace: ocp
+        tag: upi-installer
+    buildRoot:
+      image_stream_tag:
+        name: "4.20"
+        namespace: ocp
+        tag: cli
+    externalImages:
+      fedora:
+        name: ""
+        namespace: ""
+        registry: quay.io/fedora/fedora:43
+        tag: ""
+    releases:
+      initial:
+        integration:
+          name: "4.17"
+          namespace: ocp
+      latest:
+        integration:
+          name: "4.17"
+          namespace: ocp
+    test:
+      clusterProfile: aws
+      env:
+        foo: bar
+      workflow: test-workflow
+status:
+  conditions:
+  - lastTransitionTime: "2025-04-02T12:12:12Z"
+    status: "True"
+    type: ProwJobCreating
+  phase: Provisioning
+  prowJobId: foobar

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Several_PJ_for_the_same_EC_raises_an_error.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Several_PJ_for_the_same_EC_raises_an_error.yaml
@@ -1,8 +1,8 @@
 metadata:
-  creationTimestamp: null
-  labels:
+  annotations:
     ephemeralcluster.ci.openshift.io/konflux-cluster: kcluster
     ephemeralcluster.ci.openshift.io/konflux-tenant: ktenant
+  creationTimestamp: null
   name: ec
   namespace: ns
   resourceVersion: "1000"

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Privileged_tenant.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Privileged_tenant.yaml
@@ -1,0 +1,175 @@
+items:
+- apiVersion: prow.k8s.io/v1
+  kind: ProwJob
+  metadata:
+    annotations:
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: ephemeralcluster-ci-org-repo-branch-cluster-provisioning
+    creationTimestamp: null
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws
+      ci.openshift.io/ephemeral-cluster: ec
+      created-by-prow: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: ephemeralcluster-ci-org-repo-branch-cluster-provisioning
+      prow.k8s.io/type: periodic
+    name: foobar
+    namespace: ci
+    resourceVersion: "1"
+  spec:
+    agent: kubernetes
+    cluster: build01
+    decoration_config:
+      gcs_configuration:
+        default_org: org
+        default_repo: repo
+        path_strategy: single
+      skip_cloning: true
+      utility_images:
+        clonerefs: clonerefs
+        entrypoint: entrypoint
+        initupload: initupload
+        sidecar: sidecar
+    job: ephemeralcluster-ci-org-repo-branch-cluster-provisioning
+    namespace: ci
+    pod_spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=cluster-provisioning
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: UNRESOLVED_CONFIG
+          value: |
+            base_images:
+              upi-installer:
+                name: "4.20"
+                namespace: ocp
+                tag: upi-installer
+            build_root:
+              image_stream_tag:
+                name: "4.20"
+                namespace: ocp
+                tag: cli
+            external_images:
+              fedora:
+                name: ""
+                namespace: ""
+                registry: quay.io/fedora/fedora:43
+                tag: ""
+            releases:
+              initial:
+                integration:
+                  name: "4.17"
+                  namespace: ocp
+              latest:
+                integration:
+                  name: "4.17"
+                  namespace: ocp
+            resources:
+              '*':
+                limits:
+                  memory: 400Mi
+                requests:
+                  cpu: 200m
+            tests:
+            - as: cluster-provisioning
+              cron: '@yearly'
+              steps:
+                cluster_profile: aws
+                env:
+                  foo: bar
+                test:
+                - as: wait-test-complete
+                  commands: "set +e\n\n# This loop keeps the ephemeral cluster up and running
+                    and then waits for\n# a konflux test to complete. Once the test is done, the
+                    EphemeralCluster \n# controller creates a synthetic secret 'test-done-signal'
+                    into this ci-operator NS,\n# unbloking the workflow and starting the deprovisioning
+                    procedures.\n\n# This kubeconfig points to the ephemeral cluster. Unsetting
+                    it as we want to reach out to\n# the build farm cluster.\nunset KUBECONFIG\n\ni=0\nunexpected_err=0\nsecret='test-done-signal'\n\nwhile
+                    true; do\n    printf 'attempt %d\\n' $i\n\n    output=\"$(oc get secret/$secret
+                    2>&1)\"\n    if [ $? -eq 0 ]; then\n        printf 'secret found\\n'\n        break\n
+                    \   fi\n\n    # The sole error we expect to hit is 'not found'. Break the
+                    loop if we collect\n    # this many unexpected errors in a row.\n    if !
+                    $(grep -qF \"secrets \\\"$secret\\\" not found\" <<<\"$output\"); then\n        printf
+                    'unexpected error: %d\\n%s\\n' $unexpected_err \"$output\"\n\n        if [
+                    $unexpected_err -ge 3 ]; then\n            printf 'FAILURE: too many unexpected
+                    errors\\n' $unexpected_err\n            break\n        fi\n\n        unexpected_err=$((unexpected_err+1))\n
+                    \   else\n        unexpected_err=0\n    fi\n\n    i=$((i+1))\n    sleep 5s\ndone\n"
+                  from: cli
+                  resources:
+                    limits:
+                      memory: 100Mi
+                    requests:
+                      cpu: 10m
+                workflow: test-workflow
+            zz_generated_metadata:
+              branch: branch
+              org: org
+              repo: repo
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    prowjob_defaults:
+      tenant_id: GlobalDefaultID
+    type: periodic
+  status:
+    startTime: "2025-04-02T12:12:12Z"
+    state: scheduling
+metadata: {}


### PR DESCRIPTION
Konflux cluster and tenant information are stored into the `EphemeralCluster` annotations rather than labels, retrieve them from there then.
This PR also adds the "privileged tenants" feature: a list of powerful tenants that are allowed to use any cluster profile (this is especially useful for the Test Platform team in order to ease troubleshooting).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updates the ephemeral-cluster controller to read Konflux cluster and tenant identifiers from annotations, matching Kubernetes metadata usage and preserving cluster/tenant resolution.

Adds privileged-tenant support for operators: configured tenants can provision using any cluster profile, enabling troubleshooting workflows without normal tenant-to-cluster restrictions. Includes CLI configuration and coverage for privileged provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->