### PR TITLE
feat(pod-scaler): configurable peak usage for authoritative decrease

### DIFF
--- a/cmd/pod-scaler/admission.go
+++ b/cmd/pod-scaler/admission.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -64,7 +65,38 @@ func (c authoritativeConfig) anyDryRun() bool {
 	return c.cpuRequest.dryRun || c.cpuLimit.dryRun || c.memoryRequest.dryRun || c.memoryLimit.dryRun
 }
 
-func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Interface, kubeClient kubernetes.Interface, loaders map[string][]*cacheReloader, mutateResourceLimits bool, cpuCap int64, memoryCap string, cpuPriorityScheduling int64, percentageMeasured float64, measuredPodCPUIncrease float64, systemReservedCPU int64, authoritative authoritativeConfig, escalations *escalationServer, reporter results.PodScalerReporter) {
+type authoritativeDecreaseUsageBasis string
+
+const (
+	authoritativeDecreaseUsageP80  authoritativeDecreaseUsageBasis = "p80"
+	authoritativeDecreaseUsagePeak authoritativeDecreaseUsageBasis = "peak"
+)
+
+func parseAuthoritativeDecreaseUsageBasis(raw string) (authoritativeDecreaseUsageBasis, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "p80":
+		return authoritativeDecreaseUsageP80, nil
+	case "peak", "max":
+		return authoritativeDecreaseUsagePeak, nil
+	default:
+		return "", fmt.Errorf("unknown authoritative decrease usage basis %q", raw)
+	}
+}
+
+func usageForAuthoritativeDecrease(recommended corev1.ResourceRequirements, field corev1.ResourceName, basis authoritativeDecreaseUsageBasis) (resource.Quantity, bool) {
+	if basis == authoritativeDecreaseUsagePeak {
+		if peak, ok := recommended.Limits[field]; ok && !peak.IsZero() {
+			return peak, true
+		}
+	}
+	request, ok := recommended.Requests[field]
+	if !ok || request.IsZero() {
+		return resource.Quantity{}, false
+	}
+	return request, true
+}
+
+func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Interface, kubeClient kubernetes.Interface, loaders map[string][]*cacheReloader, mutateResourceLimits bool, cpuCap int64, memoryCap string, cpuPriorityScheduling int64, percentageMeasured float64, measuredPodCPUIncrease float64, systemReservedCPU int64, authoritative authoritativeConfig, authoritativeDecreaseUsage authoritativeDecreaseUsageBasis, escalations *escalationServer, reporter results.PodScalerReporter) {
 	logger := logrus.WithField("component", "pod-scaler admission")
 	logger.Infof("Initializing admission webhook server with %d loaders.", len(loaders))
 	if authoritative.anyDryRun() {
@@ -86,7 +118,7 @@ func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Int
 		Port:    port,
 		CertDir: certDir,
 	})
-	server.Register("/pods", &webhook.Admission{Handler: &podMutator{logger: logger, client: client, decoder: decoder, resources: resources, mutateResourceLimits: mutateResourceLimits, cpuCap: cpuCap, memoryCap: memoryCap, cpuPriorityScheduling: cpuPriorityScheduling, percentageMeasured: percentageMeasured, measuredPodCPUIncrease: measuredPodCPUIncrease, nodeCache: nodeCache, authoritative: authoritative, escalations: escalations, reporter: reporter}})
+	server.Register("/pods", &webhook.Admission{Handler: &podMutator{logger: logger, client: client, decoder: decoder, resources: resources, mutateResourceLimits: mutateResourceLimits, cpuCap: cpuCap, memoryCap: memoryCap, cpuPriorityScheduling: cpuPriorityScheduling, percentageMeasured: percentageMeasured, measuredPodCPUIncrease: measuredPodCPUIncrease, nodeCache: nodeCache, authoritative: authoritative, authoritativeDecreaseUsage: authoritativeDecreaseUsage, escalations: escalations, reporter: reporter}})
 	logger.Info("Serving admission webhooks.")
 	if err := server.Start(interrupts.Context()); err != nil {
 		logrus.WithError(err).Fatal("Failed to serve webhooks.")
@@ -94,20 +126,21 @@ func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Int
 }
 
 type podMutator struct {
-	logger                 *logrus.Entry
-	client                 buildclientv1.BuildV1Interface
-	resources              *resourceServer
-	mutateResourceLimits   bool
-	decoder                admission.Decoder
-	cpuCap                 int64
-	memoryCap              string
-	cpuPriorityScheduling  int64
-	percentageMeasured     float64
-	measuredPodCPUIncrease float64
-	nodeCache              *nodeAllocatableCache
-	authoritative          authoritativeConfig
-	escalations            *escalationServer
-	reporter               results.PodScalerReporter
+	logger                     *logrus.Entry
+	client                     buildclientv1.BuildV1Interface
+	resources                  *resourceServer
+	mutateResourceLimits       bool
+	decoder                    admission.Decoder
+	cpuCap                     int64
+	memoryCap                  string
+	cpuPriorityScheduling      int64
+	percentageMeasured         float64
+	measuredPodCPUIncrease     float64
+	nodeCache                  *nodeAllocatableCache
+	authoritative              authoritativeConfig
+	authoritativeDecreaseUsage authoritativeDecreaseUsageBasis
+	escalations                *escalationServer
+	reporter                   results.PodScalerReporter
 }
 
 func (m *podMutator) Handle(ctx context.Context, req admission.Request) admission.Response {
@@ -156,7 +189,7 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 		m.setMeasuredLabel(pod, false, logger)
 	}
 
-	mutatePodResources(pod, m.resources, m.mutateResourceLimits, m.cpuCap, m.memoryCap, isMeasured, m.nodeCache, m.measuredPodCPUIncrease, m.authoritative, m.escalations, m.reporter, logger)
+	mutatePodResources(pod, m.resources, m.mutateResourceLimits, m.cpuCap, m.memoryCap, isMeasured, m.nodeCache, m.measuredPodCPUIncrease, m.authoritative, m.authoritativeDecreaseUsage, m.escalations, m.reporter, logger)
 	m.addPriorityClass(pod)
 
 	marshaledPod, err := json.Marshal(pod)
@@ -364,7 +397,7 @@ func preventUnschedulableWithCaps(resources *corev1.ResourceRequirements, cpuCap
 	}
 }
 
-func mutatePodResources(pod *corev1.Pod, server *resourceServer, mutateResourceLimits bool, cpuCap int64, memoryCap string, isMeasured bool, nodeCache *nodeAllocatableCache, measuredPodCPUIncrease float64, authoritative authoritativeConfig, escalations *escalationServer, reporter results.PodScalerReporter, logger *logrus.Entry) {
+func mutatePodResources(pod *corev1.Pod, server *resourceServer, mutateResourceLimits bool, cpuCap int64, memoryCap string, isMeasured bool, nodeCache *nodeAllocatableCache, measuredPodCPUIncrease float64, authoritative authoritativeConfig, authoritativeDecreaseUsage authoritativeDecreaseUsageBasis, escalations *escalationServer, reporter results.PodScalerReporter, logger *logrus.Entry) {
 	workloadClass := pod.Labels[ciWorkloadLabel]
 
 	mutateResources := func(containers []corev1.Container) {
@@ -391,7 +424,7 @@ func mutatePodResources(pod *corev1.Pod, server *resourceServer, mutateResourceL
 					Limits:   corev1.ResourceList{},
 				}
 
-				// Take maximum CPU and memory from both
+				// Take maximum CPU and memory from both measured and unmeasured runs.
 				for _, resourceName := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
 					var maxRequest *resource.Quantity
 					if measuredExists && measuredResources.Requests != nil {
@@ -409,6 +442,23 @@ func mutatePodResources(pod *corev1.Pod, server *resourceServer, mutateResourceL
 					if maxRequest != nil {
 						resources.Requests[resourceName] = *maxRequest
 					}
+
+					var maxLimit *resource.Quantity
+					if measuredExists && measuredResources.Limits != nil {
+						if q, ok := measuredResources.Limits[resourceName]; ok {
+							maxLimit = &q
+						}
+					}
+					if unmeasuredExists && unmeasuredResources.Limits != nil {
+						if q, ok := unmeasuredResources.Limits[resourceName]; ok {
+							if maxLimit == nil || q.Cmp(*maxLimit) > 0 {
+								maxLimit = &q
+							}
+						}
+					}
+					if maxLimit != nil {
+						resources.Limits[resourceName] = *maxLimit
+					}
 				}
 			}
 
@@ -421,7 +471,7 @@ func mutatePodResources(pod *corev1.Pod, server *resourceServer, mutateResourceL
 					reconcileLimits(&containers[i].Resources)
 				}
 				applyFailureEscalation(&containers[i].Resources, workloadType, workloadName, escalations, logger)
-				applyAuthoritativeLimitDecrease(&resources, &containers[i].Resources, workloadName, workloadType, isMeasured, workloadClass, authoritative, escalations, logger)
+				applyAuthoritativeLimitDecrease(&resources, &containers[i].Resources, workloadName, workloadType, isMeasured, workloadClass, authoritative, authoritativeDecreaseUsage, escalations, logger)
 				if mutateResourceLimits && !authoritative.cpuLimit.apply {
 					if containers[i].Resources.Limits != nil {
 						delete(containers[i].Resources.Limits, corev1.ResourceCPU)
@@ -881,7 +931,7 @@ func storeEscalationIndex(cache Cache, index podscaler.EscalationIndex) error {
 	return context.DeadlineExceeded
 }
 
-func applyAuthoritativeLimitDecrease(recommended, configured *corev1.ResourceRequirements, workloadName, workloadType string, isMeasured bool, workloadClass string, authoritative authoritativeConfig, escalations *escalationServer, logger *logrus.Entry) {
+func applyAuthoritativeLimitDecrease(recommended, configured *corev1.ResourceRequirements, workloadName, workloadType string, isMeasured bool, workloadClass string, authoritative authoritativeConfig, authoritativeDecreaseUsage authoritativeDecreaseUsageBasis, escalations *escalationServer, logger *logrus.Entry) {
 	if isMeasured {
 		return
 	}
@@ -906,8 +956,8 @@ func applyAuthoritativeLimitDecrease(recommended, configured *corev1.ResourceReq
 			if field == corev1.ResourceMemory && memoryLevel > 0 {
 				continue
 			}
-			determined := recommended.Requests[field]
-			if determined.IsZero() {
+			determined, ok := usageForAuthoritativeDecrease(*recommended, field, authoritativeDecreaseUsage)
+			if !ok {
 				continue
 			}
 			if field == corev1.ResourceCPU {

--- a/cmd/pod-scaler/admission_test.go
+++ b/cmd/pod-scaler/admission_test.go
@@ -582,7 +582,7 @@ func TestMutatePodResources(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			original := testCase.pod.DeepCopy()
-			mutatePodResources(testCase.pod, testCase.server, testCase.mutateResourceLimits, 10, "20Gi", false, nil, 50.0, authoritativeConfig{}, nil, &defaultReporter, logrus.WithField("test", testCase.name))
+			mutatePodResources(testCase.pod, testCase.server, testCase.mutateResourceLimits, 10, "20Gi", false, nil, 50.0, authoritativeConfig{}, authoritativeDecreaseUsageP80, nil, &defaultReporter, logrus.WithField("test", testCase.name))
 			diff := cmp.Diff(original, testCase.pod)
 			// In some cases, cmp.Diff decides to use non-breaking spaces, and it's not
 			// particularly deterministic about this. We don't care.
@@ -647,7 +647,7 @@ func TestMutatePodResources_ciWorkloadLabelDoesNotBreakCacheLookup(t *testing.T)
 		},
 	}
 
-	mutatePodResources(pod, server, false, 10, "20Gi", false, nil, 50.0, authoritativeConfig{}, nil, &defaultReporter, logger)
+	mutatePodResources(pod, server, false, 10, "20Gi", false, nil, 50.0, authoritativeConfig{}, authoritativeDecreaseUsageP80, nil, &defaultReporter, logger)
 
 	got := pod.Spec.Containers[0].Resources.Requests.Cpu().MilliValue()
 	const want = 6000 // 5000m recommendation inflated by 1.2 in useOursIfLarger
@@ -948,6 +948,7 @@ func TestApplyAuthoritativeLimitDecrease(t *testing.T) {
 		name                   string
 		authoritative          authoritativeConfig
 		isMeasured             bool
+		usageBasis             authoritativeDecreaseUsageBasis
 		ours, theirs, expected corev1.ResourceRequirements
 	}{
 		{
@@ -1065,10 +1066,37 @@ func TestApplyAuthoritativeLimitDecrease(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:          "peak basis skips decrease when spike exceeds configured",
+			authoritative: authLegacyMemory(0.25),
+			usageBasis:    authoritativeDecreaseUsagePeak,
+			ours: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: *resource.NewQuantity(1e1, resource.BinarySI),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("7Gi"),
+				},
+			},
+			theirs: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+			},
+			expected: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			applyAuthoritativeLimitDecrease(&tc.ours, &tc.theirs, "test", "build", tc.isMeasured, "", tc.authoritative, nil, logrus.WithField("test", tc.name))
+			usageBasis := tc.usageBasis
+			if usageBasis == "" {
+				usageBasis = authoritativeDecreaseUsageP80
+			}
+			applyAuthoritativeLimitDecrease(&tc.ours, &tc.theirs, "test", "build", tc.isMeasured, "", tc.authoritative, usageBasis, nil, logrus.WithField("test", tc.name))
 			if diff := cmp.Diff(tc.theirs, tc.expected); diff != "" {
 				t.Errorf("unexpected resources: %s", diff)
 			}
@@ -1096,7 +1124,7 @@ func TestApplyAuthoritativeLimitDecrease_uncappedMemory(t *testing.T) {
 		},
 	}
 
-	applyAuthoritativeLimitDecrease(&ours, &theirs, "test", "build", false, "", authLegacyCPUAndMemory(0.25, 1.0), nil, logrus.WithField("test", t.Name()))
+	applyAuthoritativeLimitDecrease(&ours, &theirs, "test", "build", false, "", authLegacyCPUAndMemory(0.25, 1.0), authoritativeDecreaseUsageP80, nil, logrus.WithField("test", t.Name()))
 	if diff := cmp.Diff(theirs, expected); diff != "" {
 		t.Errorf("unexpected resources: %s", diff)
 	}
@@ -1125,7 +1153,7 @@ func TestApplyAuthoritativeLimitDecrease_dryRun(t *testing.T) {
 		},
 	}
 
-	applyAuthoritativeLimitDecrease(&ours, &theirs, "test", "build", false, "", authLegacyCPUDryRun(0.25), nil, logrus.WithField("test", t.Name()))
+	applyAuthoritativeLimitDecrease(&ours, &theirs, "test", "build", false, "", authLegacyCPUDryRun(0.25), authoritativeDecreaseUsageP80, nil, logrus.WithField("test", t.Name()))
 	if diff := cmp.Diff(theirs, expected); diff != "" {
 		t.Errorf("dry-run should not mutate resources: %s", diff)
 	}
@@ -1157,7 +1185,7 @@ func TestApplyAuthoritativeLimitDecrease_separateRequestLimitCaps(t *testing.T) 
 	applyAuthoritativeLimitDecrease(&ours, &theirs, "test", "build", false, "", authoritativeConfig{
 		cpuRequest: authPair(true, false, 0.25),
 		cpuLimit:   authPair(true, false, 1.0),
-	}, nil, logrus.WithField("test", t.Name()))
+	}, authoritativeDecreaseUsageP80, nil, logrus.WithField("test", t.Name()))
 	if diff := cmp.Diff(theirs, expected); diff != "" {
 		t.Errorf("unexpected resources: %s", diff)
 	}
@@ -1190,6 +1218,38 @@ func TestClampRequestsToLimits(t *testing.T) {
 	}
 }
 
+func TestParseAuthoritativeDecreaseUsageBasis(t *testing.T) {
+	testCases := []struct {
+		name    string
+		raw     string
+		want    authoritativeDecreaseUsageBasis
+		wantErr bool
+	}{
+		{name: "default empty", raw: "", want: authoritativeDecreaseUsageP80},
+		{name: "p80", raw: "p80", want: authoritativeDecreaseUsageP80},
+		{name: "peak", raw: "peak", want: authoritativeDecreaseUsagePeak},
+		{name: "max alias", raw: "max", want: authoritativeDecreaseUsagePeak},
+		{name: "invalid", raw: "invalid", wantErr: true},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseAuthoritativeDecreaseUsageBasis(tc.raw)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseAuthoritativeDecreaseUsageBasis(%q): %v", tc.raw, err)
+			}
+			if got != tc.want {
+				t.Fatalf("parseAuthoritativeDecreaseUsageBasis(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestApplyAuthoritativeLimitDecrease_skipsDuringEscalation(t *testing.T) {
 	ours := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
@@ -1210,7 +1270,7 @@ func TestApplyAuthoritativeLimitDecrease_skipsDuringEscalation(t *testing.T) {
 		},
 	}
 
-	applyAuthoritativeLimitDecrease(&ours, &theirs, "test", "build", false, "", authLegacyMemory(0.25), server, logrus.WithField("test", t.Name()))
+	applyAuthoritativeLimitDecrease(&ours, &theirs, "test", "build", false, "", authLegacyMemory(0.25), authoritativeDecreaseUsageP80, server, logrus.WithField("test", t.Name()))
 	want := *resource.NewQuantity(2e10, resource.BinarySI)
 	if diff := cmp.Diff(theirs, corev1.ResourceRequirements{
 		Limits:   corev1.ResourceList{corev1.ResourceMemory: want},

--- a/cmd/pod-scaler/main.go
+++ b/cmd/pod-scaler/main.go
@@ -92,6 +92,7 @@ type consumerOptions struct {
 	authoritativeCPULimitMaxReductionPercent      float64
 	authoritativeMemoryRequestMaxReductionPercent float64
 	authoritativeMemoryLimitMaxReductionPercent   float64
+	authoritativeDecreaseUsageBasis               string
 }
 
 func (o *consumerOptions) authoritativeConfig() authoritativeConfig {
@@ -152,6 +153,7 @@ func bindOptions(fs *flag.FlagSet) *options {
 	fs.Float64Var(&o.authoritativeMemoryRequestMaxReductionPercent, "authoritative-memory-request-max-reduction-percent", 1.0, "Maximum memory request reduction per admission in authoritative mode, as a fraction (0.25 = 25%, 1.0 = no cap).")
 	fs.Float64Var(&o.authoritativeMemoryLimitMaxReductionPercent, "authoritative-memory-limit-max-reduction-percent", 1.0, "Maximum memory limit reduction per admission in authoritative mode, as a fraction (0.25 = 25%, 1.0 = no cap).")
 	fs.Float64Var(&o.authoritativeMemoryLimitMaxReductionPercent, "authoritative-memory-max-reduction-percent", 1.0, "Deprecated: use --authoritative-memory-limit-max-reduction-percent.")
+	fs.StringVar(&o.authoritativeDecreaseUsageBasis, "pod-scaler-authoritative-decrease-usage-basis", "p80", "Usage basis for authoritative decreases before the 1.2x multiplier: p80 (default) or peak (histogram max/burst).")
 	fs.Float64Var(&o.failureEscalationFactor, "failure-escalation-factor", 1.5, "Multiplier applied per escalation level after OOM or CPU throttle (1.5 = 50% increase per level).")
 	fs.IntVar(&o.failureEscalationMaxLevel, "failure-escalation-max-level", 10, "Maximum escalation level tracked for a workload.")
 	fs.Float64Var(&o.cpuThrottleThreshold, "cpu-throttle-threshold", 0.25, "Minimum throttled/total CPU CFS period ratio to count as CPU deprived.")
@@ -205,6 +207,9 @@ func (o *options) validate() error {
 		}
 		if o.authoritativeMemoryLimitMaxReductionPercent < 0 || o.authoritativeMemoryLimitMaxReductionPercent > 1 {
 			return errors.New("--authoritative-memory-limit-max-reduction-percent must be between 0 and 1")
+		}
+		if _, err := parseAuthoritativeDecreaseUsageBasis(o.authoritativeDecreaseUsageBasis); err != nil {
+			return err
 		}
 		if err := o.resultsOptions.Validate(); err != nil {
 			return err
@@ -367,7 +372,12 @@ func mainAdmission(opts *options, cache Cache) {
 
 	escalations := newEscalationServer(cache, opts.failureEscalationFactor)
 
-	go admit(opts.port, opts.instrumentationOptions.HealthPort, opts.certDir, client, kubeClient, loaders(cache), opts.mutateResourceLimits, opts.cpuCap, opts.memoryCap, opts.cpuPriorityScheduling, opts.percentageMeasured, opts.measuredPodCPUIncrease, opts.systemReservedCPU, opts.authoritativeConfig(), escalations, reporter)
+	usageBasis, err := parseAuthoritativeDecreaseUsageBasis(opts.authoritativeDecreaseUsageBasis)
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to parse authoritative decrease usage basis.")
+	}
+
+	go admit(opts.port, opts.instrumentationOptions.HealthPort, opts.certDir, client, kubeClient, loaders(cache), opts.mutateResourceLimits, opts.cpuCap, opts.memoryCap, opts.cpuPriorityScheduling, opts.percentageMeasured, opts.measuredPodCPUIncrease, opts.systemReservedCPU, opts.authoritativeConfig(), usageBasis, escalations, reporter)
 }
 
 func loaders(cache Cache) map[string][]*cacheReloader {

--- a/cmd/pod-scaler/resources.go
+++ b/cmd/pod-scaler/resources.go
@@ -67,6 +67,36 @@ func quantileValueUsable(v float64) bool {
 	return !math.IsNaN(v) && !math.IsInf(v, 0) && v >= 0
 }
 
+const maxUsableUsageValue = float64(1 << 63)
+
+// recommendationPeakValue returns the histogram max (burst/spike usage).
+func recommendationPeakValue(hist *circonusllhist.Histogram) *float64 {
+	if hist.Count() == 0 {
+		return nil
+	}
+	v := hist.Max()
+	if !quantileValueUsable(v) || v >= maxUsableUsageValue {
+		return nil
+	}
+	return &v
+}
+
+func cpuPeakQuantityFromHistogram(hist *circonusllhist.Histogram) *resource.Quantity {
+	usage := recommendationPeakValue(hist)
+	if usage == nil {
+		return nil
+	}
+	return cpuQuantityFromCores(*usage)
+}
+
+func memoryPeakQuantityFromHistogram(hist *circonusllhist.Histogram) *resource.Quantity {
+	usage := recommendationPeakValue(hist)
+	if usage == nil {
+		return nil
+	}
+	return memoryQuantityFromBytes(*usage)
+}
+
 // recommendationValue returns usage in histogram-native units (cores for CPU, bytes for memory).
 // nil means there is no usable recommendation.
 func recommendationValue(hist *circonusllhist.Histogram, quantile float64) *float64 {
@@ -101,7 +131,7 @@ func memoryQuantityFromBytes(bytes float64) *resource.Quantity {
 	if !quantileValueUsable(bytes) {
 		return nil
 	}
-	if bytes > float64(math.MaxInt64) {
+	if bytes >= maxUsableUsageValue {
 		return nil
 	}
 	return resource.NewQuantity(int64(bytes), resource.BinarySI)
@@ -167,6 +197,16 @@ func (s *resourceServer) digestRecommendations(
 			}
 		}
 		s.byMetaData[meta].Requests[resource] = requests[resource]
+		switch resource {
+		case corev1.ResourceCPU:
+			if peak := cpuPeakQuantityFromHistogram(overall); peak != nil {
+				s.byMetaData[meta].Limits[resource] = *peak
+			}
+		case corev1.ResourceMemory:
+			if peak := memoryPeakQuantityFromHistogram(overall); peak != nil {
+				s.byMetaData[meta].Limits[resource] = *peak
+			}
+		}
 		metaLogger.Trace("unlocking for meta")
 		s.lock.Unlock()
 	}

--- a/cmd/pod-scaler/resources_test.go
+++ b/cmd/pod-scaler/resources_test.go
@@ -190,6 +190,112 @@ func TestMemoryRequestQuantityFromHistogram(t *testing.T) {
 	}
 }
 
+func TestRecommendationPeakValue(t *testing.T) {
+	testCases := []struct {
+		name        string
+		sampleCount int
+		sampleValue float64
+		spikeValue  float64
+		want        *float64
+	}{
+		{
+			name:        "peak reflects spike",
+			sampleCount: 20,
+			sampleValue: 0.5,
+			spikeValue:  5,
+			want:        ptr(5.1),
+		},
+		{
+			name: "empty histogram",
+		},
+		{
+			name:        "rejects int64 overflow boundary",
+			sampleCount: 1,
+			sampleValue: float64(1 << 63),
+		},
+		{
+			name:        "rejects negative",
+			sampleCount: 1,
+			sampleValue: -1,
+		},
+		{
+			name:        "rejects nan",
+			sampleCount: 1,
+			sampleValue: math.NaN(),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hist := circonusllhist.New()
+			for i := 0; i < tc.sampleCount; i++ {
+				if err := hist.RecordValue(tc.sampleValue); err != nil {
+					t.Fatalf("RecordValue: %v", err)
+				}
+			}
+			if tc.spikeValue != 0 {
+				if err := hist.RecordValue(tc.spikeValue); err != nil {
+					t.Fatalf("RecordValue spike: %v", err)
+				}
+			}
+			got := recommendationPeakValue(hist)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatalf("recommendationPeakValue differs from expected, diff:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCPUPeakQuantityFromHistogram(t *testing.T) {
+	cpuCap := *resource.NewQuantity(10, resource.DecimalSI)
+	hist := circonusllhist.New()
+	for i := 0; i < 20; i++ {
+		if err := hist.RecordValue(0.5); err != nil {
+			t.Fatalf("RecordValue: %v", err)
+		}
+	}
+	if err := hist.RecordValue(50); err != nil {
+		t.Fatalf("RecordValue spike: %v", err)
+	}
+	got := cpuPeakQuantityFromHistogram(hist)
+	want := cpuQuantityFromCores(*recommendationPeakValue(hist))
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("cpuPeakQuantityFromHistogram differs from expected, diff:\n%s", diff)
+	}
+	if got.Cmp(cpuCap) <= 0 {
+		t.Fatalf("peak quantity should exceed request cap %v, got %v", cpuCap, got)
+	}
+	capped := cpuRequestQuantityFromHistogram(hist, 0.8, cpuCap, logrus.WithField("test", t.Name()))
+	if capped != nil && capped.Cpu().Cmp(cpuCap) > 0 {
+		t.Fatalf("request helper should cap at %v, got %v", cpuCap, capped.Cpu())
+	}
+}
+
+func TestMemoryPeakQuantityFromHistogram(t *testing.T) {
+	memoryCap := resource.MustParse("20Gi")
+	hist := circonusllhist.New()
+	spikeBytes := float64(30 * 1024 * 1024 * 1024)
+	for i := 0; i < 20; i++ {
+		if err := hist.RecordValue(1e8); err != nil {
+			t.Fatalf("RecordValue: %v", err)
+		}
+	}
+	if err := hist.RecordValue(spikeBytes); err != nil {
+		t.Fatalf("RecordValue spike: %v", err)
+	}
+	got := memoryPeakQuantityFromHistogram(hist)
+	want := memoryQuantityFromBytes(*recommendationPeakValue(hist))
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("memoryPeakQuantityFromHistogram differs from expected, diff:\n%s", diff)
+	}
+	if got.Cmp(memoryCap) <= 0 {
+		t.Fatalf("peak quantity should exceed request cap %v, got %v", memoryCap, got)
+	}
+	capped := memoryRequestQuantityFromHistogram(hist, 0.8, memoryCap, logrus.WithField("test", t.Name()))
+	if capped != nil && capped.Memory().Cmp(memoryCap) > 0 {
+		t.Fatalf("request helper should cap at %v, got %v", memoryCap, capped.Memory())
+	}
+}
+
 func ptr(v float64) *float64 {
 	return &v
 }


### PR DESCRIPTION
Authoritative memory/CPU limit decreases now use histogram peak (max burst) instead of p80 when `--pod-scaler-authoritative-decrease-usage-basis=peak` is set, so the existing 1.2× multiplier accounts for compile spikes instead of steady-state usage only. Default remains `p80` for backward compatibility; release sets `peak` fleet-wide.

**Motivation:** After pod-scaler authoritative decrease rollout (~Jul 9), image builds started OOMing when memory limits were cut using p80 usage (e.g. 8Gi→6Gi) while Go compile briefly spiked higher.

**Example failure:** [pull-ci-openshift-karpenter-operator-main-images (PR #15)](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_karpenter_operator/15/pull-ci-openshift-karpenter-operator-main-images/2075602885705469952) — job history: https://prow.ci.openshift.org/job-history/gs/test-platform-results/pr-logs/directory/pull-ci-openshift-karpenter-operator-main-images

https://redhat-internal.slack.com/archives/CBN38N3MW/p1783705116856469


/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds a configurable usage basis for pod-scaler’s admission webhook when it computes authoritative CPU/memory *limit decreases*.

- **Component/behavior (`cmd/pod-scaler`)**: introduces `--pod-scaler-authoritative-decrease-usage-basis` (default **`p80`**; **`peak`** and **`max`** are treated equivalently). This controls which “determined” usage value is used **before** the existing **1.2×** safety multiplier.
- **What changes for operators**: with **`peak`**, authoritative decreases use **histogram peak (burst/max) usage** instead of the p80-derived value, so the 1.2× multiplier better covers short compile-time spikes and reduces the chance of undersizing memory/CPU.
- **Implementation notes**: pod-scaler now derives peak CPU/memory from usage histograms and populates it into the recommendation’s **resource limits**; the admission webhook selects either that peak-based quantity (**peak**) or the existing p80 request-based behavior (**p80**).
- **Safety/backward compatibility**: default remains **p80**; parsing/selection logic is covered by unit tests.
- **CI note**: author requested an end-to-end verification via **`/test e2e`**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->