### PR TITLE
DPTP-2938: add configurable skip for authoritative decrease by workload type

### DIFF
--- a/cmd/pod-scaler/admission.go
+++ b/cmd/pod-scaler/admission.go
@@ -19,6 +19,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -41,7 +42,6 @@ import (
 
 type authoritativePair struct {
 	apply        bool
-	dryRun       bool
 	maxReduction float64
 }
 
@@ -62,7 +62,7 @@ func (c authoritativeConfig) pair(field corev1.ResourceName, resourceType string
 }
 
 func (c authoritativeConfig) anyDryRun() bool {
-	return c.cpuRequest.dryRun || c.cpuLimit.dryRun || c.memoryRequest.dryRun || c.memoryLimit.dryRun
+	return !c.cpuRequest.apply || !c.cpuLimit.apply || !c.memoryRequest.apply || !c.memoryLimit.apply
 }
 
 type authoritativeDecreaseUsageBasis string
@@ -84,28 +84,79 @@ func parseAuthoritativeDecreaseUsageBasis(raw string) (authoritativeDecreaseUsag
 }
 
 func usageForAuthoritativeDecrease(recommended corev1.ResourceRequirements, field corev1.ResourceName, basis authoritativeDecreaseUsageBasis) (resource.Quantity, bool) {
+	request, hasRequest := recommended.Requests[field]
+	hasRequest = hasRequest && !request.IsZero()
+	peak, hasPeak := recommended.Limits[field]
+	hasPeak = hasPeak && !peak.IsZero()
+
 	if basis == authoritativeDecreaseUsagePeak {
-		if peak, ok := recommended.Limits[field]; ok && !peak.IsZero() {
+		switch {
+		case hasPeak && hasRequest:
+			if peak.Cmp(request) >= 0 {
+				return peak, true
+			}
+			return request, true
+		case hasPeak:
 			return peak, true
 		}
 	}
-	request, ok := recommended.Requests[field]
-	if !ok || request.IsZero() {
-		return resource.Quantity{}, false
+	if hasRequest {
+		return request, true
 	}
-	return request, true
+	return resource.Quantity{}, false
 }
 
-func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Interface, kubeClient kubernetes.Interface, loaders map[string][]*cacheReloader, mutateResourceLimits bool, cpuCap int64, memoryCap string, cpuPriorityScheduling int64, percentageMeasured float64, measuredPodCPUIncrease float64, systemReservedCPU int64, authoritative authoritativeConfig, authoritativeDecreaseUsage authoritativeDecreaseUsageBasis, escalations *escalationServer, reporter results.PodScalerReporter) {
+type authoritativeSkipConfig struct {
+	limitDecreaseWorkloadTypes     sets.Set[string]
+	limitDecreaseWorkloadClasses   sets.Set[string]
+	requestDecreaseWorkloadTypes   sets.Set[string]
+	requestDecreaseWorkloadClasses sets.Set[string]
+}
+
+func parseAuthoritativeSkipConfig(limitTypes, limitClasses, requestTypes, requestClasses string) authoritativeSkipConfig {
+	return authoritativeSkipConfig{
+		limitDecreaseWorkloadTypes:     parseCommaSeparatedSet(limitTypes),
+		limitDecreaseWorkloadClasses:   parseCommaSeparatedSet(limitClasses),
+		requestDecreaseWorkloadTypes:   parseCommaSeparatedSet(requestTypes),
+		requestDecreaseWorkloadClasses: parseCommaSeparatedSet(requestClasses),
+	}
+}
+
+func parseCommaSeparatedSet(raw string) sets.Set[string] {
+	out := sets.New[string]()
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out.Insert(part)
+		}
+	}
+	return out
+}
+
+func (c authoritativeSkipConfig) skipsLimitDecrease(workloadType, workloadClass string) bool {
+	if c.limitDecreaseWorkloadTypes.Has(workloadType) {
+		return true
+	}
+	return workloadClass != "" && c.limitDecreaseWorkloadClasses.Has(workloadClass)
+}
+
+func (c authoritativeSkipConfig) skipsRequestDecrease(workloadType, workloadClass string) bool {
+	if c.requestDecreaseWorkloadTypes.Has(workloadType) {
+		return true
+	}
+	return workloadClass != "" && c.requestDecreaseWorkloadClasses.Has(workloadClass)
+}
+
+func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Interface, kubeClient kubernetes.Interface, loaders map[string][]*cacheReloader, mutateResourceLimits bool, cpuCap int64, memoryCap string, cpuPriorityScheduling int64, percentageMeasured float64, measuredPodCPUIncrease float64, systemReservedCPU int64, authoritative authoritativeConfig, authoritativeDecreaseUsage authoritativeDecreaseUsageBasis, authoritativeSkip authoritativeSkipConfig, escalations *escalationServer, reporter results.PodScalerReporter) {
 	logger := logrus.WithField("component", "pod-scaler admission")
 	logger.Infof("Initializing admission webhook server with %d loaders.", len(loaders))
 	if authoritative.anyDryRun() {
 		logger.WithFields(logrus.Fields{
-			"authoritative_cpu_request_dry_run":    authoritative.cpuRequest.dryRun,
-			"authoritative_cpu_limit_dry_run":      authoritative.cpuLimit.dryRun,
-			"authoritative_memory_request_dry_run": authoritative.memoryRequest.dryRun,
-			"authoritative_memory_limit_dry_run":   authoritative.memoryLimit.dryRun,
-		}).Info("authoritative decrease dry-run enabled")
+			"authoritative_cpu_request_apply":    authoritative.cpuRequest.apply,
+			"authoritative_cpu_limit_apply":      authoritative.cpuLimit.apply,
+			"authoritative_memory_request_apply": authoritative.memoryRequest.apply,
+			"authoritative_memory_limit_apply":   authoritative.memoryLimit.apply,
+		}).Info("authoritative decrease dry-run enabled (apply=false)")
 	}
 	health := pjutil.NewHealthOnPort(healthPort)
 	resources := newResourceServer(loaders, health, cpuCap, memoryCap)
@@ -118,7 +169,7 @@ func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Int
 		Port:    port,
 		CertDir: certDir,
 	})
-	server.Register("/pods", &webhook.Admission{Handler: &podMutator{logger: logger, client: client, decoder: decoder, resources: resources, mutateResourceLimits: mutateResourceLimits, cpuCap: cpuCap, memoryCap: memoryCap, cpuPriorityScheduling: cpuPriorityScheduling, percentageMeasured: percentageMeasured, measuredPodCPUIncrease: measuredPodCPUIncrease, nodeCache: nodeCache, authoritative: authoritative, authoritativeDecreaseUsage: authoritativeDecreaseUsage, escalations: escalations, reporter: reporter}})
+	server.Register("/pods", &webhook.Admission{Handler: &podMutator{logger: logger, client: client, decoder: decoder, resources: resources, mutateResourceLimits: mutateResourceLimits, cpuCap: cpuCap, memoryCap: memoryCap, cpuPriorityScheduling: cpuPriorityScheduling, percentageMeasured: percentageMeasured, measuredPodCPUIncrease: measuredPodCPUIncrease, nodeCache: nodeCache, authoritative: authoritative, authoritativeDecreaseUsage: authoritativeDecreaseUsage, authoritativeSkip: authoritativeSkip, escalations: escalations, reporter: reporter}})
 	logger.Info("Serving admission webhooks.")
 	if err := server.Start(interrupts.Context()); err != nil {
 		logrus.WithError(err).Fatal("Failed to serve webhooks.")
@@ -139,6 +190,7 @@ type podMutator struct {
 	nodeCache                  *nodeAllocatableCache
 	authoritative              authoritativeConfig
 	authoritativeDecreaseUsage authoritativeDecreaseUsageBasis
+	authoritativeSkip          authoritativeSkipConfig
 	escalations                *escalationServer
 	reporter                   results.PodScalerReporter
 }
@@ -189,7 +241,7 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 		m.setMeasuredLabel(pod, false, logger)
 	}
 
-	mutatePodResources(pod, m.resources, m.mutateResourceLimits, m.cpuCap, m.memoryCap, isMeasured, m.nodeCache, m.measuredPodCPUIncrease, m.authoritative, m.authoritativeDecreaseUsage, m.escalations, m.reporter, logger)
+	mutatePodResources(pod, m.resources, m.mutateResourceLimits, m.cpuCap, m.memoryCap, isMeasured, m.nodeCache, m.measuredPodCPUIncrease, m.authoritative, m.authoritativeDecreaseUsage, m.authoritativeSkip, m.escalations, m.reporter, logger)
 	m.addPriorityClass(pod)
 
 	marshaledPod, err := json.Marshal(pod)
@@ -290,14 +342,189 @@ func mutatePodLabels(pod *corev1.Pod, build *buildv1.Build) {
 
 var authoritativeMinCPURequest = resource.MustParse("10m")
 
-// authoritativeMinMemoryLimit is the minimum memory value that can be written
-// to the cgroup v2 memory.max file.  The Linux kernel rejects any value below
-// 512 KiB, which causes CRI-O / kubelet to fail container creation.  We use
-// this as a floor when decreasing memory requests or limits.
-var authoritativeMinMemoryLimit = resource.MustParse("512Ki")
+// authoritativeMinMemoryLimit is the smallest memory request or limit pod-scaler will
+// stamp or retain. The Linux kernel rejects cgroup memory.max below 512 KiB; corrupt
+// cache idle-noise (e.g. 324 Ki entrypoint-wrapper stamps) can sit between that kernel
+// floor and values that can run CI work, so pod-scaler uses 1 MiB as the floor.
+var authoritativeMinMemoryLimit = resource.MustParse("1Mi")
+
+// maxIncreaseRatio is the largest allowed increase from configured to recommended
+// values in a single admission. Larger jumps are capped to this ratio so corrupt
+// cache spikes cannot stamp runaway requests while legitimate growth still progresses.
+const maxIncreaseRatio = 10.0
+
+func recommendationQuantityUsable(field corev1.ResourceName, q resource.Quantity) bool {
+	if q.IsZero() {
+		return false
+	}
+	switch field {
+	case corev1.ResourceCPU:
+		return q.Cmp(authoritativeMinCPURequest) >= 0
+	case corev1.ResourceMemory:
+		return q.Cmp(authoritativeMinMemoryLimit) >= 0
+	default:
+		return true
+	}
+}
+
+func increaseExceedsConfiguredThreshold(field corev1.ResourceName, determined, configured resource.Quantity) bool {
+	if configured.IsZero() || determined.IsZero() {
+		return false
+	}
+	if field == corev1.ResourceCPU {
+		return float64(determined.MilliValue()) > float64(configured.MilliValue())*maxIncreaseRatio
+	}
+	return float64(determined.Value()) > float64(configured.Value())*maxIncreaseRatio
+}
+
+func clampCorruptConfiguredQuantity(field corev1.ResourceName, resourceType string, configured, recommended, cpuCap, memoryCap resource.Quantity, authoritative authoritativeConfig) (resource.Quantity, bool) {
+	if recommended.IsZero() || configured.IsZero() {
+		return configured, false
+	}
+	if !increaseExceedsConfiguredThreshold(field, configured, recommended) {
+		return configured, false
+	}
+	if !recommendationQuantityUsable(field, recommended) {
+		return configured, false
+	}
+	clamped := cappedIncreaseQuantity(field, recommended, cpuCap, memoryCap)
+	if clamped.Cmp(configured) >= 0 {
+		return configured, false
+	}
+	if !authoritative.pair(field, resourceType).apply {
+		return configured, false
+	}
+	return clamped, true
+}
+
+func sanitizeCorruptConfiguredResources(configured, recommended *corev1.ResourceRequirements, cpuCap, memoryCap resource.Quantity, authoritative authoritativeConfig, logger *logrus.Entry) {
+	if configured == nil {
+		return
+	}
+	for _, pair := range []struct {
+		configuredList  *corev1.ResourceList
+		recommendedList corev1.ResourceList
+		resourceType    string
+	}{
+		{configuredList: &configured.Requests, recommendedList: recommended.Requests, resourceType: "request"},
+		{configuredList: &configured.Limits, recommendedList: recommended.Limits, resourceType: "limit"},
+	} {
+		if pair.configuredList == nil {
+			continue
+		}
+		for _, field := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+			q, ok := (*pair.configuredList)[field]
+			if !ok || q.IsZero() {
+				continue
+			}
+			cap := memoryCap
+			if field == corev1.ResourceCPU {
+				cap = cpuCap
+			}
+			if q.Cmp(cap) > 0 {
+				logger.WithFields(logrus.Fields{
+					"event":    "configured_resource_clamped",
+					"field":    field,
+					"resource": pair.resourceType,
+					"from":     q.String(),
+					"to":       cap.String(),
+				}).Warn("clamping previously stamped resource above cluster cap")
+				(*pair.configuredList)[field] = cap.DeepCopy()
+				q = (*pair.configuredList)[field]
+			}
+			recommendedValue, ok := pair.recommendedList[field]
+			if ok && !recommendedValue.IsZero() {
+				if clamped, changed := clampCorruptConfiguredQuantity(field, pair.resourceType, q, recommendedValue, cpuCap, memoryCap, authoritative); changed {
+					logger.WithFields(logrus.Fields{
+						"event":       "configured_resource_clamped",
+						"field":       field,
+						"resource":    pair.resourceType,
+						"from":        q.String(),
+						"to":          clamped.String(),
+						"recommended": recommendedValue.String(),
+					}).Warn("clamping previously stamped resource above recommendation threshold")
+					(*pair.configuredList)[field] = clamped
+					q = clamped
+				}
+			}
+			if field == corev1.ResourceMemory {
+				if raised, changed := raiseBelowMinimumMemory(q); changed {
+					logger.WithFields(logrus.Fields{
+						"event":    "configured_resource_clamped",
+						"field":    field,
+						"resource": pair.resourceType,
+						"from":     q.String(),
+						"to":       raised.String(),
+					}).Warn("raising previously stamped memory below usable minimum")
+					(*pair.configuredList)[field] = raised
+				}
+			}
+		}
+	}
+}
+
+func raiseBelowMinimumMemory(q resource.Quantity) (resource.Quantity, bool) {
+	if q.IsZero() || q.Cmp(authoritativeMinMemoryLimit) >= 0 {
+		return q, false
+	}
+	return authoritativeMinMemoryLimit.DeepCopy(), true
+}
+
+func enforceMinimumMemoryResources(resources *corev1.ResourceRequirements, logger *logrus.Entry) {
+	if resources == nil {
+		return
+	}
+	for _, pair := range []struct {
+		list         *corev1.ResourceList
+		resourceType string
+	}{
+		{list: &resources.Requests, resourceType: "request"},
+		{list: &resources.Limits, resourceType: "limit"},
+	} {
+		if pair.list == nil {
+			continue
+		}
+		q, ok := (*pair.list)[corev1.ResourceMemory]
+		if !ok || q.IsZero() {
+			continue
+		}
+		if raised, changed := raiseBelowMinimumMemory(q); changed {
+			logger.WithFields(logrus.Fields{
+				"event":    "configured_resource_clamped",
+				"field":    corev1.ResourceMemory,
+				"resource": pair.resourceType,
+				"from":     q.String(),
+				"to":       raised.String(),
+			}).Warn("raising memory below usable minimum")
+			(*pair.list)[corev1.ResourceMemory] = raised
+		}
+	}
+}
+
+func capQuantityToClusterMaximum(field corev1.ResourceName, q, cpuCap, memoryCap resource.Quantity) resource.Quantity {
+	cap := memoryCap
+	if field == corev1.ResourceCPU {
+		cap = cpuCap
+	}
+	if q.Cmp(cap) > 0 {
+		return cap.DeepCopy()
+	}
+	return q
+}
+
+func cappedIncreaseQuantity(field corev1.ResourceName, configured, cpuCap, memoryCap resource.Quantity) resource.Quantity {
+	capped := configured.DeepCopy()
+	switch field {
+	case corev1.ResourceCPU:
+		capped.SetMilli(int64(float64(configured.MilliValue()) * maxIncreaseRatio))
+	default:
+		capped.Set(int64(float64(configured.Value()) * maxIncreaseRatio))
+	}
+	return capQuantityToClusterMaximum(field, capped, cpuCap, memoryCap)
+}
 
 // useOursIfLarger updates fields in theirs when ours are larger.
-func useOursIfLarger(allOfOurs, allOfTheirs *corev1.ResourceRequirements, workloadName, workloadType string, isMeasured bool, workloadClass string, reporter results.PodScalerReporter, logger *logrus.Entry) {
+func useOursIfLarger(allOfOurs, allOfTheirs *corev1.ResourceRequirements, workloadName, workloadType string, isMeasured bool, workloadClass string, cpuCap, memoryCap resource.Quantity, reporter results.PodScalerReporter, logger *logrus.Entry) {
 	for _, item := range []*corev1.ResourceRequirements{allOfOurs, allOfTheirs} {
 		if item.Requests == nil {
 			item.Requests = corev1.ResourceList{}
@@ -336,13 +563,28 @@ func useOursIfLarger(allOfOurs, allOfTheirs *corev1.ResourceRequirements, worklo
 				"determined":   our.String(),
 				"configured":   their.String(),
 			})
+			if their.IsZero() {
+				fieldLogger.Debug("skipping mutation for unset configured resource")
+				continue
+			}
+			if !recommendationQuantityUsable(field, our) {
+				fieldLogger.WithField("event", "recommendation_increase_skipped").Debug("skipping increase below usable minimum")
+				continue
+			}
+			if increaseExceedsConfiguredThreshold(field, our, their) {
+				capped := cappedIncreaseQuantity(field, their, cpuCap, memoryCap)
+				fieldLogger = fieldLogger.WithFields(logrus.Fields{
+					"event":     "recommendation_increase_capped",
+					"capped_to": capped.String(),
+				})
+				fieldLogger.Warn("capping increase exceeding configured threshold")
+				reporter.ReportResourceConfigurationWarning(workloadName, workloadType, their.String(), our.String(), field.String(), isMeasured, workloadClass)
+				our = capped
+			}
 			cmp := our.Cmp(their)
 			if cmp == 1 {
 				fieldLogger.Debug("determined amount larger than configured")
 				(*pair.theirs)[field] = our
-				if their.Value() > 0 && our.Value() > (their.Value()*10) {
-					reporter.ReportResourceConfigurationWarning(workloadName, workloadType, their.String(), our.String(), field.String(), isMeasured, workloadClass)
-				}
 			} else if cmp < 0 {
 				fieldLogger.Debug("determined amount smaller than configured")
 				continue
@@ -382,28 +624,28 @@ func preventUnschedulable(resources *corev1.ResourceRequirements, cpuCap int64, 
 }
 
 func preventUnschedulableWithCaps(resources *corev1.ResourceRequirements, cpuCap, memoryCap resource.Quantity, logger *logrus.Entry) {
-	if resources.Requests == nil {
-		logger.Debug("no requests, skipping")
+	if resources == nil {
 		return
 	}
+	capResourceList(resources.Requests, cpuCap, memoryCap, "request", logger)
+	capResourceList(resources.Limits, cpuCap, memoryCap, "limit", logger)
+}
 
-	if _, ok := resources.Requests[corev1.ResourceCPU]; ok {
-		// TODO(DPTP-2525): Make cluster-specific?
-		if resources.Requests.Cpu().Cmp(cpuCap) == 1 {
-			logger.Debugf("setting original CPU request of: %s to cap", resources.Requests.Cpu())
-			resources.Requests[corev1.ResourceCPU] = cpuCap
-		}
+func capResourceList(list corev1.ResourceList, cpuCap, memoryCap resource.Quantity, kind string, logger *logrus.Entry) {
+	if list == nil {
+		return
 	}
-
-	if _, ok := resources.Requests[corev1.ResourceMemory]; ok {
-		if resources.Requests.Memory().Cmp(memoryCap) == 1 {
-			logger.Debugf("setting original memory request of: %s to cap", resources.Requests.Memory())
-			resources.Requests[corev1.ResourceMemory] = memoryCap
-		}
+	if q, ok := list[corev1.ResourceCPU]; ok && q.Cmp(cpuCap) == 1 {
+		logger.Debugf("setting original CPU %s of: %s to cap", kind, q.String())
+		list[corev1.ResourceCPU] = cpuCap
+	}
+	if q, ok := list[corev1.ResourceMemory]; ok && q.Cmp(memoryCap) == 1 {
+		logger.Debugf("setting original memory %s of: %s to cap", kind, q.String())
+		list[corev1.ResourceMemory] = memoryCap
 	}
 }
 
-func mutatePodResources(pod *corev1.Pod, server *resourceServer, mutateResourceLimits bool, cpuCap int64, memoryCap string, isMeasured bool, nodeCache *nodeAllocatableCache, measuredPodCPUIncrease float64, authoritative authoritativeConfig, authoritativeDecreaseUsage authoritativeDecreaseUsageBasis, escalations *escalationServer, reporter results.PodScalerReporter, logger *logrus.Entry) {
+func mutatePodResources(pod *corev1.Pod, server *resourceServer, mutateResourceLimits bool, cpuCap int64, memoryCap string, isMeasured bool, nodeCache *nodeAllocatableCache, measuredPodCPUIncrease float64, authoritative authoritativeConfig, authoritativeDecreaseUsage authoritativeDecreaseUsageBasis, authoritativeSkip authoritativeSkipConfig, escalations *escalationServer, reporter results.PodScalerReporter, logger *logrus.Entry) {
 	workloadClass := pod.Labels[ciWorkloadLabel]
 
 	mutateResources := func(containers []corev1.Container) {
@@ -472,12 +714,15 @@ func mutatePodResources(pod *corev1.Pod, server *resourceServer, mutateResourceL
 				logger.Debugf("recommendation exists for: %s (using max of measured and unmeasured)", containers[i].Name)
 				workloadType := determineWorkloadType(pod.Annotations, pod.Labels)
 				workloadName := determineWorkloadName(pod.Name, containers[i].Name, workloadType, pod.Labels)
-				useOursIfLarger(&resources, &containers[i].Resources, workloadName, workloadType, isMeasured, workloadClass, reporter, logger)
+				cpuCapQty := *resource.NewQuantity(cpuCap, resource.DecimalSI)
+				memoryCapQty := resource.MustParse(memoryCap)
+				sanitizeCorruptConfiguredResources(&containers[i].Resources, &resources, cpuCapQty, memoryCapQty, authoritative, logger)
+				useOursIfLarger(&resources, &containers[i].Resources, workloadName, workloadType, isMeasured, workloadClass, cpuCapQty, memoryCapQty, reporter, logger)
 				if mutateResourceLimits {
 					reconcileLimits(&containers[i].Resources)
 				}
 				applyFailureEscalation(&containers[i].Resources, workloadType, workloadName, escalations, logger)
-				applyAuthoritativeLimitDecrease(&resources, &containers[i].Resources, workloadName, workloadType, isMeasured, workloadClass, authoritative, authoritativeDecreaseUsage, escalations, logger)
+				applyAuthoritativeLimitDecrease(&resources, &containers[i].Resources, workloadName, workloadType, isMeasured, workloadClass, authoritative, authoritativeDecreaseUsage, authoritativeSkip, escalations, logger)
 				if mutateResourceLimits && !authoritative.cpuLimit.apply {
 					if containers[i].Resources.Limits != nil {
 						delete(containers[i].Resources.Limits, corev1.ResourceCPU)
@@ -485,6 +730,7 @@ func mutatePodResources(pod *corev1.Pod, server *resourceServer, mutateResourceL
 				}
 				clampRequestsToLimits(&containers[i].Resources)
 			}
+			enforceMinimumMemoryResources(&containers[i].Resources, logger)
 			preventUnschedulable(&containers[i].Resources, cpuCap, memoryCap, logger)
 		}
 	}
@@ -937,7 +1183,7 @@ func storeEscalationIndex(cache Cache, index podscaler.EscalationIndex) error {
 	return context.DeadlineExceeded
 }
 
-func applyAuthoritativeLimitDecrease(recommended, configured *corev1.ResourceRequirements, workloadName, workloadType string, isMeasured bool, workloadClass string, authoritative authoritativeConfig, authoritativeDecreaseUsage authoritativeDecreaseUsageBasis, escalations *escalationServer, logger *logrus.Entry) {
+func applyAuthoritativeLimitDecrease(recommended, configured *corev1.ResourceRequirements, workloadName, workloadType string, isMeasured bool, workloadClass string, authoritative authoritativeConfig, authoritativeDecreaseUsage authoritativeDecreaseUsageBasis, authoritativeSkip authoritativeSkipConfig, escalations *escalationServer, logger *logrus.Entry) {
 	if isMeasured {
 		return
 	}
@@ -956,6 +1202,12 @@ func applyAuthoritativeLimitDecrease(recommended, configured *corev1.ResourceReq
 			continue
 		}
 		for _, field := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+			if target.resourceType == "limit" && authoritativeSkip.skipsLimitDecrease(workloadType, workloadClass) {
+				continue
+			}
+			if target.resourceType == "request" && authoritativeSkip.skipsRequestDecrease(workloadType, workloadClass) {
+				continue
+			}
 			if field == corev1.ResourceCPU && cpuLevel > 0 {
 				continue
 			}
@@ -977,9 +1229,6 @@ func applyAuthoritativeLimitDecrease(recommended, configured *corev1.ResourceReq
 				continue
 			}
 			mode := authoritative.pair(field, target.resourceType)
-			if !mode.apply && !mode.dryRun {
-				continue
-			}
 			fieldLogger := logger.WithFields(logrus.Fields{
 				"workloadName": workloadName,
 				"workloadType": workloadType,
@@ -1024,12 +1273,11 @@ func applyAuthoritativeLimitDecrease(recommended, configured *corev1.ResourceReq
 					continue
 				}
 			}
-			if mode.dryRun {
+			if !mode.apply {
 				fieldLogger.WithFields(logrus.Fields{
 					"event":                "authoritative_decrease_dry_run",
 					"workloadClass":        workloadClass,
 					"would_set":            determined.String(),
-					"authoritative":        mode.apply,
 					"reduction_pct":        (1.0 - determined.AsApproximateFloat64()/configuredFloat) * 100,
 					"reduction_capped":     reductionCapped,
 					"memory_floor_applied": memoryFloorApplied,

--- a/cmd/pod-scaler/admission_test.go
+++ b/cmd/pod-scaler/admission_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/prow/pkg/kube"
@@ -30,31 +31,31 @@ import (
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
-func authPair(apply, dryRun bool, maxReduction float64) authoritativePair {
-	return authoritativePair{apply: apply, dryRun: dryRun, maxReduction: maxReduction}
+func authPair(apply bool, maxReduction float64) authoritativePair {
+	return authoritativePair{apply: apply, maxReduction: maxReduction}
 }
 
 func authLegacyCPU(maxReduction float64) authoritativeConfig {
-	p := authPair(true, false, maxReduction)
+	p := authPair(true, maxReduction)
 	return authoritativeConfig{cpuRequest: p, cpuLimit: p}
 }
 
 func authLegacyCPUAndMemory(maxCPU, maxMemory float64) authoritativeConfig {
 	return authoritativeConfig{
-		cpuRequest:    authPair(true, false, maxCPU),
-		cpuLimit:      authPair(true, false, maxCPU),
-		memoryRequest: authPair(true, false, maxMemory),
-		memoryLimit:   authPair(true, false, maxMemory),
+		cpuRequest:    authPair(true, maxCPU),
+		cpuLimit:      authPair(true, maxCPU),
+		memoryRequest: authPair(true, maxMemory),
+		memoryLimit:   authPair(true, maxMemory),
 	}
 }
 
 func authLegacyCPUDryRun(maxReduction float64) authoritativeConfig {
-	p := authPair(false, true, maxReduction)
+	p := authPair(false, maxReduction)
 	return authoritativeConfig{cpuRequest: p, cpuLimit: p}
 }
 
 func authLegacyMemory(maxReduction float64) authoritativeConfig {
-	p := authPair(true, false, maxReduction)
+	p := authPair(true, maxReduction)
 	return authoritativeConfig{memoryRequest: p, memoryLimit: p}
 }
 
@@ -68,6 +69,11 @@ func (r *mockReporter) ReportResourceConfigurationWarning(string, string, string
 }
 
 var defaultReporter = mockReporter{client: &http.Client{}}
+
+var (
+	testClusterCPUCap    = *resource.NewQuantity(10, resource.DecimalSI)
+	testClusterMemoryCap = resource.MustParse("20Gi")
+)
 
 func TestMutatePods(t *testing.T) {
 	client := fakebuildv1client.NewSimpleClientset(
@@ -582,7 +588,7 @@ func TestMutatePodResources(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			original := testCase.pod.DeepCopy()
-			mutatePodResources(testCase.pod, testCase.server, testCase.mutateResourceLimits, 10, "20Gi", false, nil, 50.0, authoritativeConfig{}, authoritativeDecreaseUsageP80, nil, &defaultReporter, logrus.WithField("test", testCase.name))
+			mutatePodResources(testCase.pod, testCase.server, testCase.mutateResourceLimits, 10, "20Gi", false, nil, 50.0, authoritativeConfig{}, authoritativeDecreaseUsageP80, authoritativeSkipConfig{}, nil, &defaultReporter, logrus.WithField("test", testCase.name))
 			diff := cmp.Diff(original, testCase.pod)
 			// In some cases, cmp.Diff decides to use non-breaking spaces, and it's not
 			// particularly deterministic about this. We don't care.
@@ -647,10 +653,10 @@ func TestMutatePodResources_ciWorkloadLabelDoesNotBreakCacheLookup(t *testing.T)
 		},
 	}
 
-	mutatePodResources(pod, server, false, 10, "20Gi", false, nil, 50.0, authoritativeConfig{}, authoritativeDecreaseUsageP80, nil, &defaultReporter, logger)
+	mutatePodResources(pod, server, false, 10, "20Gi", false, nil, 50.0, authoritativeConfig{}, authoritativeDecreaseUsageP80, authoritativeSkipConfig{}, nil, &defaultReporter, logger)
 
 	got := pod.Spec.Containers[0].Resources.Requests.Cpu().MilliValue()
-	const want = 6000 // 5000m recommendation inflated by 1.2 in useOursIfLarger
+	const want = 1000 // 10x cap from 100m configured; raw 5000m*1.2 would exceed threshold
 	if got != want {
 		t.Fatalf("CPU request = %dm, want %dm", got, want)
 	}
@@ -681,14 +687,8 @@ func TestUseOursIfLarger(t *testing.T) {
 				},
 			},
 			expected: corev1.ResourceRequirements{
-				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    *resource.NewQuantity(240, resource.DecimalSI),
-					corev1.ResourceMemory: *resource.NewQuantity(36e9, resource.BinarySI),
-				},
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    *resource.NewQuantity(120, resource.DecimalSI),
-					corev1.ResourceMemory: *resource.NewQuantity(24e9, resource.BinarySI),
-				},
+				Requests: corev1.ResourceList{},
+				Limits:   corev1.ResourceList{},
 			},
 		},
 		{
@@ -715,36 +715,93 @@ func TestUseOursIfLarger(t *testing.T) {
 			},
 		},
 		{
-			name: "nothing in theirs is larger",
+			name: "modest increase applied when below threshold",
 			ours: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
 					corev1.ResourceCPU:    *resource.NewQuantity(200, resource.DecimalSI),
-					corev1.ResourceMemory: *resource.NewQuantity(3e10, resource.BinarySI),
+					corev1.ResourceMemory: *resource.NewQuantity(3e9, resource.BinarySI),
 				},
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    *resource.NewQuantity(100, resource.DecimalSI),
-					corev1.ResourceMemory: *resource.NewQuantity(2e10, resource.BinarySI),
+					corev1.ResourceMemory: *resource.NewQuantity(2e9, resource.BinarySI),
 				},
 			},
 			theirs: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    *resource.NewQuantity(10, resource.DecimalSI),
-					corev1.ResourceMemory: *resource.NewQuantity(1e1, resource.BinarySI),
+					corev1.ResourceCPU:    *resource.NewQuantity(180, resource.DecimalSI),
+					corev1.ResourceMemory: *resource.NewQuantity(25e8, resource.BinarySI),
 				},
 				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    *resource.NewQuantity(10, resource.DecimalSI),
-					corev1.ResourceMemory: *resource.NewQuantity(1e1, resource.BinarySI),
+					corev1.ResourceCPU:    *resource.NewQuantity(90, resource.DecimalSI),
+					corev1.ResourceMemory: *resource.NewQuantity(15e8, resource.BinarySI),
 				},
 			},
 			expected: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
 					corev1.ResourceCPU:    *resource.NewQuantity(240, resource.DecimalSI),
-					corev1.ResourceMemory: *resource.NewQuantity(36e9, resource.BinarySI),
+					corev1.ResourceMemory: *resource.NewQuantity(36e8, resource.BinarySI),
 				},
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    *resource.NewQuantity(120, resource.DecimalSI),
-					corev1.ResourceMemory: *resource.NewQuantity(24e9, resource.BinarySI),
+					corev1.ResourceMemory: *resource.NewQuantity(24e8, resource.BinarySI),
 				},
+			},
+		},
+		{
+			name: "excessive increase capped",
+			ours: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: *resource.NewQuantity(2e10, resource.BinarySI),
+				},
+			},
+			theirs: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: *resource.NewQuantity(1e1, resource.BinarySI),
+				},
+			},
+			expected: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: *resource.NewQuantity(1e2, resource.BinarySI),
+				},
+				Limits: corev1.ResourceList{},
+			},
+		},
+		{
+			name: "corrupt spike capped at cluster maximum",
+			ours: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: *resource.NewQuantity(500*1024*1024*1024, resource.BinarySI),
+				},
+			},
+			theirs: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("3Gi"),
+				},
+			},
+			expected: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: testClusterMemoryCap,
+				},
+				Limits: corev1.ResourceList{},
+			},
+		},
+		{
+			name: "increase below cgroup minimum skipped",
+			ours: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: *resource.NewQuantity(200000, resource.BinarySI),
+				},
+			},
+			theirs: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: *resource.NewQuantity(1e6, resource.BinarySI),
+				},
+			},
+			expected: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: *resource.NewQuantity(1e6, resource.BinarySI),
+				},
+				Limits: corev1.ResourceList{},
 			},
 		},
 		{
@@ -808,15 +865,34 @@ func TestUseOursIfLarger(t *testing.T) {
 					corev1.ResourceMemory: *resource.NewQuantity(3e10, resource.BinarySI),
 				},
 				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    *resource.NewQuantity(1200, resource.DecimalSI),
+					corev1.ResourceCPU:    *resource.NewQuantity(100, resource.DecimalSI),
 					corev1.ResourceMemory: *resource.NewQuantity(48e9, resource.BinarySI),
 				},
+			},
+		},
+		{
+			name: "unset configured resources are not mutated",
+			ours: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: *resource.NewQuantity(270000, resource.BinarySI),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: *resource.NewQuantity(270000, resource.BinarySI),
+				},
+			},
+			theirs: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{},
+				Limits:   corev1.ResourceList{},
+			},
+			expected: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{},
+				Limits:   corev1.ResourceList{},
 			},
 		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			useOursIfLarger(&testCase.ours, &testCase.theirs, "test", "build", false, "", &defaultReporter, logrus.WithField("test", testCase.name))
+			useOursIfLarger(&testCase.ours, &testCase.theirs, "test", "build", false, "", testClusterCPUCap, testClusterMemoryCap, &defaultReporter, logrus.WithField("test", testCase.name))
 			if diff := cmp.Diff(testCase.theirs, testCase.expected); diff != "" {
 				t.Errorf("%s: got incorrect resources after mutation: %v", testCase.name, diff)
 			}
@@ -935,7 +1011,7 @@ func TestUseOursIfLarger_authoritative(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			useOursIfLarger(&tc.ours, &tc.theirs, "test", "build", tc.isMeasured, "", &defaultReporter, logrus.WithField("test", tc.name))
+			useOursIfLarger(&tc.ours, &tc.theirs, "test", "build", tc.isMeasured, "", testClusterCPUCap, testClusterMemoryCap, &defaultReporter, logrus.WithField("test", tc.name))
 			if diff := cmp.Diff(tc.theirs, tc.expected); diff != "" {
 				t.Errorf("unexpected resources: %s", diff)
 			}
@@ -1090,7 +1166,7 @@ func TestApplyAuthoritativeLimitDecrease(t *testing.T) {
 			},
 		},
 		{
-			name:          "memory limit decrease never below cgroup v2 minimum",
+			name:          "memory limit decrease never below usable minimum",
 			authoritative: authLegacyMemory(1.0),
 			ours: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
@@ -1099,7 +1175,7 @@ func TestApplyAuthoritativeLimitDecrease(t *testing.T) {
 			},
 			theirs: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
-					corev1.ResourceMemory: *resource.NewQuantity(1e6, resource.BinarySI),
+					corev1.ResourceMemory: resource.MustParse("2Mi"),
 				},
 			},
 			expected: corev1.ResourceRequirements{
@@ -1109,7 +1185,7 @@ func TestApplyAuthoritativeLimitDecrease(t *testing.T) {
 			},
 		},
 		{
-			name:          "memory request decrease never below cgroup v2 minimum",
+			name:          "memory request decrease never below usable minimum",
 			authoritative: authLegacyMemory(1.0),
 			ours: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
@@ -1118,7 +1194,7 @@ func TestApplyAuthoritativeLimitDecrease(t *testing.T) {
 			},
 			theirs: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
-					corev1.ResourceMemory: *resource.NewQuantity(1e6, resource.BinarySI),
+					corev1.ResourceMemory: resource.MustParse("2Mi"),
 				},
 			},
 			expected: corev1.ResourceRequirements{
@@ -1128,7 +1204,7 @@ func TestApplyAuthoritativeLimitDecrease(t *testing.T) {
 			},
 		},
 		{
-			name:          "memory limit exactly at cgroup v2 minimum stays unchanged",
+			name:          "memory limit exactly at usable minimum stays unchanged",
 			authoritative: authLegacyMemory(1.0),
 			ours: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
@@ -1147,7 +1223,7 @@ func TestApplyAuthoritativeLimitDecrease(t *testing.T) {
 			},
 		},
 		{
-			name:          "normal memory limit decrease is unaffected by cgroup v2 floor",
+			name:          "normal memory limit decrease is unaffected by usable memory floor",
 			authoritative: authLegacyCPUAndMemory(0.25, 0.25),
 			ours: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
@@ -1169,7 +1245,7 @@ func TestApplyAuthoritativeLimitDecrease(t *testing.T) {
 			},
 		},
 		{
-			name:          "cpu decrease unchanged by memory cgroup v2 floor",
+			name:          "cpu decrease unchanged by usable memory floor",
 			authoritative: authLegacyCPU(0.25),
 			ours: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
@@ -1194,7 +1270,7 @@ func TestApplyAuthoritativeLimitDecrease(t *testing.T) {
 			if usageBasis == "" {
 				usageBasis = authoritativeDecreaseUsageP80
 			}
-			applyAuthoritativeLimitDecrease(&tc.ours, &tc.theirs, "test", "build", tc.isMeasured, "", tc.authoritative, usageBasis, nil, logrus.WithField("test", tc.name))
+			applyAuthoritativeLimitDecrease(&tc.ours, &tc.theirs, "test", WorkloadTypeProwjob, tc.isMeasured, "", tc.authoritative, usageBasis, authoritativeSkipConfig{}, nil, logrus.WithField("test", tc.name))
 			if diff := cmp.Diff(tc.theirs, tc.expected); diff != "" {
 				t.Errorf("unexpected resources: %s", diff)
 			}
@@ -1222,7 +1298,7 @@ func TestApplyAuthoritativeLimitDecrease_uncappedMemory(t *testing.T) {
 		},
 	}
 
-	applyAuthoritativeLimitDecrease(&ours, &theirs, "test", "build", false, "", authLegacyCPUAndMemory(0.25, 1.0), authoritativeDecreaseUsageP80, nil, logrus.WithField("test", t.Name()))
+	applyAuthoritativeLimitDecrease(&ours, &theirs, "test", WorkloadTypeProwjob, false, "", authLegacyCPUAndMemory(0.25, 1.0), authoritativeDecreaseUsageP80, authoritativeSkipConfig{}, nil, logrus.WithField("test", t.Name()))
 	if diff := cmp.Diff(theirs, expected); diff != "" {
 		t.Errorf("unexpected resources: %s", diff)
 	}
@@ -1251,7 +1327,7 @@ func TestApplyAuthoritativeLimitDecrease_dryRun(t *testing.T) {
 		},
 	}
 
-	applyAuthoritativeLimitDecrease(&ours, &theirs, "test", "build", false, "", authLegacyCPUDryRun(0.25), authoritativeDecreaseUsageP80, nil, logrus.WithField("test", t.Name()))
+	applyAuthoritativeLimitDecrease(&ours, &theirs, "test", WorkloadTypeProwjob, false, "", authLegacyCPUDryRun(0.25), authoritativeDecreaseUsageP80, authoritativeSkipConfig{}, nil, logrus.WithField("test", t.Name()))
 	if diff := cmp.Diff(theirs, expected); diff != "" {
 		t.Errorf("dry-run should not mutate resources: %s", diff)
 	}
@@ -1280,10 +1356,10 @@ func TestApplyAuthoritativeLimitDecrease_separateRequestLimitCaps(t *testing.T) 
 		},
 	}
 
-	applyAuthoritativeLimitDecrease(&ours, &theirs, "test", "build", false, "", authoritativeConfig{
-		cpuRequest: authPair(true, false, 0.25),
-		cpuLimit:   authPair(true, false, 1.0),
-	}, authoritativeDecreaseUsageP80, nil, logrus.WithField("test", t.Name()))
+	applyAuthoritativeLimitDecrease(&ours, &theirs, "test", WorkloadTypeProwjob, false, "", authoritativeConfig{
+		cpuRequest: authPair(true, 0.25),
+		cpuLimit:   authPair(true, 1.0),
+	}, authoritativeDecreaseUsageP80, authoritativeSkipConfig{}, nil, logrus.WithField("test", t.Name()))
 	if diff := cmp.Diff(theirs, expected); diff != "" {
 		t.Errorf("unexpected resources: %s", diff)
 	}
@@ -1313,6 +1389,207 @@ func TestClampRequestsToLimits(t *testing.T) {
 	clampRequestsToLimits(&resources)
 	if diff := cmp.Diff(resources, expected); diff != "" {
 		t.Errorf("unexpected resources: %s", diff)
+	}
+}
+
+func TestUsageForAuthoritativeDecrease(t *testing.T) {
+	testCases := []struct {
+		name     string
+		basis    authoritativeDecreaseUsageBasis
+		resource corev1.ResourceName
+		request  string
+		peak     string
+		want     string
+		wantOK   bool
+	}{
+		{
+			name:     "peak basis uses request when peak is stale low",
+			basis:    authoritativeDecreaseUsagePeak,
+			resource: corev1.ResourceMemory,
+			request:  "2Gi",
+			peak:     "100Mi",
+			want:     "2Gi",
+			wantOK:   true,
+		},
+		{
+			name:     "peak basis uses peak when higher",
+			basis:    authoritativeDecreaseUsagePeak,
+			resource: corev1.ResourceMemory,
+			request:  "1Gi",
+			peak:     "3Gi",
+			want:     "3Gi",
+			wantOK:   true,
+		},
+		{
+			name:     "p80 basis uses request",
+			basis:    authoritativeDecreaseUsageP80,
+			resource: corev1.ResourceMemory,
+			request:  "1500Mi",
+			peak:     "3Gi",
+			want:     "1500Mi",
+			wantOK:   true,
+		},
+		{
+			name:     "cpu peak basis uses request when peak is stale low",
+			basis:    authoritativeDecreaseUsagePeak,
+			resource: corev1.ResourceCPU,
+			request:  "2",
+			peak:     "500m",
+			want:     "2",
+			wantOK:   true,
+		},
+		{
+			name:   "missing usage",
+			basis:  authoritativeDecreaseUsageP80,
+			wantOK: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			recommended := corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{},
+				Limits:   corev1.ResourceList{},
+			}
+			if tc.request != "" {
+				recommended.Requests[tc.resource] = resource.MustParse(tc.request)
+			}
+			if tc.peak != "" {
+				recommended.Limits[tc.resource] = resource.MustParse(tc.peak)
+			}
+			got, ok := usageForAuthoritativeDecrease(recommended, tc.resource, tc.basis)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				return
+			}
+			want := resource.MustParse(tc.want)
+			if got.Cmp(want) != 0 {
+				t.Fatalf("usageForAuthoritativeDecrease() = %s, want %s", got.String(), want.String())
+			}
+		})
+	}
+}
+
+func TestSanitizeCorruptConfiguredResources(t *testing.T) {
+	authoritativeApply := authLegacyCPUAndMemory(1.0, 1.0)
+	authoritativeDryRun := authoritativeConfig{
+		cpuRequest:    authPair(false, 1.0),
+		cpuLimit:      authPair(false, 1.0),
+		memoryRequest: authPair(false, 1.0),
+		memoryLimit:   authPair(false, 1.0),
+	}
+	testCases := []struct {
+		name                              string
+		authoritative                     authoritativeConfig
+		configured, recommended, expected corev1.ResourceRequirements
+	}{
+		{
+			name:          "sub-minimum memory request raised",
+			authoritative: authoritativeApply,
+			configured: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("260Ki"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("512Ki"),
+				},
+			},
+			expected: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: authoritativeMinMemoryLimit,
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: authoritativeMinMemoryLimit,
+				},
+			},
+		},
+		{
+			name:          "10x recommendation clamp",
+			authoritative: authoritativeApply,
+			configured: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("200Gi"),
+				},
+			},
+			recommended: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+			expected: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("10Gi"),
+				},
+			},
+		},
+		{
+			name:          "cluster memory cap clamp",
+			authoritative: authoritativeApply,
+			configured: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("25Gi"),
+				},
+			},
+			recommended: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+			expected: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: testClusterMemoryCap,
+				},
+			},
+		},
+		{
+			name:          "cluster cpu cap clamp",
+			authoritative: authoritativeApply,
+			configured: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("100"),
+				},
+			},
+			recommended: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("2"),
+				},
+			},
+			expected: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: testClusterCPUCap,
+				},
+			},
+		},
+		{
+			name:          "dry-run skips downscale from tiny recommendation",
+			authoritative: authoritativeDryRun,
+			configured: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
+			recommended: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("1Mi"),
+				},
+			},
+			expected: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			configured := tc.configured
+			recommended := tc.recommended
+			sanitizeCorruptConfiguredResources(&configured, &recommended, testClusterCPUCap, testClusterMemoryCap, tc.authoritative, logrus.WithField("test", tc.name))
+			if diff := cmp.Diff(tc.expected, configured); diff != "" {
+				t.Fatalf("sanitizeCorruptConfiguredResources differs from expected, diff:\n%s", diff)
+			}
+		})
 	}
 }
 
@@ -1348,6 +1625,226 @@ func TestParseAuthoritativeDecreaseUsageBasis(t *testing.T) {
 	}
 }
 
+func TestApplyAuthoritativeLimitDecrease_skipsBuildLimits(t *testing.T) {
+	ours := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: *resource.NewQuantity(1e1, resource.BinarySI),
+		},
+	}
+	theirs := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: *resource.NewQuantity(2e10, resource.BinarySI),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: *resource.NewQuantity(2e10, resource.BinarySI),
+		},
+	}
+	expected := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: *resource.NewQuantity(2e10, resource.BinarySI),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: *resource.NewQuantity(15e9, resource.BinarySI),
+		},
+	}
+
+	applyAuthoritativeLimitDecrease(&ours, &theirs, "test-build-docker-build", WorkloadTypeBuild, false, "builds", authLegacyMemory(0.25), authoritativeDecreaseUsageP80, parseAuthoritativeSkipConfig("build", "", "", ""), nil, logrus.WithField("test", t.Name()))
+	if diff := cmp.Diff(theirs, expected); diff != "" {
+		t.Errorf("expected build limits unchanged with request decrease: %s", diff)
+	}
+}
+
+func TestApplyAuthoritativeLimitDecrease_skipsBuildRequests(t *testing.T) {
+	ours := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: *resource.NewQuantity(1e1, resource.BinarySI),
+		},
+	}
+	theirs := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: *resource.NewQuantity(2e10, resource.BinarySI),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: *resource.NewQuantity(2e10, resource.BinarySI),
+		},
+	}
+	expected := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: *resource.NewQuantity(15e9, resource.BinarySI),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: *resource.NewQuantity(2e10, resource.BinarySI),
+		},
+	}
+
+	applyAuthoritativeLimitDecrease(&ours, &theirs, "test-build-docker-build", WorkloadTypeBuild, false, "builds", authLegacyMemory(0.25), authoritativeDecreaseUsageP80, parseAuthoritativeSkipConfig("", "", "build", ""), nil, logrus.WithField("test", t.Name()))
+	if diff := cmp.Diff(theirs, expected); diff != "" {
+		t.Errorf("expected build requests unchanged with limit decrease: %s", diff)
+	}
+}
+
+func TestApplyAuthoritativeLimitDecrease_skipsBuildLimitsByClass(t *testing.T) {
+	ours := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: *resource.NewQuantity(1e1, resource.BinarySI),
+		},
+	}
+	theirs := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: *resource.NewQuantity(2e10, resource.BinarySI),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: *resource.NewQuantity(2e10, resource.BinarySI),
+		},
+	}
+	expected := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: *resource.NewQuantity(2e10, resource.BinarySI),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: *resource.NewQuantity(15e9, resource.BinarySI),
+		},
+	}
+
+	applyAuthoritativeLimitDecrease(&ours, &theirs, "test", WorkloadTypeProwjob, false, "builds", authLegacyMemory(0.25), authoritativeDecreaseUsageP80, parseAuthoritativeSkipConfig("", "builds", "", ""), nil, logrus.WithField("test", t.Name()))
+	if diff := cmp.Diff(theirs, expected); diff != "" {
+		t.Errorf("expected limits unchanged when workload class is skipped: %s", diff)
+	}
+}
+
+func TestParseAuthoritativeSkipConfig(t *testing.T) {
+	testCases := []struct {
+		name           string
+		limitTypes     string
+		limitClasses   string
+		requestTypes   string
+		requestClasses string
+		wantLimitTypes []string
+		wantLimitClass []string
+		wantReqTypes   []string
+		wantReqClass   []string
+	}{
+		{
+			name:           "parses trimmed comma-separated values",
+			limitTypes:     " build,prowjob ",
+			limitClasses:   "builds",
+			requestTypes:   "build",
+			requestClasses: " tests ",
+			wantLimitTypes: []string{"build", "prowjob"},
+			wantLimitClass: []string{"builds"},
+			wantReqTypes:   []string{"build"},
+			wantReqClass:   []string{"tests"},
+		},
+		{
+			name:           "empty input yields empty sets",
+			wantLimitTypes: nil,
+			wantLimitClass: nil,
+			wantReqTypes:   nil,
+			wantReqClass:   nil,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseAuthoritativeSkipConfig(tc.limitTypes, tc.limitClasses, tc.requestTypes, tc.requestClasses)
+			assertSetEqual(t, "limit workload types", got.limitDecreaseWorkloadTypes, tc.wantLimitTypes)
+			assertSetEqual(t, "limit workload classes", got.limitDecreaseWorkloadClasses, tc.wantLimitClass)
+			assertSetEqual(t, "request workload types", got.requestDecreaseWorkloadTypes, tc.wantReqTypes)
+			assertSetEqual(t, "request workload classes", got.requestDecreaseWorkloadClasses, tc.wantReqClass)
+		})
+	}
+}
+
+func assertSetEqual(t *testing.T, label string, got sets.Set[string], want []string) {
+	t.Helper()
+	if len(want) == 0 {
+		if len(got) != 0 {
+			t.Fatalf("unexpected %s: %v", label, sets.List(got))
+		}
+		return
+	}
+	for _, item := range want {
+		if !got.Has(item) {
+			t.Fatalf("missing %s %q in %v", label, item, sets.List(got))
+		}
+	}
+	if len(got) != len(want) {
+		t.Fatalf("%s count = %d, want %d (%v)", label, len(got), len(want), sets.List(got))
+	}
+}
+
+func TestCappedIncreaseQuantity(t *testing.T) {
+	testCases := []struct {
+		name       string
+		field      corev1.ResourceName
+		configured string
+		want       string
+	}{
+		{name: "memory cap", field: corev1.ResourceMemory, configured: "100Mi", want: "1000Mi"},
+		{name: "memory cluster cap", field: corev1.ResourceMemory, configured: "5Gi", want: "20Gi"},
+		{name: "cpu cap", field: corev1.ResourceCPU, configured: "500m", want: "5"},
+		{name: "cpu cluster cap", field: corev1.ResourceCPU, configured: "2", want: "10"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			configured := resource.MustParse(tc.configured)
+			got := cappedIncreaseQuantity(tc.field, configured, testClusterCPUCap, testClusterMemoryCap)
+			want := resource.MustParse(tc.want)
+			if got.Cmp(want) != 0 {
+				t.Fatalf("cappedIncreaseQuantity() = %s, want %s", got.String(), want.String())
+			}
+		})
+	}
+}
+
+func TestIncreaseExceedsConfiguredThreshold(t *testing.T) {
+	testCases := []struct {
+		name       string
+		field      corev1.ResourceName
+		determined string
+		configured string
+		want       bool
+	}{
+		{name: "below threshold", field: corev1.ResourceMemory, determined: "200Mi", configured: "100Mi", want: false},
+		{name: "above threshold", field: corev1.ResourceMemory, determined: "2Gi", configured: "100Mi", want: true},
+		{name: "zero configured", field: corev1.ResourceMemory, determined: "1Gi", configured: "0", want: false},
+		{name: "cpu uses millicores", field: corev1.ResourceCPU, determined: "2600m", configured: "250m", want: true},
+		{name: "cpu below threshold in millicores", field: corev1.ResourceCPU, determined: "1500m", configured: "2", want: false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			determined := resource.MustParse(tc.determined)
+			configured := resource.MustParse(tc.configured)
+			if got := increaseExceedsConfiguredThreshold(tc.field, determined, configured); got != tc.want {
+				t.Fatalf("increaseExceedsConfiguredThreshold() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRecommendationQuantityUsable(t *testing.T) {
+	testCases := []struct {
+		name  string
+		field corev1.ResourceName
+		value string
+		want  bool
+	}{
+		{name: "cpu at minimum", field: corev1.ResourceCPU, value: "10m", want: true},
+		{name: "cpu below minimum", field: corev1.ResourceCPU, value: "1m", want: false},
+		{name: "memory at minimum", field: corev1.ResourceMemory, value: "1Mi", want: true},
+		{name: "memory below minimum", field: corev1.ResourceMemory, value: "512Ki", want: false},
+		{name: "memory corrupt idle stamp", field: corev1.ResourceMemory, value: "260Ki", want: false},
+		{name: "zero memory", field: corev1.ResourceMemory, value: "0", want: false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			q := resource.MustParse(tc.value)
+			if got := recommendationQuantityUsable(tc.field, q); got != tc.want {
+				t.Fatalf("recommendationQuantityUsable() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestApplyAuthoritativeLimitDecrease_skipsDuringEscalation(t *testing.T) {
 	ours := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
@@ -1368,7 +1865,7 @@ func TestApplyAuthoritativeLimitDecrease_skipsDuringEscalation(t *testing.T) {
 		},
 	}
 
-	applyAuthoritativeLimitDecrease(&ours, &theirs, "test", "build", false, "", authLegacyMemory(0.25), authoritativeDecreaseUsageP80, server, logrus.WithField("test", t.Name()))
+	applyAuthoritativeLimitDecrease(&ours, &theirs, "test", WorkloadTypeBuild, false, "", authLegacyMemory(0.25), authoritativeDecreaseUsageP80, authoritativeSkipConfig{}, server, logrus.WithField("test", t.Name()))
 	want := *resource.NewQuantity(2e10, resource.BinarySI)
 	if diff := cmp.Diff(theirs, corev1.ResourceRequirements{
 		Limits:   corev1.ResourceList{corev1.ResourceMemory: want},
@@ -1461,7 +1958,7 @@ func TestUseOursIfLarger_authoritativeDryRun(t *testing.T) {
 		},
 	}
 
-	useOursIfLarger(&ours, &theirs, "test", "build", false, "", &defaultReporter, logrus.WithField("test", t.Name()))
+	useOursIfLarger(&ours, &theirs, "test", "build", false, "", testClusterCPUCap, testClusterMemoryCap, &defaultReporter, logrus.WithField("test", t.Name()))
 	if diff := cmp.Diff(theirs, expected); diff != "" {
 		t.Errorf("dry-run should not mutate resources: %s", diff)
 	}
@@ -1544,10 +2041,19 @@ func TestUseOursIsLarger_ReporterReports(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			useOursIfLarger(&tc.ours, &tc.theirs, "test", "build", false, "", &tc.reporter, logrus.WithField("test", tc.name))
+			theirs := copyResourceRequirements(tc.theirs)
+			useOursIfLarger(&tc.ours, &theirs, "test", "build", false, "", testClusterCPUCap, testClusterMemoryCap, &tc.reporter, logrus.WithField("test", tc.name))
 
 			if diff := cmp.Diff(tc.reporter.called, tc.expected); diff != "" {
 				t.Errorf("actual and expected reporter states don't match, : %v", diff)
+			}
+			if tc.name == "ours is 10 times larger than theirs" {
+				want := copyResourceRequirements(tc.theirs)
+				want.Requests[corev1.ResourceMemory] = *resource.NewQuantity(1e1, resource.BinarySI)
+				want.Limits[corev1.ResourceMemory] = *resource.NewQuantity(1e2, resource.BinarySI)
+				if diff := cmp.Diff(theirs, want); diff != "" {
+					t.Errorf("expected excessive increase to cap resources: %s", diff)
+				}
 			}
 		})
 	}
@@ -1740,10 +2246,36 @@ func TestPreventUnschedulable(t *testing.T) {
 			resources: &corev1.ResourceRequirements{},
 			expected:  &corev1.ResourceRequirements{},
 		},
+		{
+			name: "too much memory limit",
+			resources: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("25Gi"),
+				},
+			},
+			expected: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse(memoryCap),
+				},
+			},
+		},
+		{
+			name: "too much cpu limit",
+			resources: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: *resource.NewQuantity(100, resource.DecimalSI),
+				},
+			},
+			expected: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: *resource.NewQuantity(cpuCap, resource.DecimalSI),
+				},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			capDigestRequests(tc.resources, *resource.NewQuantity(cpuCap, resource.DecimalSI), resource.MustParse(memoryCap), logrus.WithField("test", tc.name))
+			preventUnschedulableWithCaps(tc.resources, *resource.NewQuantity(cpuCap, resource.DecimalSI), resource.MustParse(memoryCap), logrus.WithField("test", tc.name))
 			if diff := cmp.Diff(tc.expected, tc.resources); diff != "" {
 				t.Fatalf("result doesn't match expected, diff: %s", diff)
 			}

--- a/cmd/pod-scaler/consumer.go
+++ b/cmd/pod-scaler/consumer.go
@@ -13,6 +13,8 @@ import (
 	podscaler "github.com/openshift/ci-tools/pkg/pod-scaler"
 )
 
+const initialCacheLoadAttempts = 3
+
 func newReloader(name string, cache Cache) *cacheReloader {
 	reloader := &cacheReloader{
 		name:  name,
@@ -34,54 +36,139 @@ type cacheReloader struct {
 
 	lock        *sync.RWMutex
 	lastUpdated time.Time
+	pending     *podscaler.CachedQuery
 	subscribers []chan<- *podscaler.CachedQuery
 }
 
 func (c *cacheReloader) subscribe(out chan<- *podscaler.CachedQuery) {
 	c.lock.Lock()
+	defer c.lock.Unlock()
 	c.subscribers = append(c.subscribers, out)
 	c.logger.Debugf("new subscriber, subscriber count now: %d", len(c.subscribers))
-	c.lock.Unlock()
+	if c.pending != nil {
+		out <- c.pending
+		c.pending = nil
+	}
+}
+
+func emptyCachedQuery() *podscaler.CachedQuery {
+	return &podscaler.CachedQuery{}
+}
+
+func cachedQueryEmpty(q *podscaler.CachedQuery) bool {
+	if q == nil {
+		return true
+	}
+	return len(q.Data) == 0 && len(q.DataByMetaData) == 0
+}
+
+func loadCacheWithRetries(cache Cache, name string, logger *logrus.Entry, attempts int) (*podscaler.CachedQuery, error) {
+	var lastErr error
+	for attempt := 0; attempt < attempts; attempt++ {
+		if attempt > 0 {
+			time.Sleep(time.Duration(attempt) * time.Second)
+			logger.WithField("attempt", attempt+1).Debug("Retrying initial cache load.")
+		}
+		data, err := LoadCache(cache, name, logger)
+		if err == nil {
+			return data, nil
+		}
+		lastErr = err
+	}
+	return nil, lastErr
 }
 
 func (c *cacheReloader) reload() {
 	// technically this can race as we read the attribute and data from the handle at
 	// different times, but there doesn't seem to be an atomic call to GCS for that anyway
-	lastUpdated, err := LastUpdated(c.cache, c.name)
-	if err != nil {
-		c.logger.WithError(err).Warn("Failed to query for last cache update time, won't reload this tick.")
-		return
-	}
+	lastUpdated, lastUpdatedErr := LastUpdated(c.cache, c.name)
 	c.lock.RLock()
 	lastSeen := c.lastUpdated
 	c.lock.RUnlock()
 	logger := c.logger.WithFields(logrus.Fields{
 		"last_update_seen": lastSeen.Format(time.RFC3339),
-		"last_update":      lastUpdated.Format(time.RFC3339),
 	})
-
-	if lastUpdated == lastSeen {
-		logger.Debug("Last updated time on cloud artifacts matches our last load, won't reload this tick.")
-		return
-	}
-	logger.Debug("Newer update available in cloud storage, reloading data.")
-
-	data, err := LoadCache(c.cache, c.name, c.logger)
-	if err != nil {
-		logger.WithError(err).Warn("Failed to read cached data, won't reload this tick.")
-		return
-	}
-	c.lock.Lock()
-	if len(c.subscribers) > 0 {
-		c.lastUpdated = lastUpdated
-		for _, subscriber := range c.subscribers {
-			subscriber <- data
+	if lastUpdatedErr != nil {
+		logger.WithError(lastUpdatedErr).Warn("Failed to query for last cache update time.")
+		if !lastSeen.IsZero() {
+			logger.Warn("Skipping reload because freshness is unknown and cache was loaded previously.")
+			return
 		}
+		logger.Warn("Attempting initial cache load without last-updated metadata.")
 	} else {
-		logger.Warn("no subscribers yet, won't mark as loaded")
+		logger = logger.WithField("last_update", lastUpdated.Format(time.RFC3339))
+		if !lastSeen.IsZero() && lastUpdated == lastSeen {
+			logger.Debug("Last updated time on cloud artifacts matches our last load, won't reload this tick.")
+			return
+		}
+		logger.Debug("Newer update available in cloud storage, reloading data.")
 	}
-	c.lock.Unlock()
-	logger.Debug("Newer update loaded.")
+
+	var (
+		data    *podscaler.CachedQuery
+		loadErr error
+	)
+	if lastSeen.IsZero() {
+		data, loadErr = loadCacheWithRetries(c.cache, c.name, c.logger, initialCacheLoadAttempts)
+	} else {
+		data, loadErr = LoadCache(c.cache, c.name, c.logger)
+	}
+	if loadErr != nil {
+		logger.WithError(loadErr).Warn("Failed to read cached data.")
+		if !lastSeen.IsZero() {
+			logger.Warn("Keeping previously loaded cache.")
+			return
+		}
+		logger.Warn("Serving with empty cache after failed initial load.")
+		data = emptyCachedQuery()
+	}
+	c.deliverLoadedCache(logger, lastSeen, lastUpdated, lastUpdatedErr, loadErr, data)
+}
+
+func (c *cacheReloader) deliverLoadedCache(logger *logrus.Entry, lastSeen, lastUpdated time.Time, lastUpdatedErr, loadErr error, data *podscaler.CachedQuery) {
+	if loadErr == nil && !lastSeen.IsZero() && cachedQueryEmpty(data) {
+		logger.Warn("Ignoring empty cache reload; keeping previously loaded cache.")
+		return
+	}
+	if lastUpdatedErr == nil && loadErr == nil {
+		afterLoad, err := LastUpdated(c.cache, c.name)
+		if err == nil && !afterLoad.Equal(lastUpdated) {
+			logger.WithField("last_update_after_load", afterLoad.Format(time.RFC3339)).Warn("Cache object changed during load; keeping previous cache.")
+			if !lastSeen.IsZero() {
+				return
+			}
+		}
+	}
+
+	updatedAt := lastUpdated
+	if lastUpdatedErr != nil {
+		updatedAt = time.Now()
+	}
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	initialLoadFailed := loadErr != nil && lastSeen.IsZero()
+	if !initialLoadFailed {
+		c.lastUpdated = updatedAt
+	}
+	if len(c.subscribers) == 0 {
+		logger.Warn("no subscribers yet, deferring cache delivery until subscription")
+		c.pending = data
+		if lastUpdatedErr != nil && loadErr != nil {
+			logger.Debug("Initial empty cache deferred.")
+		} else {
+			logger.Debug("Newer update deferred.")
+		}
+		return
+	}
+	for _, subscriber := range c.subscribers {
+		subscriber <- data
+	}
+	if lastUpdatedErr != nil && loadErr != nil {
+		logger.Debug("Initial empty cache loaded.")
+	} else {
+		logger.Debug("Newer update loaded.")
+	}
 }
 
 func digestAll(data map[string][]*cacheReloader, digesters map[string]digester, health *pjutil.Health, logger *logrus.Entry) {

--- a/cmd/pod-scaler/consumer_test.go
+++ b/cmd/pod-scaler/consumer_test.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/openhistogram/circonusllhist"
+	"github.com/prometheus/common/model"
+	"github.com/sirupsen/logrus"
+
+	podscaler "github.com/openshift/ci-tools/pkg/pod-scaler"
+)
+
+type stubCache struct {
+	updated    time.Time
+	updatedErr error
+	payload    []byte
+	loadErr    error
+}
+
+func (s *stubCache) load(_ context.Context, _ string) (io.ReadCloser, error) {
+	if s.loadErr != nil {
+		return nil, s.loadErr
+	}
+	return io.NopCloser(bytes.NewReader(s.payload)), nil
+}
+
+func (s *stubCache) store(_ context.Context, _ string) (io.WriteCloser, error) {
+	return nil, errors.New("store not implemented in test stub")
+}
+
+func (s *stubCache) lastUpdated(_ context.Context, _ string) (time.Time, error) {
+	return s.updated, s.updatedErr
+}
+
+func newTestCacheReloader(t *testing.T, cache Cache) *cacheReloader {
+	t.Helper()
+	return &cacheReloader{
+		name:   t.Name(),
+		cache:  cache,
+		logger: logrus.WithField("test", t.Name()),
+		lock:   &sync.RWMutex{},
+	}
+}
+
+func marshalCachedQuery(t *testing.T, query *podscaler.CachedQuery) []byte {
+	t.Helper()
+	raw, err := json.Marshal(query)
+	if err != nil {
+		t.Fatalf("marshal cache query: %v", err)
+	}
+	return raw
+}
+
+func reloadOnce(t *testing.T, reloader *cacheReloader) []*podscaler.CachedQuery {
+	t.Helper()
+	ch := make(chan *podscaler.CachedQuery, 1)
+	reloader.subscribe(ch)
+	reloader.reload()
+	return drainReloadNotifications(ch)
+}
+
+func drainReloadNotifications(ch <-chan *podscaler.CachedQuery) []*podscaler.CachedQuery {
+	var got []*podscaler.CachedQuery
+	for {
+		select {
+		case query := <-ch:
+			got = append(got, query)
+		default:
+			return got
+		}
+	}
+}
+
+func seedLastUpdated(t *testing.T, reloader *cacheReloader, at time.Time) {
+	t.Helper()
+	reloader.lock.Lock()
+	reloader.lastUpdated = at
+	reloader.lock.Unlock()
+}
+
+func TestCachedQueryEmpty(t *testing.T) {
+	testCases := []struct {
+		name  string
+		query *podscaler.CachedQuery
+		want  bool
+	}{
+		{name: "nil", want: true},
+		{name: "empty struct", query: &podscaler.CachedQuery{}, want: true},
+		{name: "metadata present", query: &podscaler.CachedQuery{
+			DataByMetaData: map[podscaler.FullMetadata][]podscaler.FingerprintTime{
+				{Container: "test"}: {},
+			},
+		}, want: false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cachedQueryEmpty(tc.query); got != tc.want {
+				t.Fatalf("cachedQueryEmpty() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCacheReloader_reload(t *testing.T) {
+	updatedAt := time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC)
+	freshMeta := podscaler.FullMetadata{Container: "fresh"}
+	fingerprint := model.Fingerprint(42)
+	inner := circonusllhist.New()
+	if err := inner.RecordValue(1e8); err != nil {
+		t.Fatalf("RecordValue: %v", err)
+	}
+	freshPayload := marshalCachedQuery(t, &podscaler.CachedQuery{
+		Data: map[model.Fingerprint]*circonusllhist.HistogramWithoutLookups{
+			fingerprint: circonusllhist.NewHistogramWithoutLookups(inner),
+		},
+		DataByMetaData: map[podscaler.FullMetadata][]podscaler.FingerprintTime{
+			freshMeta: {{Fingerprint: fingerprint}},
+		},
+	})
+	emptyPayload := marshalCachedQuery(t, emptyCachedQuery())
+
+	t.Run("initial load failure serves empty cache", func(t *testing.T) {
+		reloader := newTestCacheReloader(t, &stubCache{
+			updated: updatedAt,
+			loadErr: errors.New("read failed"),
+		})
+		got := reloadOnce(t, reloader)
+		if len(got) != 1 {
+			t.Fatalf("reload notifications = %d, want 1", len(got))
+		}
+		if diff := cmp.Diff(map[podscaler.FullMetadata][]podscaler.FingerprintTime(nil), got[0].DataByMetaData); diff != "" {
+			t.Fatalf("reload cache differs from expected empty cache, diff:\n%s", diff)
+		}
+		reloader.lock.RLock()
+		lastUp := reloader.lastUpdated
+		reloader.lock.RUnlock()
+		if !lastUp.IsZero() {
+			t.Fatalf("lastUpdated = %v, want zero after failed initial load", lastUp)
+		}
+	})
+
+	t.Run("initial load failure retries on next reload", func(t *testing.T) {
+		cache := &stubCache{
+			updated: updatedAt,
+			loadErr: errors.New("read failed"),
+		}
+		reloader := newTestCacheReloader(t, cache)
+		if got := reloadOnce(t, reloader); len(got) != 1 {
+			t.Fatalf("first reload notifications = %d, want 1", len(got))
+		}
+		cache.loadErr = nil
+		cache.payload = freshPayload
+		ch := make(chan *podscaler.CachedQuery, 1)
+		reloader.subscribe(ch)
+		reloader.reload()
+		got := drainReloadNotifications(ch)
+		if len(got) != 1 {
+			t.Fatalf("retry reload notifications = %d, want 1", len(got))
+		}
+		if _, ok := got[0].DataByMetaData[freshMeta]; !ok {
+			t.Fatalf("expected retry reload to deliver fresh metadata")
+		}
+	})
+
+	t.Run("failed reload keeps previous cache", func(t *testing.T) {
+		reloader := newTestCacheReloader(t, &stubCache{
+			updated: updatedAt,
+			loadErr: errors.New("read failed"),
+		})
+		seedLastUpdated(t, reloader, updatedAt)
+		got := reloadOnce(t, reloader)
+		if len(got) != 0 {
+			t.Fatalf("reload notifications = %d, want 0", len(got))
+		}
+	})
+
+	t.Run("empty reload keeps previous cache", func(t *testing.T) {
+		reloader := newTestCacheReloader(t, &stubCache{
+			updated: updatedAt.Add(time.Hour),
+			payload: emptyPayload,
+		})
+		seedLastUpdated(t, reloader, updatedAt)
+		got := reloadOnce(t, reloader)
+		if len(got) != 0 {
+			t.Fatalf("reload notifications = %d, want 0", len(got))
+		}
+	})
+
+	t.Run("unchanged freshness skips reload", func(t *testing.T) {
+		reloader := newTestCacheReloader(t, &stubCache{
+			updated: updatedAt,
+			payload: freshPayload,
+		})
+		seedLastUpdated(t, reloader, updatedAt)
+		got := reloadOnce(t, reloader)
+		if len(got) != 0 {
+			t.Fatalf("reload notifications = %d, want 0", len(got))
+		}
+	})
+
+	t.Run("newer update reloads cache snapshot", func(t *testing.T) {
+		reloader := newTestCacheReloader(t, &stubCache{
+			updated: updatedAt.Add(time.Hour),
+			payload: freshPayload,
+		})
+		seedLastUpdated(t, reloader, updatedAt)
+		got := reloadOnce(t, reloader)
+		if len(got) != 1 {
+			t.Fatalf("reload notifications = %d, want 1", len(got))
+		}
+		wantMeta := []podscaler.FullMetadata{freshMeta}
+		gotMeta := make([]podscaler.FullMetadata, 0, len(got[0].DataByMetaData))
+		for meta := range got[0].DataByMetaData {
+			gotMeta = append(gotMeta, meta)
+		}
+		if diff := cmp.Diff(wantMeta, gotMeta); diff != "" {
+			t.Fatalf("reloaded metadata differs from expected, diff:\n%s", diff)
+		}
+	})
+
+	t.Run("pending cache delivered on subscribe", func(t *testing.T) {
+		reloader := newTestCacheReloader(t, &stubCache{
+			updated: updatedAt,
+			payload: freshPayload,
+		})
+		reloader.reload()
+		ch := make(chan *podscaler.CachedQuery, 1)
+		reloader.subscribe(ch)
+		got := drainReloadNotifications(ch)
+		if len(got) != 1 {
+			t.Fatalf("pending notifications = %d, want 1", len(got))
+		}
+		if _, ok := got[0].DataByMetaData[freshMeta]; !ok {
+			t.Fatalf("expected pending cache to include fresh metadata")
+		}
+	})
+}

--- a/cmd/pod-scaler/main.go
+++ b/cmd/pod-scaler/main.go
@@ -78,37 +78,40 @@ type consumerOptions struct {
 	systemReservedCPU                             int64
 	authoritativeCPU                              bool
 	authoritativeMemory                           bool
-	authoritativeCPUDryRun                        bool
-	authoritativeMemoryDryRun                     bool
 	authoritativeCPURequest                       bool
 	authoritativeCPULimit                         bool
 	authoritativeMemoryRequest                    bool
 	authoritativeMemoryLimit                      bool
-	authoritativeCPURequestDryRun                 bool
-	authoritativeCPULimitDryRun                   bool
-	authoritativeMemoryRequestDryRun              bool
-	authoritativeMemoryLimitDryRun                bool
 	authoritativeCPURequestMaxReductionPercent    float64
 	authoritativeCPULimitMaxReductionPercent      float64
 	authoritativeMemoryRequestMaxReductionPercent float64
 	authoritativeMemoryLimitMaxReductionPercent   float64
 	authoritativeDecreaseUsageBasis               string
+	skipWorkloadTypeRequestDecrease               string
+	skipWorkloadTypeLimitDecrease                 string
+	skipWorkloadClassRequestDecrease              string
+	skipWorkloadClassLimitDecrease                string
 }
 
 func (o *consumerOptions) authoritativeConfig() authoritativeConfig {
-	pair := func(apply, dryRun bool, maxReduction float64, legacyApply, legacyDryRun bool) authoritativePair {
-		return authoritativePair{
-			apply:        apply || legacyApply,
-			dryRun:       dryRun || legacyDryRun,
-			maxReduction: maxReduction,
-		}
+	pair := func(apply bool, maxReduction float64, legacyApply bool) authoritativePair {
+		return authoritativePair{apply: apply || legacyApply, maxReduction: maxReduction}
 	}
 	return authoritativeConfig{
-		cpuRequest:    pair(o.authoritativeCPURequest, o.authoritativeCPURequestDryRun, o.authoritativeCPURequestMaxReductionPercent, o.authoritativeCPU, o.authoritativeCPUDryRun),
-		cpuLimit:      pair(o.authoritativeCPULimit, o.authoritativeCPULimitDryRun, o.authoritativeCPULimitMaxReductionPercent, o.authoritativeCPU, o.authoritativeCPUDryRun),
-		memoryRequest: pair(o.authoritativeMemoryRequest, o.authoritativeMemoryRequestDryRun, o.authoritativeMemoryRequestMaxReductionPercent, o.authoritativeMemory, o.authoritativeMemoryDryRun),
-		memoryLimit:   pair(o.authoritativeMemoryLimit, o.authoritativeMemoryLimitDryRun, o.authoritativeMemoryLimitMaxReductionPercent, o.authoritativeMemory, o.authoritativeMemoryDryRun),
+		cpuRequest:    pair(o.authoritativeCPURequest, o.authoritativeCPURequestMaxReductionPercent, o.authoritativeCPU),
+		cpuLimit:      pair(o.authoritativeCPULimit, o.authoritativeCPULimitMaxReductionPercent, o.authoritativeCPU),
+		memoryRequest: pair(o.authoritativeMemoryRequest, o.authoritativeMemoryRequestMaxReductionPercent, o.authoritativeMemory),
+		memoryLimit:   pair(o.authoritativeMemoryLimit, o.authoritativeMemoryLimitMaxReductionPercent, o.authoritativeMemory),
 	}
+}
+
+func (o *consumerOptions) authoritativeSkipConfig() authoritativeSkipConfig {
+	return parseAuthoritativeSkipConfig(
+		o.skipWorkloadTypeLimitDecrease,
+		o.skipWorkloadClassLimitDecrease,
+		o.skipWorkloadTypeRequestDecrease,
+		o.skipWorkloadClassRequestDecrease,
+	)
 }
 
 func bindOptions(fs *flag.FlagSet) *options {
@@ -135,18 +138,12 @@ func bindOptions(fs *flag.FlagSet) *options {
 	fs.Float64Var(&o.percentageMeasured, "percentage-measured", 0, "Percentage of pods to mark as measured (0-100). Measured pods get increased CPU requests and anti-affinity rules.")
 	fs.Float64Var(&o.measuredPodCPUIncrease, "measured-pod-cpu-increase", 50, "Percentage increase in CPU requests for measured pods (default: 50%).")
 	fs.Int64Var(&o.systemReservedCPU, "system-reserved-cpu", 2, "CPU cores to reserve for system overhead when capping measured pod CPU.")
-	fs.BoolVar(&o.authoritativeCPURequest, "authoritative-cpu-request", false, "Allow admission to decrease CPU requests based on measured usage.")
-	fs.BoolVar(&o.authoritativeCPULimit, "authoritative-cpu-limit", false, "Allow admission to decrease CPU limits based on measured usage.")
+	fs.BoolVar(&o.authoritativeCPURequest, "authoritative-cpu-request", false, "When true, apply CPU request decreases from measured usage. When false, log would-be decreases without mutating (dry-run).")
+	fs.BoolVar(&o.authoritativeCPULimit, "authoritative-cpu-limit", false, "When true, apply CPU limit decreases from measured usage. When false, log would-be decreases without mutating (dry-run).")
 	fs.BoolVar(&o.authoritativeCPU, "authoritative-cpu", false, "Deprecated: enables both --authoritative-cpu-request and --authoritative-cpu-limit.")
-	fs.BoolVar(&o.authoritativeMemoryRequest, "authoritative-memory-request", false, "Allow admission to decrease memory requests based on measured usage.")
-	fs.BoolVar(&o.authoritativeMemoryLimit, "authoritative-memory-limit", false, "Allow admission to decrease memory limits based on measured usage.")
+	fs.BoolVar(&o.authoritativeMemoryRequest, "authoritative-memory-request", false, "When true, apply memory request decreases from measured usage. When false, log would-be decreases without mutating (dry-run).")
+	fs.BoolVar(&o.authoritativeMemoryLimit, "authoritative-memory-limit", false, "When true, apply memory limit decreases from measured usage. When false, log would-be decreases without mutating (dry-run).")
 	fs.BoolVar(&o.authoritativeMemory, "authoritative-memory", false, "Deprecated: enables both --authoritative-memory-request and --authoritative-memory-limit.")
-	fs.BoolVar(&o.authoritativeCPURequestDryRun, "authoritative-cpu-request-dry-run", false, "Log CPU request decreases that authoritative mode would apply without mutating pods.")
-	fs.BoolVar(&o.authoritativeCPULimitDryRun, "authoritative-cpu-limit-dry-run", false, "Log CPU limit decreases that authoritative mode would apply without mutating pods.")
-	fs.BoolVar(&o.authoritativeCPUDryRun, "authoritative-cpu-dry-run", false, "Deprecated: enables both --authoritative-cpu-request-dry-run and --authoritative-cpu-limit-dry-run.")
-	fs.BoolVar(&o.authoritativeMemoryRequestDryRun, "authoritative-memory-request-dry-run", false, "Log memory request decreases that authoritative mode would apply without mutating pods.")
-	fs.BoolVar(&o.authoritativeMemoryLimitDryRun, "authoritative-memory-limit-dry-run", false, "Log memory limit decreases that authoritative mode would apply without mutating pods.")
-	fs.BoolVar(&o.authoritativeMemoryDryRun, "authoritative-memory-dry-run", false, "Deprecated: enables both --authoritative-memory-request-dry-run and --authoritative-memory-limit-dry-run.")
 	fs.Float64Var(&o.authoritativeCPURequestMaxReductionPercent, "authoritative-cpu-request-max-reduction-percent", 1.0, "Maximum CPU request reduction per admission in authoritative mode, as a fraction (0.25 = 25%, 1.0 = no cap).")
 	fs.Float64Var(&o.authoritativeCPULimitMaxReductionPercent, "authoritative-cpu-limit-max-reduction-percent", 1.0, "Maximum CPU limit reduction per admission in authoritative mode, as a fraction (0.25 = 25%, 1.0 = no cap).")
 	fs.Float64Var(&o.authoritativeCPULimitMaxReductionPercent, "authoritative-cpu-max-reduction-percent", 1.0, "Deprecated: use --authoritative-cpu-limit-max-reduction-percent.")
@@ -154,6 +151,10 @@ func bindOptions(fs *flag.FlagSet) *options {
 	fs.Float64Var(&o.authoritativeMemoryLimitMaxReductionPercent, "authoritative-memory-limit-max-reduction-percent", 1.0, "Maximum memory limit reduction per admission in authoritative mode, as a fraction (0.25 = 25%, 1.0 = no cap).")
 	fs.Float64Var(&o.authoritativeMemoryLimitMaxReductionPercent, "authoritative-memory-max-reduction-percent", 1.0, "Deprecated: use --authoritative-memory-limit-max-reduction-percent.")
 	fs.StringVar(&o.authoritativeDecreaseUsageBasis, "pod-scaler-authoritative-decrease-usage-basis", "p80", "Usage basis for authoritative decreases before the 1.2x multiplier: p80 (default) or peak (histogram max/burst).")
+	fs.StringVar(&o.skipWorkloadTypeLimitDecrease, "pod-scaler-skip-workload-type-limit-decrease", "", "Comma-separated workload types that skip authoritative limit decreases (e.g. build).")
+	fs.StringVar(&o.skipWorkloadClassLimitDecrease, "pod-scaler-skip-workload-class-limit-decrease", "", "Comma-separated ci-workload classes that skip authoritative limit decreases (e.g. builds,tests).")
+	fs.StringVar(&o.skipWorkloadTypeRequestDecrease, "pod-scaler-skip-workload-type-request-decrease", "", "Comma-separated workload types that skip authoritative request decreases.")
+	fs.StringVar(&o.skipWorkloadClassRequestDecrease, "pod-scaler-skip-workload-class-request-decrease", "", "Comma-separated ci-workload classes that skip authoritative request decreases.")
 	fs.Float64Var(&o.failureEscalationFactor, "failure-escalation-factor", 1.5, "Multiplier applied per escalation level after OOM or CPU throttle (1.5 = 50% increase per level).")
 	fs.IntVar(&o.failureEscalationMaxLevel, "failure-escalation-max-level", 10, "Maximum escalation level tracked for a workload.")
 	fs.Float64Var(&o.cpuThrottleThreshold, "cpu-throttle-threshold", 0.25, "Minimum throttled/total CPU CFS period ratio to count as CPU deprived.")
@@ -377,7 +378,7 @@ func mainAdmission(opts *options, cache Cache) {
 		logrus.WithError(err).Fatal("Failed to parse authoritative decrease usage basis.")
 	}
 
-	go admit(opts.port, opts.instrumentationOptions.HealthPort, opts.certDir, client, kubeClient, loaders(cache), opts.mutateResourceLimits, opts.cpuCap, opts.memoryCap, opts.cpuPriorityScheduling, opts.percentageMeasured, opts.measuredPodCPUIncrease, opts.systemReservedCPU, opts.authoritativeConfig(), usageBasis, escalations, reporter)
+	go admit(opts.port, opts.instrumentationOptions.HealthPort, opts.certDir, client, kubeClient, loaders(cache), opts.mutateResourceLimits, opts.cpuCap, opts.memoryCap, opts.cpuPriorityScheduling, opts.percentageMeasured, opts.measuredPodCPUIncrease, opts.systemReservedCPU, opts.authoritativeConfig(), usageBasis, opts.authoritativeSkipConfig(), escalations, reporter)
 }
 
 func loaders(cache Cache) map[string][]*cacheReloader {

--- a/cmd/pod-scaler/main_test.go
+++ b/cmd/pod-scaler/main_test.go
@@ -1,1 +1,77 @@
 package main
+
+import (
+	"testing"
+)
+
+func TestConsumerOptions_authoritativeConfig(t *testing.T) {
+	testCases := []struct {
+		name string
+		opts consumerOptions
+		want authoritativeConfig
+	}{
+		{
+			name: "apply enabled",
+			opts: consumerOptions{
+				authoritativeCPURequest:    true,
+				authoritativeCPULimit:      true,
+				authoritativeMemoryRequest: true,
+				authoritativeMemoryLimit:   true,
+			},
+			want: authoritativeConfig{
+				cpuRequest:    authoritativePair{apply: true},
+				cpuLimit:      authoritativePair{apply: true},
+				memoryRequest: authoritativePair{apply: true},
+				memoryLimit:   authoritativePair{apply: true},
+			},
+		},
+		{
+			name: "apply disabled implies dry-run",
+			opts: consumerOptions{
+				authoritativeCPURequest:    false,
+				authoritativeCPULimit:      false,
+				authoritativeMemoryRequest: false,
+				authoritativeMemoryLimit:   false,
+			},
+			want: authoritativeConfig{
+				cpuRequest:    authoritativePair{apply: false},
+				cpuLimit:      authoritativePair{apply: false},
+				memoryRequest: authoritativePair{apply: false},
+				memoryLimit:   authoritativePair{apply: false},
+			},
+		},
+		{
+			name: "legacy authoritative cpu enables apply",
+			opts: consumerOptions{
+				authoritativeCPU: true,
+			},
+			want: authoritativeConfig{
+				cpuRequest:    authoritativePair{apply: true},
+				cpuLimit:      authoritativePair{apply: true},
+				memoryRequest: authoritativePair{apply: false},
+				memoryLimit:   authoritativePair{apply: false},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.opts.authoritativeConfig()
+			assertAuthoritativeConfigEqual(t, tc.want, got)
+		})
+	}
+}
+
+func assertAuthoritativePairEqual(t *testing.T, want, got authoritativePair) {
+	t.Helper()
+	if want.apply != got.apply {
+		t.Fatalf("authoritativePair mismatch: want apply=%v, got apply=%v", want.apply, got.apply)
+	}
+}
+
+func assertAuthoritativeConfigEqual(t *testing.T, want, got authoritativeConfig) {
+	t.Helper()
+	assertAuthoritativePairEqual(t, want.cpuRequest, got.cpuRequest)
+	assertAuthoritativePairEqual(t, want.cpuLimit, got.cpuLimit)
+	assertAuthoritativePairEqual(t, want.memoryRequest, got.memoryRequest)
+	assertAuthoritativePairEqual(t, want.memoryLimit, got.memoryLimit)
+}

--- a/cmd/pod-scaler/resources.go
+++ b/cmd/pod-scaler/resources.go
@@ -147,6 +147,10 @@ func cpuRequestQuantityFromHistogram(hist *circonusllhist.Histogram, quantile fl
 	if q == nil {
 		return nil
 	}
+	if !recommendationQuantityUsable(corev1.ResourceCPU, *q) {
+		logger.WithField("recommendation", q.String()).Debug("skipping CPU recommendation below minimum")
+		return nil
+	}
 	reqs := &corev1.ResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceCPU: *q}}
 	capDigestRequests(reqs, cpuCap, resource.Quantity{}, logger)
 	return reqs.Requests
@@ -162,9 +166,79 @@ func memoryRequestQuantityFromHistogram(hist *circonusllhist.Histogram, quantile
 	if q == nil {
 		return nil
 	}
+	if !recommendationQuantityUsable(corev1.ResourceMemory, *q) {
+		logger.WithField("recommendation", q.String()).Debug("skipping memory recommendation below cgroup v2 minimum")
+		return nil
+	}
 	reqs := &corev1.ResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceMemory: *q}}
 	capDigestRequests(reqs, resource.Quantity{}, memoryCap, logger)
 	return reqs.Requests
+}
+
+func mergeHistogramsForMeta(data *podscaler.CachedQuery, fingerprintTimes []podscaler.FingerprintTime) *circonusllhist.Histogram {
+	overall := circonusllhist.New()
+	merged := 0
+	for _, fingerprintTime := range fingerprintTimes {
+		histData := data.Data[fingerprintTime.Fingerprint]
+		if histData == nil {
+			continue
+		}
+		overall.Merge(histData.Histogram())
+		merged++
+	}
+	if merged == 0 || overall.Count() == 0 {
+		return nil
+	}
+	return overall
+}
+
+func peakLimitQuantity(resourceName corev1.ResourceName, hist *circonusllhist.Histogram, request *resource.Quantity, cpuCap, memoryCap resource.Quantity) *resource.Quantity {
+	var q *resource.Quantity
+	switch resourceName {
+	case corev1.ResourceCPU:
+		q = cpuPeakQuantityFromHistogram(hist)
+	case corev1.ResourceMemory:
+		q = memoryPeakQuantityFromHistogram(hist)
+	}
+	if q == nil || !recommendationQuantityUsable(resourceName, *q) {
+		return nil
+	}
+	if request != nil && !request.IsZero() && increaseExceedsConfiguredThreshold(resourceName, *q, *request) {
+		capped := cappedIncreaseQuantity(resourceName, *request, cpuCap, memoryCap)
+		q = &capped
+	} else {
+		capped := capQuantityToClusterMaximum(resourceName, *q, cpuCap, memoryCap)
+		q = &capped
+	}
+	return q
+}
+
+func (s *resourceServer) applyDigestUpdates(resource corev1.ResourceName, updates map[podscaler.FullMetadata]corev1.ResourceRequirements) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	for meta, existing := range s.byMetaData {
+		delete(existing.Requests, resource)
+		delete(existing.Limits, resource)
+		if len(existing.Requests) == 0 && len(existing.Limits) == 0 {
+			delete(s.byMetaData, meta)
+		}
+	}
+	for meta, reqs := range updates {
+		entry, exists := s.byMetaData[meta]
+		if !exists {
+			entry = corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{},
+				Limits:   corev1.ResourceList{},
+			}
+		}
+		if q, ok := reqs.Requests[resource]; ok {
+			entry.Requests[resource] = q
+		}
+		if q, ok := reqs.Limits[resource]; ok {
+			entry.Limits[resource] = q
+		}
+		s.byMetaData[meta] = entry
+	}
 }
 
 func (s *resourceServer) digestRecommendations(
@@ -175,41 +249,30 @@ func (s *resourceServer) digestRecommendations(
 ) {
 	logger := s.logger.WithField("resource", resource)
 	logger.Debugf("Digesting %d identifiers.", len(data.DataByMetaData))
+	updates := map[podscaler.FullMetadata]corev1.ResourceRequirements{}
 	for meta, fingerprintTimes := range data.DataByMetaData {
-		overall := circonusllhist.New()
 		metaLogger := logger.WithField("meta", meta)
 		metaLogger.Tracef("digesting %d fingerprints", len(fingerprintTimes))
-		for _, fingerprintTime := range fingerprintTimes {
-			overall.Merge(data.Data[fingerprintTime.Fingerprint].Histogram())
+		overall := mergeHistogramsForMeta(data, fingerprintTimes)
+		if overall == nil {
+			metaLogger.Debug("skipping recommendation with no resolvable histogram data")
+			continue
 		}
-		metaLogger.Trace("merged all fingerprints")
 		requests := recommend(overall, quantile)
 		if len(requests) == 0 {
 			metaLogger.Debug("skipping recommendation with no usable histogram data")
 			continue
 		}
-		metaLogger.Trace("locking for value update")
-		s.lock.Lock()
-		if _, exists := s.byMetaData[meta]; !exists {
-			s.byMetaData[meta] = corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{},
-				Limits:   corev1.ResourceList{},
-			}
+		entry := corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{resource: requests[resource]},
 		}
-		s.byMetaData[meta].Requests[resource] = requests[resource]
-		switch resource {
-		case corev1.ResourceCPU:
-			if peak := cpuPeakQuantityFromHistogram(overall); peak != nil {
-				s.byMetaData[meta].Limits[resource] = *peak
-			}
-		case corev1.ResourceMemory:
-			if peak := memoryPeakQuantityFromHistogram(overall); peak != nil {
-				s.byMetaData[meta].Limits[resource] = *peak
-			}
+		requestQty := requests[resource]
+		if peak := peakLimitQuantity(resource, overall, &requestQty, s.cpuRequestCap, s.memoryRequestCap); peak != nil {
+			entry.Limits = corev1.ResourceList{resource: *peak}
 		}
-		metaLogger.Trace("unlocking for meta")
-		s.lock.Unlock()
+		updates[meta] = entry
 	}
+	s.applyDigestUpdates(resource, updates)
 	logger.Debug("Finished digesting new data.")
 }
 

--- a/cmd/pod-scaler/resources_test.go
+++ b/cmd/pod-scaler/resources_test.go
@@ -3,13 +3,17 @@ package main
 import (
 	"math"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/openhistogram/circonusllhist"
+	"github.com/prometheus/common/model"
 	"github.com/sirupsen/logrus"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+
+	podscaler "github.com/openshift/ci-tools/pkg/pod-scaler"
 )
 
 func TestQuantileValueUsable(t *testing.T) {
@@ -256,17 +260,13 @@ func TestCPUPeakQuantityFromHistogram(t *testing.T) {
 	if err := hist.RecordValue(50); err != nil {
 		t.Fatalf("RecordValue spike: %v", err)
 	}
-	got := cpuPeakQuantityFromHistogram(hist)
-	want := cpuQuantityFromCores(*recommendationPeakValue(hist))
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Fatalf("cpuPeakQuantityFromHistogram differs from expected, diff:\n%s", diff)
+	request := resource.MustParse("500m")
+	got := peakLimitQuantity(corev1.ResourceCPU, hist, &request, cpuCap, resource.Quantity{})
+	if got == nil {
+		t.Fatal("expected capped peak limit")
 	}
-	if got.Cmp(cpuCap) <= 0 {
-		t.Fatalf("peak quantity should exceed request cap %v, got %v", cpuCap, got)
-	}
-	capped := cpuRequestQuantityFromHistogram(hist, 0.8, cpuCap, logrus.WithField("test", t.Name()))
-	if capped != nil && capped.Cpu().Cmp(cpuCap) > 0 {
-		t.Fatalf("request helper should cap at %v, got %v", cpuCap, capped.Cpu())
+	if got.Cmp(*resource.NewMilliQuantity(5000, resource.DecimalSI)) != 0 {
+		t.Fatalf("peak limit = %v, want 5 cores", got)
 	}
 }
 
@@ -282,13 +282,14 @@ func TestMemoryPeakQuantityFromHistogram(t *testing.T) {
 	if err := hist.RecordValue(spikeBytes); err != nil {
 		t.Fatalf("RecordValue spike: %v", err)
 	}
-	got := memoryPeakQuantityFromHistogram(hist)
-	want := memoryQuantityFromBytes(*recommendationPeakValue(hist))
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Fatalf("memoryPeakQuantityFromHistogram differs from expected, diff:\n%s", diff)
+	request := resource.MustParse("100Mi")
+	got := peakLimitQuantity(corev1.ResourceMemory, hist, &request, resource.Quantity{}, memoryCap)
+	if got == nil {
+		t.Fatal("expected capped peak limit")
 	}
-	if got.Cmp(memoryCap) <= 0 {
-		t.Fatalf("peak quantity should exceed request cap %v, got %v", memoryCap, got)
+	wantPeak := resource.MustParse("1000Mi")
+	if got.Cmp(wantPeak) != 0 {
+		t.Fatalf("peak limit = %v, want %v", got, wantPeak)
 	}
 	capped := memoryRequestQuantityFromHistogram(hist, 0.8, memoryCap, logrus.WithField("test", t.Name()))
 	if capped != nil && capped.Memory().Cmp(memoryCap) > 0 {
@@ -298,4 +299,104 @@ func TestMemoryPeakQuantityFromHistogram(t *testing.T) {
 
 func ptr(v float64) *float64 {
 	return &v
+}
+
+func TestCPURequestQuantityFromHistogram_rejectsBelowMinimum(t *testing.T) {
+	hist := circonusllhist.New()
+	if err := hist.RecordValue(0.001); err != nil {
+		t.Fatalf("RecordValue: %v", err)
+	}
+	got := cpuRequestQuantityFromHistogram(hist, 0.8, *resource.NewQuantity(10, resource.DecimalSI), logrus.WithField("test", t.Name()))
+	if got != nil {
+		t.Fatalf("expected nil recommendation below CPU minimum, got %v", got)
+	}
+}
+
+func TestMemoryRequestQuantityFromHistogram_rejectsBelowCgroupMinimum(t *testing.T) {
+	hist := circonusllhist.New()
+	if err := hist.RecordValue(200000); err != nil {
+		t.Fatalf("RecordValue: %v", err)
+	}
+	got := memoryRequestQuantityFromHistogram(hist, 0.8, resource.MustParse("20Gi"), logrus.WithField("test", t.Name()))
+	if got != nil {
+		t.Fatalf("expected nil recommendation below cgroup minimum, got %v", got)
+	}
+}
+
+func TestMergeHistogramsForMeta(t *testing.T) {
+	meta := podscaler.FullMetadata{Container: "test"}
+	fp := model.Fingerprint(42)
+	inner := circonusllhist.New(circonusllhist.NoLookup())
+	if err := inner.RecordValue(1e8); err != nil {
+		t.Fatalf("RecordValue: %v", err)
+	}
+	hist := circonusllhist.NewHistogramWithoutLookups(inner)
+
+	t.Run("orphan refs only", func(t *testing.T) {
+		data := &podscaler.CachedQuery{
+			Data:           map[model.Fingerprint]*circonusllhist.HistogramWithoutLookups{},
+			DataByMetaData: map[podscaler.FullMetadata][]podscaler.FingerprintTime{meta: {{Fingerprint: fp}}},
+		}
+		merged := mergeHistogramsForMeta(data, data.DataByMetaData[meta])
+		if merged != nil {
+			t.Fatalf("expected no merge for orphan refs, got histogram")
+		}
+	})
+
+	t.Run("resolvable histogram", func(t *testing.T) {
+		data := &podscaler.CachedQuery{
+			Data: map[model.Fingerprint]*circonusllhist.HistogramWithoutLookups{
+				fp: hist,
+			},
+			DataByMetaData: map[podscaler.FullMetadata][]podscaler.FingerprintTime{meta: {{Fingerprint: fp}}},
+		}
+		merged := mergeHistogramsForMeta(data, data.DataByMetaData[meta])
+		if merged == nil {
+			t.Fatalf("expected merged histogram")
+		}
+	})
+}
+
+func TestDigestRecommendations_replacesPerResourceSnapshot(t *testing.T) {
+	meta := podscaler.FullMetadata{Container: "test"}
+	fp := model.Fingerprint(7)
+	inner := circonusllhist.New(circonusllhist.NoLookup())
+	for i := 0; i < 20; i++ {
+		if err := inner.RecordValue(1e8); err != nil {
+			t.Fatalf("RecordValue: %v", err)
+		}
+	}
+	hist := circonusllhist.NewHistogramWithoutLookups(inner)
+
+	server := &resourceServer{
+		logger:           logrus.WithField("test", t.Name()),
+		byMetaData:       map[podscaler.FullMetadata]corev1.ResourceRequirements{},
+		memoryRequestCap: resource.MustParse("20Gi"),
+	}
+	staleMeta := podscaler.FullMetadata{Container: "stale"}
+	server.byMetaData[staleMeta] = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: *resource.NewQuantity(324000, resource.BinarySI),
+		},
+	}
+
+	data := &podscaler.CachedQuery{
+		Data: map[model.Fingerprint]*circonusllhist.HistogramWithoutLookups{
+			fp: hist,
+		},
+		DataByMetaData: map[podscaler.FullMetadata][]podscaler.FingerprintTime{
+			meta: {{Fingerprint: fp, Added: time.Now()}},
+		},
+	}
+	server.digestRecommendations(data, corev1.ResourceMemory, memRequestQuantile, func(h *circonusllhist.Histogram, quantile float64) corev1.ResourceList {
+		return memoryRequestQuantityFromHistogram(h, quantile, server.memoryRequestCap, server.logger)
+	})
+
+	if _, ok := server.byMetaData[staleMeta]; ok {
+		t.Fatalf("expected stale memory recommendation to be cleared on reload")
+	}
+	got, ok := server.recommendedRequestFor(meta)
+	if !ok || got.Requests.Memory().IsZero() {
+		t.Fatalf("expected fresh memory recommendation for %v, got ok=%v reqs=%v", meta, ok, got.Requests)
+	}
 }

--- a/cmd/pod-scaler/storage.go
+++ b/cmd/pod-scaler/storage.go
@@ -119,6 +119,18 @@ func (e notExist) Unwrap() error {
 	return e.wrapped
 }
 
+func logRepairStats(logger *logrus.Entry, stats podscaler.RepairStats, action string) {
+	if stats.RemovedMetaKeys+stats.RemovedOrphanRefs+stats.RemovedHistograms+stats.RemovedCorruptValues == 0 {
+		return
+	}
+	logger.WithFields(logrus.Fields{
+		"removed_meta_keys":      stats.RemovedMetaKeys,
+		"removed_orphan_refs":    stats.RemovedOrphanRefs,
+		"removed_histograms":     stats.RemovedHistograms,
+		"removed_corrupt_values": stats.RemovedCorruptValues,
+	}).Warn("Repaired corrupt or orphan cache data " + action)
+}
+
 // LoadCache loads cached query data from the given storage loader.
 func LoadCache(loader loader, metricName string, logger *logrus.Entry) (*podscaler.CachedQuery, error) {
 	readStart := time.Now()
@@ -143,6 +155,8 @@ func LoadCache(loader loader, metricName string, logger *logrus.Entry) (*podscal
 		return nil, fmt.Errorf("could not unmarshal cached data: %w", err)
 	}
 	logger.Infof("Loaded %d distributions for %d identifiers after %s.", len(cache.Data), len(cache.DataByMetaData), time.Since(readStart).Round(time.Second))
+	repairStats := cache.Repair(metricName, podscaler.DefaultSanitizeOptions())
+	logRepairStats(logger, repairStats, "after load.")
 	return &cache, nil
 }
 
@@ -166,6 +180,9 @@ func storeCache(storer storer, metricName string, data *podscaler.CachedQuery, m
 	logger.Debug("Pruning cached Prometheus data.")
 	data.PruneWithMaxAge(maxDataAge)
 	logger.Debugf("Pruned cached Prometheus data after %s.", time.Since(pruneStart).Round(time.Second))
+
+	repairStats := data.Repair(metricName, podscaler.DefaultSanitizeOptions())
+	logRepairStats(logger, repairStats, "before storing.")
 
 	flushStart := time.Now()
 	logger.Info("Flushing Prometheus data to Cache.")

--- a/cmd/pod-scaler/storage_test.go
+++ b/cmd/pod-scaler/storage_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/openhistogram/circonusllhist"
+	"github.com/prometheus/common/model"
+	"github.com/sirupsen/logrus"
+
+	podscaler "github.com/openshift/ci-tools/pkg/pod-scaler"
+)
+
+type bytesLoader struct {
+	payload []byte
+}
+
+func (b *bytesLoader) load(_ context.Context, _ string) (io.ReadCloser, error) {
+	return io.NopCloser(bytes.NewReader(b.payload)), nil
+}
+
+func corruptMemoryCachedQuery(t *testing.T) *podscaler.CachedQuery {
+	t.Helper()
+	fp := model.Fingerprint(99)
+	inner := circonusllhist.New()
+	for i := 0; i < 20; i++ {
+		if err := inner.RecordValue(1e8); err != nil {
+			t.Fatalf("RecordValue: %v", err)
+		}
+	}
+	if err := inner.RecordValue(float64(30 * 1024 * 1024 * 1024)); err != nil {
+		t.Fatalf("RecordValue spike: %v", err)
+	}
+	return &podscaler.CachedQuery{
+		Data: map[model.Fingerprint]*circonusllhist.HistogramWithoutLookups{
+			fp: circonusllhist.NewHistogramWithoutLookups(inner),
+		},
+		DataByMetaData: map[podscaler.FullMetadata][]podscaler.FingerprintTime{
+			{Container: "test"}: {{Fingerprint: fp}},
+		},
+	}
+}
+
+func TestLoadCache(t *testing.T) {
+	t.Run("repairs corrupt histograms", func(t *testing.T) {
+		raw := marshalCachedQuery(t, corruptMemoryCachedQuery(t))
+
+		got, err := LoadCache(&bytesLoader{payload: raw}, MetricNameMemoryWorkingSet, logrus.WithField("test", t.Name()))
+		if err != nil {
+			t.Fatalf("LoadCache() error = %v", err)
+		}
+		if len(got.Data) != 0 {
+			t.Fatalf("expected corrupt histogram removed, got %d entries", len(got.Data))
+		}
+		if len(got.DataByMetaData) != 0 {
+			t.Fatalf("expected orphan metadata removed, got %d entries", len(got.DataByMetaData))
+		}
+	})
+}

--- a/cmd/pod-scaler/testdata/zz_fixture_TestMutatePodResources_resources_to_add.diff
+++ b/cmd/pod-scaler/testdata/zz_fixture_TestMutatePodResources_resources_to_add.diff
@@ -49,7 +49,7 @@
 - 						s"cpu":    {i: resource.int64Amount{value: 2}, Format: "DecimalSI"},
 + 						s"cpu":    {i: resource.int64Amount{value: 6000, scale: -3}, s: "6", Format: "DecimalSI"},
 - 						s"memory": {i: resource.int64Amount{value: 100}, Format: "BinarySI"},
-+ 						s"memory": {i: resource.int64Amount{value: 240000000}, s: "234375Ki", Format: "BinarySI"},
++ 						s"memory": {i: resource.int64Amount{value: 10485760}, s: "10Mi", Format: "BinarySI"},
   					},
   					Claims: nil,
   				},
@@ -66,7 +66,7 @@
   					Requests: v1.ResourceList{
   						s"cpu":    {i: {...}, Format: "DecimalSI"},
 - 						s"memory": {i: resource.int64Amount{value: 100}, Format: "BinarySI"},
-+ 						s"memory": {i: resource.int64Amount{value: 240000000}, s: "234375Ki", Format: "BinarySI"},
++ 						s"memory": {i: resource.int64Amount{value: 10485760}, s: "10Mi", Format: "BinarySI"},
   					},
   					Claims: nil,
   				},

--- a/cmd/pod-scaler/testdata/zz_fixture_TestMutatePodResources_resources_to_add__limits_disabled.diff
+++ b/cmd/pod-scaler/testdata/zz_fixture_TestMutatePodResources_resources_to_add__limits_disabled.diff
@@ -10,7 +10,12 @@
   				EnvFrom: nil,
   				Env:     nil,
   				Resources: v1.ResourceRequirements{
-  					Limits: {s"cpu": {i: {...}, Format: "DecimalSI"}, s"memory": {i: {...}, Format: "BinarySI"}},
+  					Limits: v1.ResourceList{
+- 						s"cpu":    {i: resource.int64Amount{value: 16}, Format: "DecimalSI"},
++ 						s"cpu":    {i: resource.int64Amount{value: 10}, s: "10", Format: "DecimalSI"},
+- 						s"memory": {i: resource.int64Amount{value: 40000000000}, Format: "BinarySI"},
++ 						s"memory": {i: resource.int64Amount{value: 21474836480}, s: "20Gi", Format: "BinarySI"},
+  					},
   					Requests: v1.ResourceList{
   						s"cpu":    {i: {...}, Format: "DecimalSI"},
 - 						s"memory": {i: resource.int64Amount{value: 30000000000}, Format: "BinarySI"},
@@ -49,7 +54,7 @@
 - 						s"cpu":    {i: resource.int64Amount{value: 2}, Format: "DecimalSI"},
 + 						s"cpu":    {i: resource.int64Amount{value: 6000, scale: -3}, s: "6", Format: "DecimalSI"},
 - 						s"memory": {i: resource.int64Amount{value: 100}, Format: "BinarySI"},
-+ 						s"memory": {i: resource.int64Amount{value: 21474836480}, s: "20Gi", Format: "BinarySI"},
++ 						s"memory": {i: resource.int64Amount{value: 10485760}, s: "10Mi", Format: "BinarySI"},
   					},
   					Claims: nil,
   				},

--- a/cmd/pod-scaler/testdata/zz_fixture_TestMutatePods_pod_associated_with_a_build_with_labels.yaml
+++ b/cmd/pod-scaler/testdata/zz_fixture_TestMutatePods_pod_associated_with_a_build_with_labels.yaml
@@ -19,16 +19,10 @@ Patches:
   value: "true"
 - op: add
   path: /spec/containers/0/resources
-  value:
-    requests:
-      cpu: "10"
-      memory: "24000"
+  value: {}
 - op: add
   path: /spec/containers/1/resources
   value: {}
-- op: add
-  path: /spec/priorityClassName
-  value: high-priority-nonpreempting
 allowed: true
 patchType: JSONPatch
 uid: ""

--- a/pkg/pod-scaler/cache_sanitize.go
+++ b/pkg/pod-scaler/cache_sanitize.go
@@ -1,0 +1,172 @@
+package pod_scaler
+
+import (
+	"math"
+	"strings"
+
+	"github.com/openhistogram/circonusllhist"
+	"github.com/prometheus/common/model"
+)
+
+const (
+	// DefaultMaxMemoryWorkingSetBytes matches the build-farm admission --memory-cap default.
+	DefaultMaxMemoryWorkingSetBytes = 20 * 1024 * 1024 * 1024
+	// DefaultMaxCPUCores matches the build-farm admission --cpu-cap default.
+	DefaultMaxCPUCores = 10.0
+	// DefaultMaxIncreaseRatio matches admission corrupt-spike detection.
+	DefaultMaxIncreaseRatio = 10.0
+)
+
+// SanitizeOptions bounds acceptable histogram values when repairing cached query data.
+type SanitizeOptions struct {
+	MaxMemoryBytes     float64
+	MaxCPUCores        float64
+	MaxIncreaseRatio   float64
+	SparseSampleCutoff uint64
+}
+
+// DefaultSanitizeOptions returns options aligned with admission webhook caps.
+func DefaultSanitizeOptions() SanitizeOptions {
+	return SanitizeOptions{
+		MaxMemoryBytes:     DefaultMaxMemoryWorkingSetBytes,
+		MaxCPUCores:        DefaultMaxCPUCores,
+		MaxIncreaseRatio:   DefaultMaxIncreaseRatio,
+		SparseSampleCutoff: 10,
+	}
+}
+
+// RepairStats summarizes cache repair actions.
+type RepairStats struct {
+	RemovedMetaKeys      int
+	RemovedOrphanRefs    int
+	RemovedHistograms    int
+	RemovedCorruptValues int
+}
+
+// Repair removes orphan metadata references and histograms with corrupt spikes.
+func (q *CachedQuery) Repair(metricName string, opts SanitizeOptions) RepairStats {
+	if q == nil {
+		return RepairStats{}
+	}
+	if q.Data == nil {
+		q.Data = map[model.Fingerprint]*circonusllhist.HistogramWithoutLookups{}
+	}
+	if q.DataByMetaData == nil {
+		q.DataByMetaData = map[FullMetadata][]FingerprintTime{}
+	}
+
+	stats := RepairStats{}
+	stats.RemovedMetaKeys, stats.RemovedOrphanRefs = q.pruneOrphanMetadata()
+	removedCorrupt, extraMeta, extraRefs := q.pruneCorruptHistograms(metricName, opts)
+	stats.RemovedCorruptValues = removedCorrupt
+	stats.RemovedMetaKeys += extraMeta
+	stats.RemovedOrphanRefs += extraRefs
+	stats.RemovedHistograms = q.pruneUnreferencedHistograms()
+	return stats
+}
+
+func (q *CachedQuery) pruneOrphanMetadata() (removedMeta int, removedRefs int) {
+	for meta, fingerprintTimes := range q.DataByMetaData {
+		kept := make([]FingerprintTime, 0, len(fingerprintTimes))
+		for _, fingerprintTime := range fingerprintTimes {
+			if _, ok := q.Data[fingerprintTime.Fingerprint]; ok {
+				kept = append(kept, fingerprintTime)
+				continue
+			}
+			removedRefs++
+		}
+		if len(kept) == 0 {
+			delete(q.DataByMetaData, meta)
+			removedMeta++
+			continue
+		}
+		q.DataByMetaData[meta] = kept
+	}
+	return removedMeta, removedRefs
+}
+
+func (q *CachedQuery) pruneCorruptHistograms(metricName string, opts SanitizeOptions) (removed int, extraMeta int, extraRefs int) {
+	for fingerprint, histWithoutLookups := range q.Data {
+		hist := histWithoutLookups.Histogram()
+		if hist == nil || hist.Count() == 0 {
+			delete(q.Data, fingerprint)
+			removed++
+			continue
+		}
+		if histogramCorrupt(metricName, hist, opts) {
+			delete(q.Data, fingerprint)
+			removed++
+		}
+	}
+	if removed > 0 {
+		extraMeta, extraRefs = q.pruneOrphanMetadata()
+	}
+	return removed, extraMeta, extraRefs
+}
+
+func (q *CachedQuery) pruneUnreferencedHistograms() int {
+	referenced := map[model.Fingerprint]struct{}{}
+	for _, fingerprintTimes := range q.DataByMetaData {
+		for _, fingerprintTime := range fingerprintTimes {
+			referenced[fingerprintTime.Fingerprint] = struct{}{}
+		}
+	}
+	removed := 0
+	for fingerprint := range q.Data {
+		if _, ok := referenced[fingerprint]; ok {
+			continue
+		}
+		delete(q.Data, fingerprint)
+		removed++
+	}
+	return removed
+}
+
+func histogramCorrupt(metricName string, hist *circonusllhist.Histogram, opts SanitizeOptions) bool {
+	maxValue := hist.Max()
+	if !valueUsable(maxValue) {
+		return true
+	}
+	if isMemoryMetric(metricName) {
+		if maxValue > opts.MaxMemoryBytes {
+			return true
+		}
+	} else if isCPUMetric(metricName) {
+		if maxValue > opts.MaxCPUCores {
+			return true
+		}
+	}
+	baseline := histogramBaseline(hist, opts.SparseSampleCutoff)
+	if baseline != nil && *baseline > 0 && maxValue > (*baseline)*opts.MaxIncreaseRatio {
+		return true
+	}
+	return false
+}
+
+func histogramBaseline(hist *circonusllhist.Histogram, sparseSampleCutoff uint64) *float64 {
+	if hist.Count() == 0 {
+		return nil
+	}
+	var baseline float64
+	if hist.Count() < sparseSampleCutoff {
+		baseline = hist.Max()
+	} else {
+		baseline = hist.ValueAtQuantile(0.8)
+	}
+	if !valueUsable(baseline) {
+		return nil
+	}
+	return &baseline
+}
+
+func valueUsable(v float64) bool {
+	return !math.IsNaN(v) && !math.IsInf(v, 0) && v >= 0
+}
+
+func isMemoryMetric(metricName string) bool {
+	return strings.Contains(metricName, "memory")
+}
+
+func isCPUMetric(metricName string) bool {
+	return strings.Contains(metricName, "cpu")
+}

--- a/pkg/pod-scaler/cache_sanitize_test.go
+++ b/pkg/pod-scaler/cache_sanitize_test.go
@@ -1,0 +1,133 @@
+package pod_scaler
+
+import (
+	"testing"
+
+	"github.com/openhistogram/circonusllhist"
+	"github.com/prometheus/common/model"
+)
+
+func TestCachedQuery_Repair(t *testing.T) {
+	opts := DefaultSanitizeOptions()
+
+	t.Run("memory orphan and spike", func(t *testing.T) {
+		fpGood := model.Fingerprint(1)
+		fpOrphan := model.Fingerprint(2)
+		fpSpike := model.Fingerprint(3)
+
+		goodInner := circonusllhist.New()
+		for i := 0; i < 20; i++ {
+			if err := goodInner.RecordValue(1e8); err != nil {
+				t.Fatalf("RecordValue: %v", err)
+			}
+		}
+		goodHist := circonusllhist.NewHistogramWithoutLookups(goodInner)
+
+		spikeInner := circonusllhist.New()
+		for i := 0; i < 20; i++ {
+			if err := spikeInner.RecordValue(1e8); err != nil {
+				t.Fatalf("RecordValue: %v", err)
+			}
+		}
+		if err := spikeInner.RecordValue(float64(30 * 1024 * 1024 * 1024)); err != nil {
+			t.Fatalf("RecordValue spike: %v", err)
+		}
+		spikeHist := circonusllhist.NewHistogramWithoutLookups(spikeInner)
+
+		meta := FullMetadata{Container: "test"}
+		query := &CachedQuery{
+			Data: map[model.Fingerprint]*circonusllhist.HistogramWithoutLookups{
+				fpGood:  goodHist,
+				fpSpike: spikeHist,
+			},
+			DataByMetaData: map[FullMetadata][]FingerprintTime{
+				meta: {
+					{Fingerprint: fpGood},
+					{Fingerprint: fpOrphan},
+					{Fingerprint: fpSpike},
+				},
+			},
+		}
+
+		stats := query.Repair("container_memory_working_set_bytes", opts)
+		if stats.RemovedOrphanRefs != 2 {
+			t.Fatalf("RemovedOrphanRefs = %d, want 2", stats.RemovedOrphanRefs)
+		}
+		if stats.RemovedCorruptValues != 1 {
+			t.Fatalf("RemovedCorruptValues = %d, want 1", stats.RemovedCorruptValues)
+		}
+		if len(query.Data) != 1 {
+			t.Fatalf("histogram count = %d, want 1", len(query.Data))
+		}
+		if len(query.DataByMetaData[meta]) != 1 {
+			t.Fatalf("meta refs = %d, want 1", len(query.DataByMetaData[meta]))
+		}
+	})
+
+	t.Run("zero baseline skips ratio check", func(t *testing.T) {
+		fp := model.Fingerprint(11)
+		meta := FullMetadata{Container: "idle"}
+
+		inner := circonusllhist.New()
+		for i := 0; i < 20; i++ {
+			if err := inner.RecordValue(0); err != nil {
+				t.Fatalf("RecordValue: %v", err)
+			}
+		}
+		if err := inner.RecordValue(0.5); err != nil {
+			t.Fatalf("RecordValue: %v", err)
+		}
+
+		query := &CachedQuery{
+			Data: map[model.Fingerprint]*circonusllhist.HistogramWithoutLookups{
+				fp: circonusllhist.NewHistogramWithoutLookups(inner),
+			},
+			DataByMetaData: map[FullMetadata][]FingerprintTime{
+				meta: {{Fingerprint: fp}},
+			},
+		}
+
+		stats := query.Repair("container_cpu_usage_seconds_total", opts)
+		if stats.RemovedCorruptValues != 0 {
+			t.Fatalf("RemovedCorruptValues = %d, want 0", stats.RemovedCorruptValues)
+		}
+		if len(query.Data) != 1 {
+			t.Fatalf("histogram count = %d, want 1", len(query.Data))
+		}
+	})
+
+	t.Run("cpu corrupt histogram", func(t *testing.T) {
+		fp := model.Fingerprint(10)
+		meta := FullMetadata{Container: "test"}
+
+		inner := circonusllhist.New()
+		for i := 0; i < 20; i++ {
+			if err := inner.RecordValue(0.5); err != nil {
+				t.Fatalf("RecordValue: %v", err)
+			}
+		}
+		if err := inner.RecordValue(50); err != nil {
+			t.Fatalf("RecordValue spike: %v", err)
+		}
+
+		query := &CachedQuery{
+			Data: map[model.Fingerprint]*circonusllhist.HistogramWithoutLookups{
+				fp: circonusllhist.NewHistogramWithoutLookups(inner),
+			},
+			DataByMetaData: map[FullMetadata][]FingerprintTime{
+				meta: {{Fingerprint: fp}},
+			},
+		}
+
+		stats := query.Repair("container_cpu_usage_seconds_total", opts)
+		if stats.RemovedCorruptValues != 1 {
+			t.Fatalf("RemovedCorruptValues = %d, want 1", stats.RemovedCorruptValues)
+		}
+		if len(query.Data) != 0 {
+			t.Fatalf("histogram count = %d, want 0", len(query.Data))
+		}
+		if len(query.DataByMetaData) != 0 {
+			t.Fatalf("meta refs = %d, want 0", len(query.DataByMetaData))
+		}
+	})
+}

--- a/test/e2e/pod-scaler/e2e_test.go
+++ b/test/e2e/pod-scaler/e2e_test.go
@@ -406,8 +406,7 @@ func TestAdmissionAuthoritativeDryRun(t *testing.T) {
 		ctx, cancel := context.WithCancel(interrupts.Context())
 		defer cancel()
 		admissionHost, transport := run.Admission(T, dataDir, kubeconfigFile, ctx, false,
-			"--authoritative-cpu=true",
-			"--authoritative-cpu-dry-run=true",
+			"--authoritative-cpu-request=false",
 			fmt.Sprintf("--cpu-cap=%d", cpuCap),
 		)
 		got := cpuRequestAfterAdmission(t, &basePod, admissionHost, transport)

--- a/test/e2e/pod-scaler/run/consumer.go
+++ b/test/e2e/pod-scaler/run/consumer.go
@@ -20,8 +20,8 @@ import (
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
-// Admission sets up the pod-scaler admission server and returns a transport for talking to it.
-// extraFlags are appended to the pod-scaler admission invocation (e.g. authoritative dry-run flags).
+// Admission starts pod-scaler admission and returns its HTTPS endpoint and transport.
+// extraFlags are appended to the invocation, for example authoritative apply flags.
 func Admission(t testhelper.TestingTInterface, dataDir, kubeconfig string, parent context.Context, stream bool, extraFlags ...string) (string, *http.Transport) {
 	authDir := t.TempDir()
 	caCertFile := path.Join(authDir, "ca.crt")


### PR DESCRIPTION
Follow-up to [DPTP-2938](https://redhat.atlassian.net/browse/DPTP-2938) 
Hardens pod-scaler against corrupt GCS cache: skip zero-config and >10x increases, reject sub-512Ki recommendations, and replace per-resource cache snapshots on reload so stale RAM data clears without pod restarts.
Adds configurable skip flags for authoritative decrease by workload type/class so OOM'd workloads can be adjusted via escalation and adaptive decrease instead of bad admission mutations.

https://github.com/openshift/release/pull/81763

/cc @openshift/test-platform 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Hardens the OpenShift CI pod-scaler admission/recommendation pipeline and makes authoritative decrease behavior safer and more flexible.

### Component behavior changes (pod-scaler)
- **Skips unsafe cache-driven recommendations**: rejects recommendations that don’t meet the pod-scaler “usable minimum” (e.g., memory below **512Ki**), avoids **zero-config** and **over-10x** increases, and sanitizes previously-stamped/corrupt configured resource values before applying increases. Increases are clamped to both cluster caps and configured thresholds (including a max increase ratio), with warnings emitted when recommendation-based increases are capped.
- **Makes GCS cache reload resilient to corruption/staleness**: repairs cached query data on both load and store (removing orphan metadata, corrupt histograms/values, and stale references), and improves reload delivery semantics with retries, freshness checks, and “pending delivery” so early subscribers immediately see the correct cached snapshot.
- **Prevents unschedulable mutations more robustly**: refactors CPU/memory capping logic (with nil-guards) to cap both **requests and limits** consistently.

### Authoritative decrease controls for CI workloads
- Adds **configurable skip flags** to avoid authoritative CPU/memory *decreases* for selected **workload types/classes**. For those workloads, the pipeline uses escalation/adaptive decrease instead of admission-driven authoritative decrease mutations.
- Updates authoritative decrease logic (including usage-basis selection) and changes the apply/dry-run branching and logging to reflect the new configuration model.

### Tests/fixtures
- Updates and expands unit tests for cache repair, reload/pending delivery, recommendation sanitization/capping, authoritative basis/skip parsing, and unschedulable-prevention edge cases.
- Updates pod mutation fixtures and e2e expectations (including authoritative dry-run flag behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->