### PR TITLE
clusterimageset-updater: bump integration fixtures to 4.21.24

### DIFF
--- a/test/integration/clusterimageset-updater/output/imagesets/ocp-release-4.21.24-multi-for-4.21.0-0-to-4.22.0-0_clusterimageset.yaml
+++ b/test/integration/clusterimageset-updater/output/imagesets/ocp-release-4.21.24-multi-for-4.21.0-0-to-4.22.0-0_clusterimageset.yaml
@@ -5,7 +5,7 @@ metadata:
     version_lower: 4.21.0-0
     version_upper: 4.22.0-0
   creationTimestamp: null
-  name: ocp-release-4.21.20-multi-for-4.21.0-0-to-4.22.0-0
+  name: ocp-release-4.21.24-multi-for-4.21.0-0-to-4.22.0-0
 spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.21.20-multi
+  releaseImage: quay.io/openshift-release-dev/ocp-release:4.21.24-multi
 status: {}

--- a/test/integration/clusterimageset-updater/output/pools/4-21-20_clusterpool.yaml
+++ b/test/integration/clusterimageset-updater/output/pools/4-21-20_clusterpool.yaml
@@ -18,7 +18,7 @@ spec:
   hibernationConfig:
     resumeTimeout: 20m0s
   imageSetRef:
-    name: ocp-release-4.21.20-multi-for-4.21.0-0-to-4.22.0-0
+    name: ocp-release-4.21.24-multi-for-4.21.0-0-to-4.22.0-0
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
     name: install-config-aws-us-east-1

--- a/test/integration/clusterimageset-updater/output/pools/4-21-auto_clusterpool.yaml
+++ b/test/integration/clusterimageset-updater/output/pools/4-21-auto_clusterpool.yaml
@@ -18,7 +18,7 @@ spec:
   hibernationConfig:
     resumeTimeout: 20m0s
   imageSetRef:
-    name: ocp-release-4.21.20-multi-for-4.21.0-0-to-4.22.0-0
+    name: ocp-release-4.21.24-multi-for-4.21.0-0-to-4.22.0-0
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
     name: install-config-aws-us-east-1


### PR DESCRIPTION
/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates the clusterimageset-updater integration fixtures to OCP 4.21.24. ClusterPool fixtures now reference the corresponding `4.21.24-multi` ClusterImageSet, while preserving the existing release mapping and version range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->