### PR TITLE
bug fix: Don't drop secrets from index that don't come from ci-secret-generator config

### DIFF
--- a/cmd/ci-secret-generator/main.go
+++ b/cmd/ci-secret-generator/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"reflect"
+	"sort"
 	"strings"
 
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
@@ -279,10 +280,41 @@ type FieldUpdateInfo struct {
 	Payload   []byte
 }
 
+func configManagedIndexEntries(config secretgenerator.Config, disabledClusters sets.Set[string]) sets.Set[string] {
+	managed := sets.New[string]()
+	for _, item := range config {
+		for _, field := range item.Fields {
+			if disabledClusters.Has(field.Cluster) {
+				continue
+			}
+			normalizedGroup := gsmvalidation.NormalizeName(item.ItemName)
+			normalizedField := gsmvalidation.NormalizeName(field.Name)
+			managed.Insert(fmt.Sprintf("%s%s%s", normalizedGroup, gsmvalidation.CollectionSecretDelimiter, normalizedField))
+		}
+	}
+	return managed
+}
+
+func mergeIndexEntries(managedFromConfig []string, previousIndexEntries, configManaged sets.Set[string]) []string {
+	indexEntries := sets.New(managedFromConfig...)
+	for entry := range previousIndexEntries {
+		if !configManaged.Has(entry) {
+			indexEntries.Insert(entry)
+		}
+	}
+	result := indexEntries.UnsortedList()
+	sort.Strings(result)
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
 func buildSecretsToUpdate(config secretgenerator.Config, disabledClusters sets.Set[string], previousIndexEntries sets.Set[string]) ([]ItemUpdateInfo, []string, error) {
 	var errs []error
 	var newIndexEntries []string
 	var secretsToUpdate []ItemUpdateInfo
+	configManaged := configManagedIndexEntries(config, disabledClusters)
 
 	for _, item := range config {
 		logger := logrus.WithField("item", item.ItemName)
@@ -328,7 +360,9 @@ func buildSecretsToUpdate(config secretgenerator.Config, disabledClusters sets.S
 		secretsToUpdate = append(secretsToUpdate, itemStruct)
 	}
 
-	return secretsToUpdate, newIndexEntries, utilerrors.NewAggregate(errs)
+	// we need to preserve secrets in our collection that do not come from the generator config file
+	updatedIndexEntries := mergeIndexEntries(newIndexEntries, previousIndexEntries, configManaged)
+	return secretsToUpdate, updatedIndexEntries, utilerrors.NewAggregate(errs)
 }
 
 func main() {

--- a/cmd/ci-secret-generator/main_test.go
+++ b/cmd/ci-secret-generator/main_test.go
@@ -629,6 +629,29 @@ func TestBuildSecretsToUpdate(t *testing.T) {
 			expectedIndexFields: []string{"cluster-test__field1", "cluster-test__field3"},
 		},
 		{
+			name: "disabled cluster field preserved when already in index",
+			config: secretgenerator.Config{{
+				ItemName: "cluster-test",
+				Fields: []secretgenerator.FieldGenerator{
+					{Name: "field1", Cmd: "printf 'value1'", Cluster: "enabled-cluster"},
+					{Name: "field2", Cmd: "printf 'value2'", Cluster: "disabled-cluster"},
+					{Name: "field3", Cmd: "printf 'value3'", Cluster: "enabled-cluster"},
+				},
+			}},
+			disabledClusters:    sets.New[string]("disabled-cluster"),
+			existingIndexValues: []string{"cluster-test__field2", "non-generated__secret"},
+			expectedItems: map[string]ItemUpdateInfo{
+				"cluster-test": {
+					ItemName: "cluster-test",
+					Fields: []FieldUpdateInfo{
+						{FieldName: "field1", Payload: []byte("value1")},
+						{FieldName: "field3", Payload: []byte("value3")},
+					},
+				},
+			},
+			expectedIndexFields: []string{"cluster-test__field1", "cluster-test__field2", "cluster-test__field3", "non-generated__secret"},
+		},
+		{
 			name: "GSM sync enabled - names with forbidden characters are normalized in index",
 			config: secretgenerator.Config{{
 				ItemName: "aws.config",
@@ -646,7 +669,7 @@ func TestBuildSecretsToUpdate(t *testing.T) {
 					},
 				},
 			},
-			expectedIndexFields: []string{"aws--dot--config__config--dot--json", "aws--dot--config__auth_token"},
+			expectedIndexFields: []string{"aws--dot--config__auth_token", "aws--dot--config__config--dot--json"},
 		},
 		{
 			name: "GSM sync enabled - item with notes",
@@ -722,7 +745,7 @@ func TestBuildSecretsToUpdate(t *testing.T) {
 			expectError:         true,
 		},
 		{
-			name: "secret removed from config is removed from index",
+			name: "secret not in config is preserved in index",
 			config: secretgenerator.Config{{
 				ItemName: "item1",
 				Fields: []secretgenerator.FieldGenerator{
@@ -738,7 +761,26 @@ func TestBuildSecretsToUpdate(t *testing.T) {
 					},
 				},
 			},
-			expectedIndexFields: []string{"item1__field1"},
+			expectedIndexFields: []string{"item1__field1", "item2__field2"},
+		},
+		{
+			name: "manually created secret is preserved across generator run",
+			config: secretgenerator.Config{{
+				ItemName: "build_farm",
+				Fields: []secretgenerator.FieldGenerator{
+					{Name: "field1", Cmd: "printf 'value1'"},
+				},
+			}},
+			existingIndexValues: []string{"build_farm__field1", "cherrypick-signing-key__id_ed25519"},
+			expectedItems: map[string]ItemUpdateInfo{
+				"build_farm": {
+					ItemName: "build_farm",
+					Fields: []FieldUpdateInfo{
+						{FieldName: "field1", Payload: []byte("value1")},
+					},
+				},
+			},
+			expectedIndexFields: []string{"build_farm__field1", "cherrypick-signing-key__id_ed25519"},
 		},
 		{
 			name: "mixed: existing succeeds, existing fails, new succeeds, new fails",
@@ -761,7 +803,7 @@ func TestBuildSecretsToUpdate(t *testing.T) {
 					},
 				},
 			},
-			expectedIndexFields: []string{"test__existing-success", "test__existing-fail", "test__new-success"},
+			expectedIndexFields: []string{"test__existing-fail", "test__existing-success", "test__new-success"},
 			expectError:         true,
 		},
 	}


### PR DESCRIPTION
`ci-secret-generator` runs every 12h and rebuilds the collection index from `_config.yaml`. Secrets created manually (e.g. `secret-manager create cherrypick-signing-key/id_ed25519` using the CLI tool) were dropped from the index each run — GSM kept the secret but the index didn't list it, so `secret-manager list` missed it and `create`/`update` could fail.

**Root cause:** The generator read the previous index but only used it to rescue failed command executions — it never merged in entries not derived from config.

**Fix:** After building index entries from config, merge in previous index entries whose names don't appear in the config-managed set. Index is now sorted for determinism.

**Example:** Some GSM secrets (including `cherrypick-signing-key__id_ed25519`) were missing from the index while present in GSM. After this fix they persist across generator runs.

**Trade-off:** Secrets removed from config will linger in the index (indistinguishable from manual secrets). No GSM-side deletion occurs — cleanup is manual.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Fix `ci-secret-generator` dropping manually created GSM secrets during its periodic (12-hour) index rebuilds.

In the `cmd/ci-secret-generator` component, newly generated index entries from `_config.yaml` are now merged with the previous index contents for any entries that are not config-managed (including entries for disabled clusters). The resulting index is then sorted deterministically so `secret-manager` can reliably discover the full set of GSM secrets, not just those coming from config. If a secret is removed from `_config.yaml`, it is kept in the index and requires manual cleanup; the generator does not delete anything in GSM.

Unit tests were updated to verify preservation of manually created entries across rebuilds and to assert the expected deterministic ordering of index fields/items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->