### PR TITLE
fix(check-cluster-profiles-config): read secrets from config file

### DIFF
--- a/cmd/check-cluster-profiles-config/main.go
+++ b/cmd/check-cluster-profiles-config/main.go
@@ -20,12 +20,7 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/load"
-	"github.com/openshift/ci-tools/pkg/registry/server"
 	"github.com/openshift/ci-tools/pkg/util"
-)
-
-var (
-	configResolverAddress = api.URLForService(api.ServiceConfig)
 )
 
 type options struct {
@@ -183,7 +178,7 @@ func (validator *profileValidator) Validate(profiles api.ClusterProfiles) error 
 	return nil
 }
 
-// checkCISecrets verifies that the secret for each cluster profile exists in the ci namespace
+// checkCISecrets verifies that the secret for each cluster profile exists in the ci namespace.
 func (validator *profileValidator) checkCISecrets() error {
 	errs := make([]error, 0)
 
@@ -192,16 +187,15 @@ func (validator *profileValidator) checkCISecrets() error {
 			continue
 		}
 
-		clusterProfile, err := server.NewResolverClient(configResolverAddress).ClusterProfile(profile.Name)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to retrieve details from config resolver for '%s' cluster profile: %w", profile.Name, err))
+		if profile.Secret == "" {
+			errs = append(errs, fmt.Errorf("cluster profile '%s' is missing a secret", profile.Name))
 			continue
 		}
 
 		ciSecret := &coreapi.Secret{}
-		err = validator.kubeClient.Get(context.Background(), ctrlruntimeclient.ObjectKey{Namespace: "ci", Name: clusterProfile.Secret}, ciSecret)
+		err := validator.kubeClient.Get(context.Background(), ctrlruntimeclient.ObjectKey{Namespace: "ci", Name: profile.Secret}, ciSecret)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to get secret '%s' for cluster profile '%s': %w", clusterProfile.Secret, profile.Name, err))
+			errs = append(errs, fmt.Errorf("failed to get secret '%s' for cluster profile '%s': %w", profile.Secret, profile.Name, err))
 		}
 	}
 

--- a/cmd/check-cluster-profiles-config/main_test.go
+++ b/cmd/check-cluster-profiles-config/main_test.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	coreapi "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/openshift/ci-tools/pkg/api"
@@ -103,6 +106,84 @@ func TestValidate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			validator := newValidator(fakectrlruntimeclient.NewFakeClient())
 			err := validator.Validate(tc.profiles)
+			if diff := cmp.Diff(tc.expected, err, testhelper.EquateErrorMessage); diff != "" {
+				t.Errorf("error differs from expected:\n%v", diff)
+			}
+		})
+	}
+}
+
+func TestCheckCISecrets(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		profiles api.ClusterProfiles
+		secrets  []coreapi.Secret
+		expected error
+	}{
+		{
+			name: "existing secret for profile",
+			profiles: api.ClusterProfiles{
+				Items: []api.ClusterProfile{{
+					Name:   "aws",
+					Secret: "cluster-secrets-aws",
+				}},
+			},
+			secrets: []coreapi.Secret{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ci",
+					Name:      "cluster-secrets-aws",
+				},
+			}},
+		},
+		{
+			name: "profile set is skipped",
+			profiles: api.ClusterProfiles{
+				Items: []api.ClusterProfile{{
+					Name:       "openshift-org-aws",
+					SetMembers: []string{"aws", "aws-2"},
+				}},
+			},
+		},
+		{
+			name: "missing secret in cluster",
+			profiles: api.ClusterProfiles{
+				Items: []api.ClusterProfile{{
+					Name:   "aws",
+					Secret: "cluster-secrets-aws",
+				}},
+			},
+			expected: fmt.Errorf(`failed to get secret 'cluster-secrets-aws' for cluster profile 'aws': secrets "cluster-secrets-aws" not found`),
+		},
+		{
+			name: "profile without secret field",
+			profiles: api.ClusterProfiles{
+				Items: []api.ClusterProfile{{
+					Name: "aws",
+				}},
+			},
+			expected: fmt.Errorf(`cluster profile 'aws' is missing a secret`),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			objects := make([]runtime.Object, 0, len(tc.secrets))
+			for i := range tc.secrets {
+				objects = append(objects, &tc.secrets[i])
+			}
+
+			client := fakectrlruntimeclient.NewClientBuilder().WithRuntimeObjects(objects...).Build()
+			validator := newValidator(client)
+
+			if err := validator.Validate(tc.profiles); err != nil {
+				t.Fatalf("unexpected validation error: %v", err)
+			}
+
+			err := validator.checkCISecrets()
 			if diff := cmp.Diff(tc.expected, err, testhelper.EquateErrorMessage); diff != "" {
 				t.Errorf("error differs from expected:\n%v", diff)
 			}


### PR DESCRIPTION
`check-cluster-profiles-config` presubmit queried the live config resolver for secret names, which fails with 404 for newly introduced profiles. Fix: Read secret names from the config file under validation instead, since every non-set profile already declares `secret:` there.

https://redhat.atlassian.net/browse/DPTP-5051

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updates the `check-cluster-profiles-config` CI validation tool to look up referenced Kubernetes Secret names directly from the cluster profile configuration being validated, rather than resolving them against the live config-resolver. This prevents false 404 validation failures when newly introduced profiles declare their secrets only in the config under test. The validator now also produces a clear validation error when a profile omits the required `Secret` field. Added table-driven test coverage for successful Secret lookup, skipping profiles with `SetMembers`, missing Secrets, and missing/empty Secret declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->