### PR TITLE
pod-scaler: add authoritative-guaranteed-qos admission flag

### DIFF
--- a/cmd/pod-scaler/admission.go
+++ b/cmd/pod-scaler/admission.go
@@ -147,9 +147,12 @@ func (c authoritativeSkipConfig) skipsRequestDecrease(workloadType, workloadClas
 	return workloadClass != "" && c.requestDecreaseWorkloadClasses.Has(workloadClass)
 }
 
-func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Interface, kubeClient kubernetes.Interface, loaders map[string][]*cacheReloader, mutateResourceLimits bool, cpuCap int64, memoryCap string, cpuPriorityScheduling int64, percentageMeasured float64, measuredPodCPUIncrease float64, systemReservedCPU int64, authoritative authoritativeConfig, authoritativeDecreaseUsage authoritativeDecreaseUsageBasis, authoritativeSkip authoritativeSkipConfig, escalations *escalationServer, reporter results.PodScalerReporter, recommendationBufferPercent int) {
+func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Interface, kubeClient kubernetes.Interface, loaders map[string][]*cacheReloader, mutateResourceLimits bool, cpuCap int64, memoryCap string, cpuPriorityScheduling int64, percentageMeasured float64, measuredPodCPUIncrease float64, systemReservedCPU int64, authoritative authoritativeConfig, authoritativeDecreaseUsage authoritativeDecreaseUsageBasis, authoritativeSkip authoritativeSkipConfig, escalations *escalationServer, reporter results.PodScalerReporter, recommendationBufferPercent int, authoritativeGuaranteedQoS bool) {
 	logger := logrus.WithField("component", "pod-scaler admission")
 	logger.Infof("Initializing admission webhook server with %d loaders.", len(loaders))
+	if authoritativeGuaranteedQoS {
+		logger.Info("authoritative guaranteed QoS enabled: requests will be set equal to limits after authoritative decreases")
+	}
 	if authoritative.anyDryRun() {
 		logger.WithFields(logrus.Fields{
 			"authoritative_cpu_request_apply":    authoritative.cpuRequest.apply,
@@ -169,7 +172,7 @@ func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Int
 		Port:    port,
 		CertDir: certDir,
 	})
-	server.Register("/pods", &webhook.Admission{Handler: &podMutator{logger: logger, client: client, decoder: decoder, resources: resources, mutateResourceLimits: mutateResourceLimits, cpuCap: cpuCap, memoryCap: memoryCap, cpuPriorityScheduling: cpuPriorityScheduling, percentageMeasured: percentageMeasured, measuredPodCPUIncrease: measuredPodCPUIncrease, nodeCache: nodeCache, authoritative: authoritative, authoritativeDecreaseUsage: authoritativeDecreaseUsage, authoritativeSkip: authoritativeSkip, escalations: escalations, reporter: reporter, recommendationBufferPercent: recommendationBufferPercent}})
+	server.Register("/pods", &webhook.Admission{Handler: &podMutator{logger: logger, client: client, decoder: decoder, resources: resources, mutateResourceLimits: mutateResourceLimits, cpuCap: cpuCap, memoryCap: memoryCap, cpuPriorityScheduling: cpuPriorityScheduling, percentageMeasured: percentageMeasured, measuredPodCPUIncrease: measuredPodCPUIncrease, nodeCache: nodeCache, authoritative: authoritative, authoritativeDecreaseUsage: authoritativeDecreaseUsage, authoritativeSkip: authoritativeSkip, authoritativeGuaranteedQoS: authoritativeGuaranteedQoS, escalations: escalations, reporter: reporter, recommendationBufferPercent: recommendationBufferPercent}})
 	logger.Info("Serving admission webhooks.")
 	if err := server.Start(interrupts.Context()); err != nil {
 		logrus.WithError(err).Fatal("Failed to serve webhooks.")
@@ -191,6 +194,7 @@ type podMutator struct {
 	authoritative               authoritativeConfig
 	authoritativeDecreaseUsage  authoritativeDecreaseUsageBasis
 	authoritativeSkip           authoritativeSkipConfig
+	authoritativeGuaranteedQoS  bool
 	escalations                 *escalationServer
 	reporter                    results.PodScalerReporter
 	recommendationBufferPercent int
@@ -242,7 +246,7 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 		m.setMeasuredLabel(pod, false, logger)
 	}
 
-	mutatePodResources(pod, m.resources, m.mutateResourceLimits, m.cpuCap, m.memoryCap, isMeasured, m.nodeCache, m.measuredPodCPUIncrease, m.authoritative, m.authoritativeDecreaseUsage, m.authoritativeSkip, m.escalations, m.reporter, m.recommendationBufferPercent, logger)
+	mutatePodResources(pod, m.resources, m.mutateResourceLimits, m.cpuCap, m.memoryCap, isMeasured, m.nodeCache, m.measuredPodCPUIncrease, m.authoritative, m.authoritativeDecreaseUsage, m.authoritativeSkip, m.escalations, m.reporter, m.recommendationBufferPercent, m.authoritativeGuaranteedQoS, logger)
 	m.addPriorityClass(pod)
 
 	marshaledPod, err := json.Marshal(pod)
@@ -653,7 +657,7 @@ func capResourceList(list corev1.ResourceList, cpuCap, memoryCap resource.Quanti
 	}
 }
 
-func mutatePodResources(pod *corev1.Pod, server *resourceServer, mutateResourceLimits bool, cpuCap int64, memoryCap string, isMeasured bool, nodeCache *nodeAllocatableCache, measuredPodCPUIncrease float64, authoritative authoritativeConfig, authoritativeDecreaseUsage authoritativeDecreaseUsageBasis, authoritativeSkip authoritativeSkipConfig, escalations *escalationServer, reporter results.PodScalerReporter, recommendationBufferPercent int, logger *logrus.Entry) {
+func mutatePodResources(pod *corev1.Pod, server *resourceServer, mutateResourceLimits bool, cpuCap int64, memoryCap string, isMeasured bool, nodeCache *nodeAllocatableCache, measuredPodCPUIncrease float64, authoritative authoritativeConfig, authoritativeDecreaseUsage authoritativeDecreaseUsageBasis, authoritativeSkip authoritativeSkipConfig, escalations *escalationServer, reporter results.PodScalerReporter, recommendationBufferPercent int, authoritativeGuaranteedQoS bool, logger *logrus.Entry) {
 	workloadClass := pod.Labels[ciWorkloadLabel]
 
 	mutateResources := func(containers []corev1.Container) {
@@ -726,17 +730,21 @@ func mutatePodResources(pod *corev1.Pod, server *resourceServer, mutateResourceL
 				memoryCapQty := resource.MustParse(memoryCap)
 				sanitizeCorruptConfiguredResources(&containers[i].Resources, &resources, cpuCapQty, memoryCapQty, authoritative, logger)
 				useOursIfLarger(&resources, &containers[i].Resources, workloadName, workloadType, isMeasured, workloadClass, cpuCapQty, memoryCapQty, recommendationBufferPercent, reporter, logger)
-				if mutateResourceLimits {
+				if mutateResourceLimits && !authoritativeGuaranteedQoS {
 					reconcileLimits(&containers[i].Resources)
 				}
 				applyFailureEscalation(&containers[i].Resources, workloadType, workloadName, escalations, logger)
 				applyAuthoritativeLimitDecrease(&resources, &containers[i].Resources, workloadName, workloadType, isMeasured, workloadClass, authoritative, authoritativeDecreaseUsage, authoritativeSkip, escalations, logger)
-				if mutateResourceLimits && !authoritative.cpuLimit.apply {
+				if mutateResourceLimits && !authoritative.cpuLimit.apply && !authoritativeGuaranteedQoS {
 					if containers[i].Resources.Limits != nil {
 						delete(containers[i].Resources.Limits, corev1.ResourceCPU)
 					}
 				}
-				clampRequestsToLimits(&containers[i].Resources)
+				if authoritativeGuaranteedQoS {
+					applyAuthoritativeGuaranteedQoS(&containers[i].Resources)
+				} else {
+					clampRequestsToLimits(&containers[i].Resources)
+				}
 			}
 			enforceMinimumMemoryResources(&containers[i].Resources, logger)
 			preventUnschedulable(&containers[i].Resources, cpuCap, memoryCap, logger)
@@ -1321,5 +1329,23 @@ func clampRequestsToLimits(resources *corev1.ResourceRequirements) {
 		if request.Cmp(limit) > 0 {
 			resources.Requests[field] = limit.DeepCopy()
 		}
+	}
+}
+
+// applyAuthoritativeGuaranteedQoS sets requests equal to limits for CPU and memory
+// so admitted pods run with Guaranteed QoS after authoritative decreases.
+func applyAuthoritativeGuaranteedQoS(resources *corev1.ResourceRequirements) {
+	if resources == nil || resources.Limits == nil {
+		return
+	}
+	for _, field := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+		limit, ok := resources.Limits[field]
+		if !ok || limit.IsZero() {
+			continue
+		}
+		if resources.Requests == nil {
+			resources.Requests = corev1.ResourceList{}
+		}
+		resources.Requests[field] = limit.DeepCopy()
 	}
 }

--- a/cmd/pod-scaler/admission_test.go
+++ b/cmd/pod-scaler/admission_test.go
@@ -588,7 +588,7 @@ func TestMutatePodResources(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			original := testCase.pod.DeepCopy()
-			mutatePodResources(testCase.pod, testCase.server, testCase.mutateResourceLimits, 10, "20Gi", false, nil, 50.0, authoritativeConfig{}, authoritativeDecreaseUsageP80, authoritativeSkipConfig{}, nil, &defaultReporter, 20, logrus.WithField("test", testCase.name))
+			mutatePodResources(testCase.pod, testCase.server, testCase.mutateResourceLimits, 10, "20Gi", false, nil, 50.0, authoritativeConfig{}, authoritativeDecreaseUsageP80, authoritativeSkipConfig{}, nil, &defaultReporter, 20, false, logrus.WithField("test", testCase.name))
 			diff := cmp.Diff(original, testCase.pod)
 			// In some cases, cmp.Diff decides to use non-breaking spaces, and it's not
 			// particularly deterministic about this. We don't care.
@@ -653,7 +653,7 @@ func TestMutatePodResources_ciWorkloadLabelDoesNotBreakCacheLookup(t *testing.T)
 		},
 	}
 
-	mutatePodResources(pod, server, false, 10, "20Gi", false, nil, 50.0, authoritativeConfig{}, authoritativeDecreaseUsageP80, authoritativeSkipConfig{}, nil, &defaultReporter, 20, logger)
+	mutatePodResources(pod, server, false, 10, "20Gi", false, nil, 50.0, authoritativeConfig{}, authoritativeDecreaseUsageP80, authoritativeSkipConfig{}, nil, &defaultReporter, 20, false, logger)
 
 	got := pod.Spec.Containers[0].Resources.Requests.Cpu().MilliValue()
 	const want = 1000 // 10x cap from 100m configured; raw 5000m*1.2 would exceed threshold
@@ -1473,6 +1473,98 @@ func TestClampRequestsToLimits(t *testing.T) {
 	clampRequestsToLimits(&resources)
 	if diff := cmp.Diff(resources, expected); diff != "" {
 		t.Errorf("unexpected resources: %s", diff)
+	}
+}
+
+func TestApplyAuthoritativeGuaranteedQoS(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    corev1.ResourceRequirements
+		expected corev1.ResourceRequirements
+	}{
+		{
+			name: "raises requests to match limits",
+			input: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
+			expected: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
+		},
+		{
+			name: "only syncs resources with limits",
+			input: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("500m"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+			expected: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resources := tc.input
+			applyAuthoritativeGuaranteedQoS(&resources)
+			if diff := cmp.Diff(tc.expected, resources); diff != "" {
+				t.Errorf("unexpected resources: %s", diff)
+			}
+		})
+	}
+}
+
+func TestApplyAuthoritativeLimitDecrease_guaranteedQoS(t *testing.T) {
+	ours := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
+		},
+	}
+	theirs := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("4"),
+			corev1.ResourceMemory: resource.MustParse("8Gi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("4"),
+			corev1.ResourceMemory: resource.MustParse("8Gi"),
+		},
+	}
+	applyAuthoritativeLimitDecrease(&ours, &theirs, "test", WorkloadTypeProwjob, false, "", authLegacyCPUAndMemory(1.0, 1.0), authoritativeDecreaseUsageP80, authoritativeSkipConfig{}, nil, logrus.WithField("test", t.Name()))
+	expected := theirs
+	expected.Requests = corev1.ResourceList{}
+	expected.Limits = corev1.ResourceList{}
+	for field, limit := range theirs.Limits {
+		expected.Requests[field] = limit.DeepCopy()
+		expected.Limits[field] = limit.DeepCopy()
+	}
+	applyAuthoritativeGuaranteedQoS(&theirs)
+	if diff := cmp.Diff(expected, theirs); diff != "" {
+		t.Errorf("unexpected resources after guaranteed QoS: %s", diff)
 	}
 }
 

--- a/cmd/pod-scaler/main.go
+++ b/cmd/pod-scaler/main.go
@@ -91,6 +91,7 @@ type consumerOptions struct {
 	skipWorkloadTypeLimitDecrease                 string
 	skipWorkloadClassRequestDecrease              string
 	skipWorkloadClassLimitDecrease                string
+	authoritativeGuaranteedQoS                    bool
 	recommendationBufferPercent                   int
 }
 
@@ -156,6 +157,7 @@ func bindOptions(fs *flag.FlagSet) *options {
 	fs.StringVar(&o.skipWorkloadClassLimitDecrease, "pod-scaler-skip-workload-class-limit-decrease", "", "Comma-separated ci-workload classes that skip authoritative limit decreases (e.g. builds,tests).")
 	fs.StringVar(&o.skipWorkloadTypeRequestDecrease, "pod-scaler-skip-workload-type-request-decrease", "", "Comma-separated workload types that skip authoritative request decreases.")
 	fs.StringVar(&o.skipWorkloadClassRequestDecrease, "pod-scaler-skip-workload-class-request-decrease", "", "Comma-separated ci-workload classes that skip authoritative request decreases.")
+	fs.BoolVar(&o.authoritativeGuaranteedQoS, "authoritative-guaranteed-qos", false, "When true, after authoritative decreases set CPU and memory requests equal to their limits so pods run with Guaranteed QoS.")
 	fs.Float64Var(&o.failureEscalationFactor, "failure-escalation-factor", 1.5, "Multiplier applied per escalation level after OOM or CPU throttle (1.5 = 50% increase per level).")
 	fs.IntVar(&o.failureEscalationMaxLevel, "failure-escalation-max-level", 10, "Maximum escalation level tracked for a workload.")
 	fs.Float64Var(&o.cpuThrottleThreshold, "cpu-throttle-threshold", 0.25, "Minimum throttled/total CPU CFS period ratio to count as CPU deprived.")
@@ -384,7 +386,7 @@ func mainAdmission(opts *options, cache Cache) {
 	}
 
 	logrus.WithField("recommendation_buffer_percent", opts.recommendationBufferPercent).Info("Recommendation buffer configured.")
-	go admit(opts.port, opts.instrumentationOptions.HealthPort, opts.certDir, client, kubeClient, loaders(cache), opts.mutateResourceLimits, opts.cpuCap, opts.memoryCap, opts.cpuPriorityScheduling, opts.percentageMeasured, opts.measuredPodCPUIncrease, opts.systemReservedCPU, opts.authoritativeConfig(), usageBasis, opts.authoritativeSkipConfig(), escalations, reporter, opts.recommendationBufferPercent)
+	go admit(opts.port, opts.instrumentationOptions.HealthPort, opts.certDir, client, kubeClient, loaders(cache), opts.mutateResourceLimits, opts.cpuCap, opts.memoryCap, opts.cpuPriorityScheduling, opts.percentageMeasured, opts.measuredPodCPUIncrease, opts.systemReservedCPU, opts.authoritativeConfig(), usageBasis, opts.authoritativeSkipConfig(), escalations, reporter, opts.recommendationBufferPercent, opts.authoritativeGuaranteedQoS)
 }
 
 func loaders(cache Cache) map[string][]*cacheReloader {

--- a/test/e2e/pod-scaler/run/consumer.go
+++ b/test/e2e/pod-scaler/run/consumer.go
@@ -62,6 +62,7 @@ func Admission(t testhelper.TestingTInterface, dataDir, kubeconfig string, paren
 		"--mutate-resource-limits",
 		"--serving-cert-dir=" + authDir,
 		"--metrics-port=9092",
+		"--pprof-port=0",
 		"--report-credentials-file=" + credFile,
 	}
 	podScalerFlags = append(podScalerFlags, extraFlags...)


### PR DESCRIPTION
/cc @bear-redhat 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds an `--authoritative-guaranteed-qos` CLI option to the pod-scaler admission webhook used in OpenShift CI. When enabled, the scaler treats authoritative CPU/memory limit decreases as requests-to-limits “stamping” so the admitted pod’s CPU and memory requests are updated to match its limits, ensuring pods land in Kubernetes Guaranteed QoS.

The flag is plumbed from pod-scaler startup into the admission/mutation logic, replacing the prior request clamping path for CPU/memory with an authoritative-guaranteed QoS application routine. Unit tests were added to verify request/limit synchronization and correct interaction with authoritative limit decreases, and the e2e consumer admission process disables pprof via `--pprof-port=0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->