### PR TITLE
ci-operator: PDB allows removing unhealthy pods

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -54,6 +54,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	crcontrollerutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -1770,6 +1771,7 @@ func pdb(labelKey, namespace string) (*policyv1.PodDisruptionBudget, crcontrolle
 				Operator: metav1.LabelSelectorOpExists,
 			}},
 		}
+		pdb.Spec.UnhealthyPodEvictionPolicy = ptr.To(policyv1.AlwaysAllow)
 		return nil
 	}
 }


### PR DESCRIPTION
We are noticing the following problematic scenario:
1. `ci-operator` creates a Pod on the node `node-a`.
2. The main `test` container gets OOMKilled.
3. The pod becomes unhealthy.
4. The MCO controller tries to drain `node-a` but the PDB forbids the action.
5. The MCO gets stuck.

By setting `unhealthyPodEvictionPolicy: AlwaysAllow` we change the PDB behavour at point (4), as a consequence the MCO controller doesn't get stuck anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates the `ci-operator` PodDisruptionBudgets to always allow eviction of unhealthy test pods, including pods whose main container was OOM-killed. This helps node draining complete successfully instead of leaving the Machine Config Operator stuck.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->