### PR TITLE
Derive assemble release version prefix from stream name

### DIFF
--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -3,6 +3,7 @@ package release
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -155,9 +156,10 @@ func (s *assembleReleaseStep) run(ctx context.Context) error {
 		return fmt.Errorf("failed to resolve for importing imagestreamtags on %s/%s:%s: %w", s.jobSpec.Namespace(), streamName, "cluster-version-operator", err)
 	}
 
-	// we want to expose the release payload as a CI version that looks just like
-	// the release versions for nightlies and CI release candidates
-	prefix := "0.0.1-0"
+	// Prefer release-controller config when present; otherwise derive major.minor
+	// from the stream name (tag_specification / integration) so ClusterVersion
+	// stays in sync for presubmit-assembled payloads without an RC annotation.
+	prefix := assembleReleaseVersionPrefix(s.config)
 	if raw, ok := stable.ObjectMeta.Annotations[api.ReleaseConfigAnnotation]; ok {
 		configName, err := configresolver.ReleaseControllerAnnotationValueToConfigName(raw)
 		if err != nil {
@@ -298,6 +300,27 @@ func AssembleReleaseStep(name, nodeName string, config *api.ReleaseTagConfigurat
 		jobSpec:   jobSpec,
 		secret:    pullSecret,
 	}
+}
+
+func assembleReleaseVersionPrefix(config *api.ReleaseTagConfiguration) string {
+	if config == nil {
+		return "0.0.1-0"
+	}
+	// ocp-private streams are named like "5.0-priv"; strip that suffix before parsing.
+	name := strings.TrimSuffix(config.Name, "-priv")
+	parts := strings.Split(name, ".")
+	if len(parts) != 2 {
+		return "0.0.1-0"
+	}
+	major, err := strconv.ParseUint(parts[0], 10, 64)
+	if err != nil {
+		return "0.0.1-0"
+	}
+	minor, err := strconv.ParseUint(parts[1], 10, 64)
+	if err != nil {
+		return "0.0.1-0"
+	}
+	return fmt.Sprintf("%d.%d.0-0", major, minor)
 }
 
 func hasMinimumVersion(config *api.ReleaseTagConfiguration, majorVersion, minorVersion int) bool {

--- a/pkg/steps/release/create_release_test.go
+++ b/pkg/steps/release/create_release_test.go
@@ -10,6 +10,36 @@ import (
 	"github.com/openshift/ci-tools/pkg/api"
 )
 
+func TestAssembleReleaseVersionPrefix(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *api.ReleaseTagConfiguration
+		want   string
+	}{
+		{name: "nil config", want: "0.0.1-0"},
+		{name: "unparseable", config: &api.ReleaseTagConfiguration{Name: "not-a-version"}, want: "0.0.1-0"},
+		{name: "4.19 stream", config: &api.ReleaseTagConfiguration{Name: "4.19"}, want: "4.19.0-0"},
+		{name: "5.0 stream", config: &api.ReleaseTagConfiguration{Name: "5.0"}, want: "5.0.0-0"},
+		{name: "5.0-priv stream", config: &api.ReleaseTagConfiguration{Name: "5.0-priv"}, want: "5.0.0-0"},
+		{name: "4.19-priv stream", config: &api.ReleaseTagConfiguration{Name: "4.19-priv"}, want: "4.19.0-0"},
+		{name: "5.0-private ignored", config: &api.ReleaseTagConfiguration{Name: "5.0-private"}, want: "0.0.1-0"},
+		{name: "extra component", config: &api.ReleaseTagConfiguration{Name: "4.19.1"}, want: "0.0.1-0"},
+		{name: "suffix", config: &api.ReleaseTagConfiguration{Name: "4.19-suffix"}, want: "0.0.1-0"},
+		{name: "trailing letters", config: &api.ReleaseTagConfiguration{Name: "4.19x"}, want: "0.0.1-0"},
+		{name: "signed major", config: &api.ReleaseTagConfiguration{Name: "-1.2"}, want: "0.0.1-0"},
+		{name: "signed minor", config: &api.ReleaseTagConfiguration{Name: "4.-19"}, want: "0.0.1-0"},
+		{name: "leading whitespace", config: &api.ReleaseTagConfiguration{Name: " 4.19"}, want: "0.0.1-0"},
+		{name: "trailing whitespace", config: &api.ReleaseTagConfiguration{Name: "4.19 "}, want: "0.0.1-0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := cmp.Diff(tt.want, assembleReleaseVersionPrefix(tt.config)); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
 func TestBuildOcAdmReleaseNewCommand(t *testing.T) {
 	sourceTagReference := imagev1.SourceTagReferencePolicy
 


### PR DESCRIPTION
When assembling a release payload without a `release.openshift.io/config` annotation (typical for some presubmits), derive the version prefix from the stream name in `tag_specification` / `integration` (e.g. `5.0` → `5.0.0-0`, `4.19` → `4.19.0-0`) instead of a hardcoded fallback.

Release-controller annotated streams are unchanged: annotation `name` still wins (e.g. `5.0.0-0.ci`).

This keeps ClusterVersion / consumers that parse major in sync across OpenShift 4 and 5 without baking a single major into ci-operator.

/cc @openshift/test-platform

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updates the ci-operator release assembly step to pick the release image version prefix from the configured stream version (from `tag_specification` / `integration`) when the `release.openshift.io/config` annotation is not set. Unannotated streams now convert an input `major.minor` like `5.0` → `5.0.0-0` and `4.19` → `4.19.0-0`; if the derived stream name can’t be parsed as `major.minor` (or the config is nil), it falls back to `0.0.1-0`. When the `release.openshift.io/config` annotation is present, its resolved config `name` still takes precedence and leaves the prefix derivation unchanged. Adds unit coverage for nil/unparseable and multiple edge-case version strings in the new `assembleReleaseVersionPrefix` helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->