### PR TITLE
Improve validation for GSM secrets

### DIFF
--- a/pkg/api/gsm.go
+++ b/pkg/api/gsm.go
@@ -332,6 +332,11 @@ func (c *GSMConfig) Validate() error {
 				if !gsmvalidation.ValidateSecretName(secret.Name) {
 					errs = append(errs, fmt.Errorf("component %s[%d].secrets[%d] has invalid name", componentName, j, k))
 				}
+				if secret.As != "" {
+					if err := gsmvalidation.ValidateMountFileName(secret.As); err != nil {
+						errs = append(errs, fmt.Errorf("component %s[%d].secrets[%d].as is invalid: %w", componentName, j, k, err))
+					}
+				}
 			}
 		}
 	}
@@ -426,6 +431,11 @@ func validateBundle(bundle *GSMBundle, idx int) error {
 			if !gsmvalidation.ValidateSecretName(field.Name) {
 				errs = append(errs, fmt.Errorf("bundle %s gsm_secrets[%d].secrets[%d] has invalid name", bundle.Name, j, k))
 			}
+			if field.As != "" {
+				if err := gsmvalidation.ValidateMountFileName(field.As); err != nil {
+					errs = append(errs, fmt.Errorf("bundle %s gsm_secrets[%d].fields[%d].as is invalid: %w", bundle.Name, j, k, err))
+				}
+			}
 		}
 	}
 
@@ -447,6 +457,12 @@ func validateBundle(bundle *GSMBundle, idx int) error {
 
 func validateDockerConfig(dc *DockerConfigSpec, bundleIdx int, bundleName string) error {
 	var errs []error
+
+	if dc.As != "" {
+		if err := gsmvalidation.ValidateMountFileName(dc.As); err != nil {
+			errs = append(errs, fmt.Errorf("bundle[%d] %s dockerconfig.as is invalid: %w", bundleIdx, bundleName, err))
+		}
+	}
 
 	if len(dc.Registries) == 0 {
 		errs = append(errs, fmt.Errorf("bundle[%d] %s dockerconfig has no registries", bundleIdx, bundleName))

--- a/pkg/api/gsm_test.go
+++ b/pkg/api/gsm_test.go
@@ -1034,6 +1034,19 @@ func TestGSMConfigValidate(t *testing.T) {
 			errorContains: "component my-component[0].secrets[0] has invalid name",
 		},
 		{
+			name: "error: component GSMSecretRef with invalid as alias",
+			config: GSMConfig{
+				Components: map[string][]GSMSecretRef{
+					"my-component": {
+						{Collection: "valid-collection", Group: "group1", Fields: []FieldEntry{{Name: "token", As: "foo/../bar"}}},
+					},
+				},
+				Bundles: []GSMBundle{},
+			},
+			expectError:   true,
+			errorContains: "component my-component[0].secrets[0].as is invalid",
+		},
+		{
 			name: "error: component with neither fields nor group",
 			config: GSMConfig{
 				Components: map[string][]GSMSecretRef{
@@ -1280,6 +1293,25 @@ func TestGSMConfigValidate(t *testing.T) {
 			},
 			expectError:   true,
 			errorContains: "bundle test-bundle gsm_secrets[0].secrets[0] has invalid name",
+		},
+		{
+			name: "error: bundle GSMSecretRef with invalid as alias",
+			config: GSMConfig{
+				Bundles: []GSMBundle{
+					{
+						Name: "test-bundle",
+						GSMSecrets: []GSMSecretRef{
+							{Collection: "test-secrets", Group: "group1", Fields: []FieldEntry{{Name: "token", As: "/etc/passwd"}}},
+						},
+						SyncToCluster: true,
+						Targets: []TargetSpec{
+							{Cluster: "build01", Namespace: "ci"},
+						},
+					},
+				},
+			},
+			expectError:   true,
+			errorContains: "bundle test-bundle gsm_secrets[0].fields[0].as is invalid",
 		},
 		{
 			name: "valid config - dockerconfig with empty 'as' field defaults to .dockerconfigjson",

--- a/pkg/gsm-validation/mount_filename.go
+++ b/pkg/gsm-validation/mount_filename.go
@@ -1,0 +1,46 @@
+package gsmvalidation
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var mountFileNameCharRegexp = regexp.MustCompile(`[^a-zA-Z0-9\-._]`)
+
+// DecodeMountFileName decodes a GSM-encoded mount filename (field name or `as` alias)
+// and validates it is safe to use as a CSI SecretProviderClass file name.
+func DecodeMountFileName(encoded string) (string, error) {
+	decoded := DenormalizeName(encoded)
+	if err := validateDecodedMountFileName(encoded, decoded); err != nil {
+		return "", err
+	}
+	return decoded, nil
+}
+
+// ValidateMountFileName validates a GSM-encoded mount filename without returning the decoded value.
+func ValidateMountFileName(encoded string) error {
+	_, err := DecodeMountFileName(encoded)
+	return err
+}
+
+func validateDecodedMountFileName(encoded, decoded string) error {
+	if decoded == "" {
+		return fmt.Errorf("mount file name %q decodes to an empty string", encoded)
+	}
+	if strings.HasPrefix(decoded, "/") {
+		return fmt.Errorf("mount file name %q decodes to %q which is an absolute path", encoded, decoded)
+	}
+	for _, segment := range strings.Split(decoded, "/") {
+		if segment == ".." {
+			return fmt.Errorf("mount file name %q decodes to %q which contains a path traversal segment", encoded, decoded)
+		}
+	}
+	if invalidCharacters := mountFileNameCharRegexp.FindAllString(decoded, -1); len(invalidCharacters) > 0 {
+		return fmt.Errorf(
+			"mount file name %q decodes to %q which contains forbidden characters (%s); decoded names must only contain letters, numbers, dashes (-), dots (.), and underscores (_)",
+			encoded, decoded, strings.Join(invalidCharacters, ", "),
+		)
+	}
+	return nil
+}

--- a/pkg/gsm-validation/mount_filename_test.go
+++ b/pkg/gsm-validation/mount_filename_test.go
@@ -1,0 +1,89 @@
+package gsmvalidation
+
+import "testing"
+
+func TestDecodeMountFileName(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		input       string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:     "simple name",
+			input:    "api-token",
+			expected: "api-token",
+		},
+		{
+			name:     "encoded dot prefix",
+			input:    "--dot--dockerconfigjson",
+			expected: ".dockerconfigjson",
+		},
+		{
+			name:     "encoded dots in middle",
+			input:    "sa--dot--ci-operator--dot--token--dot--txt",
+			expected: "sa.ci-operator.token.txt",
+		},
+		{
+			name:     "GSM encoded field name decodes to dot-prefixed mount file",
+			input:    "--dot--awscred",
+			expected: ".awscred",
+		},
+		{
+			name:     "as alias with literal dots passes through unchanged",
+			input:    ".awscred",
+			expected: ".awscred",
+		},
+		{
+			name:     "consecutive dots in filename are not path traversal",
+			input:    "version..json",
+			expected: "version..json",
+		},
+		{
+			name:        "absolute path after decode",
+			input:       "/etc/passwd",
+			expectError: true,
+		},
+		{
+			name:        "parent directory segment",
+			input:       "foo/../bar",
+			expectError: true,
+		},
+		{
+			name:        "subdirectory in mount filename",
+			input:       "dir/file",
+			expectError: true,
+		},
+		{
+			name:        "parent directory filename",
+			input:       "..",
+			expectError: true,
+		},
+		{
+			name:        "forbidden characters",
+			input:       "bad$name",
+			expectError: true,
+		},
+		{
+			name:        "empty string",
+			input:       "",
+			expectError: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := DecodeMountFileName(tc.input)
+			if tc.expectError {
+				if err == nil {
+					t.Fatalf("expected error for %q, got decoded %q", tc.input, actual)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if actual != tc.expected {
+				t.Fatalf("expected decoded name %q, got %q", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/pkg/steps/csi_secrets/csi_utils.go
+++ b/pkg/steps/csi_secrets/csi_utils.go
@@ -3,7 +3,6 @@ package csi_secrets
 import (
 	"crypto/sha256"
 	"fmt"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -81,16 +80,7 @@ func RestoreForbiddenSymbolsInSecretName(s string) (string, error) {
 	// Because all credentials with these forbidden symbols in their names or keys have been renamed,
 	// e.g. '.awscreds' to '--dot--awscreds', to preserve backwards compatibility,
 	// we now need to mount the secret as the original '.awscreds' file to the Pod that will be created by ci-operator.
-
-	replacedName := gsmvalidation.DenormalizeName(s)
-
-	re := regexp.MustCompile(`[^a-zA-Z0-9\-._/]`)
-	invalidCharacters := re.FindAllString(replacedName, -1)
-	if invalidCharacters != nil {
-		return "", fmt.Errorf("secret name '%s' decodes to '%s' which contains forbidden characters (%s); decoded names must only contain letters, numbers, dashes (-), dots (.), underscores (_), and slashes (/)", s, replacedName, strings.Join(invalidCharacters, ", "))
-	} else {
-		return replacedName, nil
-	}
+	return gsmvalidation.DecodeMountFileName(s)
 }
 
 // GetSPCName generates a unique SPC name for a set of credentials that share


### PR DESCRIPTION
Mostly just adding pieces that were missed before & refactoring

- Add shared `DecodeMountFileName` / `ValidateMountFileName` in `pkg/gsm-validation` for CSI mount filenames (path traversal, absolute paths, char class after denormalize)
- Validate `fields[].as` and `dockerconfig.as` in `GSMConfig.Validate()` — caught by existing bootstrap presubmit on gsm-config changes
- Refactor `RestoreForbiddenSymbolsInSecretName` to use the shared helper; runtime now rejects `..` and absolute paths too


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Improves GSM (CSI) secret mount filename validation for CI configurations and CSI secrets.

- Adds shared `DecodeMountFileName`/`ValidateMountFileName` helpers for GSM-encoded mount filenames, enforcing non-empty, non-absolute paths, no `..` traversal, and allowed character sets after denormalization.
- Tightens `GSMConfig.Validate()` to reject invalid `as` aliases for mounted secrets in both:
  - `GSMSecretRef.Fields[].as` (component- and bundle-scoped errors)
  - `dockerconfig.as` (bundle-scoped errors)
- Reuses the same shared decoder/validator at runtime in the CSI secrets path restoration logic, so attempts to restore forbidden filenames (e.g., `..` or absolute paths) are rejected.
- Extends test coverage for both the validator’s decoding rules (valid encoded variants and invalid absolute/traversal/character/empty inputs) and for config validation failures when `fields[].as` is invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->