### PR TITLE
Add a custom equality func for the `Retry` type

### DIFF
--- a/cmd/config-change-trigger/main.go
+++ b/cmd/config-change-trigger/main.go
@@ -104,7 +104,10 @@ func main() {
 	if prConfig.CiOperator == nil || masterConfig.CiOperator == nil {
 		logger.WithError(err).Fatal("could not load ci-operator configs from base or tested revision of release repo")
 	}
-	changedCiopConfigs, _, _ := diffs.GetChangedCiopConfigs(masterConfig.CiOperator, prConfig.CiOperator, logger)
+	changedCiopConfigs, _, _, err := diffs.GetChangedCiopConfigs(masterConfig.CiOperator, prConfig.CiOperator, logger)
+	if err != nil {
+		logger.WithError(err).Fatal("could not compute changed ci-operator configs")
+	}
 	changedImagesPostsubmits := diffs.GetImagesPostsubmitsForCiopConfigs(prConfig.Prow, changedCiopConfigs)
 
 	namespace := prConfig.Prow.ProwJobNamespace

--- a/pkg/diffs/diffs.go
+++ b/pkg/diffs/diffs.go
@@ -33,7 +33,14 @@ const (
 
 // GetChangedCiopConfigs identifies CI Operator configurations that are new or have changed and
 // determines for each which jobs are impacted if job-specific changes were made
-func GetChangedCiopConfigs(masterConfig, prConfig config.DataByFilename, logger *logrus.Entry) (configs config.DataByFilename, affectedJobs map[string]sets.Set[string], restrictNetworkAccessFalseJobs []string) {
+func GetChangedCiopConfigs(masterConfig, prConfig config.DataByFilename, logger *logrus.Entry) (configs config.DataByFilename, affectedJobs map[string]sets.Set[string], restrictNetworkAccessFalseJobs []string, err error) {
+	equalities := equality.Semantic.Copy()
+	if err = equalities.AddFunc(func(a, b prowconfig.Retry) bool {
+		return a.RunAll == b.RunAll && a.Interval == b.Interval && a.Attempts == b.Attempts
+	}); err != nil {
+		return nil, nil, nil, fmt.Errorf("add compare func: %w", err)
+	}
+
 	configs = config.DataByFilename{}
 	affectedJobs = map[string]sets.Set[string]{}
 
@@ -72,7 +79,7 @@ func GetChangedCiopConfigs(masterConfig, prConfig config.DataByFilename, logger 
 
 		for as, test := range newTests {
 			oldTest := oldTests[as]
-			if !equality.Semantic.DeepEqual(oldTest, test) {
+			if !equalities.DeepEqual(oldTest, test) {
 				testLogger := logger.WithField(logCiopConfig, filename)
 				testLogger.Info(changedCiopConfigMsg)
 				configs[filename] = newConfig

--- a/pkg/diffs/diffs_test.go
+++ b/pkg/diffs/diffs_test.go
@@ -228,7 +228,10 @@ func TestGetChangedCiopConfigs(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			before, after := tc.configGenerator(t)
-			actual, affectedJobs, disabledDueToNetworkAccessToggle := GetChangedCiopConfigs(before, after, logrus.NewEntry(logrus.New()))
+			actual, affectedJobs, disabledDueToNetworkAccessToggle, err := GetChangedCiopConfigs(before, after, logrus.NewEntry(logrus.New()))
+			if err != nil {
+				t.Fatal(err)
+			}
 			expected := tc.expected()
 
 			if diff := cmp.Diff(expected, actual,

--- a/pkg/rehearse/rehearse.go
+++ b/pkg/rehearse/rehearse.go
@@ -138,7 +138,10 @@ func (r RehearsalConfig) DetermineAffectedJobs(candidate RehearsalCandidate, can
 	if masterConfig.CiOperator != nil && prConfig.CiOperator != nil {
 		var changedCiopConfigData config.DataByFilename
 		var affectedJobs map[string]sets.Set[string]
-		changedCiopConfigData, affectedJobs, restrictNetworkAccessFalseJobs = diffs.GetChangedCiopConfigs(masterConfig.CiOperator, prConfig.CiOperator, logger)
+		changedCiopConfigData, affectedJobs, restrictNetworkAccessFalseJobs, err = diffs.GetChangedCiopConfigs(masterConfig.CiOperator, prConfig.CiOperator, logger)
+		if err != nil {
+			return nil, nil, nil, nil, fmt.Errorf("could not load compute changed ci-operator configurations: %w", err)
+		}
 		// If we allow network access rehearsals, we can just ignore the returned jobs that set it to 'false'
 		if networkAccessRehearsalsAllowed {
 			restrictNetworkAccessFalseJobs = []string{}


### PR DESCRIPTION
The `Retry` type has now an unexported field that `equality.Semantic.DeepEqual` can't handle natively, causing panics like the following:
```
Webhook handler panicked: an unexported field was encountered, nested like this:
  api.TestStepConfiguration -> *config.Retry -> config.Retry -> time.Duration

goroutine 72737 [running]:
main.(*handlerDispatcher).run.func1.2()
    /go/src/github.com/openshift/ci-tools/cmd/pj-rehearse/main.go:119 +0x6e
panic({0x372cca0?, 0xc08194a0a8?})
    /usr/local/go/src/runtime/panic.go:783 +0x132
[k8s.io/apimachinery/third_party/forked/golang/reflect.makeUsefulPanic(...)](http://k8s.io/apimachinery/third_party/forked/golang/reflect.makeUsefulPanic(...))
    deep_equal.go:96 +0x14f
  [5 more nested panic/makeUsefulPanic frames — same pattern]
[k8s.io/apimachinery/third_party/forked/golang/reflect.Equalities.deepValueEqual(...)](http://k8s.io/apimachinery/third_party/forked/golang/reflect.Equalities.deepValueEqual(...))
    deep_equal.go:257 +0x16f4
    ...
[k8s.io/apimachinery/third_party/forked/golang/reflect.Equalities.DeepEqual(...)](http://k8s.io/apimachinery/third_party/forked/golang/reflect.Equalities.DeepEqual(...))
    deep_equal.go:273 +0x2d
[github.com/openshift/ci-tools/pkg/diffs.GetChangedCiopConfigs(...)](http://github.com/openshift/ci-tools/pkg/diffs.GetChangedCiopConfigs(...))
    diffs.go:75 +0xd29
[github.com/openshift/ci-tools/pkg/rehearse.RehearsalConfig.DetermineAffectedJobs(...)](http://github.com/openshift/ci-tools/pkg/rehearse.RehearsalConfig.DetermineAffectedJobs(...))
    rehearse.go:141 +0x6f6
main.(*server).handlePotentialCommands(...)
    server.go:432 +0x1d48
main.(*server).handleIssueComment(...)
    server.go:311 +0x50e
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updates CI-Operator configuration change detection so CI tooling can safely diff `prowconfig.Retry` without panicking when `Retry`’s unexported `time.Duration` field is present. The diff logic now uses a local semantic equality registry with a custom comparator that treats two `Retry` values as equal only when `RunAll`, `Interval`, and `Attempts` match; this custom comparison is applied when deciding whether individual ci-operator test steps (and therefore affected presubmit/periodic jobs) have changed.

Also improves reliability of downstream tooling by propagating errors from the change-detection step: `config-change-trigger`, `RehearsalConfig.DetermineAffectedJobs`, and `TestGetChangedCiopConfigs` now handle the additional returned `err` instead of continuing with potentially incomplete results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->