### PR TITLE
check-cluster-profiles-config: Do not resolve profiles

### DIFF
--- a/cmd/check-cluster-profiles-config/main.go
+++ b/cmd/check-cluster-profiles-config/main.go
@@ -20,12 +20,7 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/load"
-	"github.com/openshift/ci-tools/pkg/registry/server"
 	"github.com/openshift/ci-tools/pkg/util"
-)
-
-var (
-	configResolverAddress = api.URLForService(api.ServiceConfig)
 )
 
 type options struct {
@@ -192,16 +187,9 @@ func (validator *profileValidator) checkCISecrets() error {
 			continue
 		}
 
-		clusterProfile, err := server.NewResolverClient(configResolverAddress).ClusterProfile(profile.Name)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to retrieve details from config resolver for '%s' cluster profile: %w", profile.Name, err))
-			continue
-		}
-
 		ciSecret := &coreapi.Secret{}
-		err = validator.kubeClient.Get(context.Background(), ctrlruntimeclient.ObjectKey{Namespace: "ci", Name: clusterProfile.Secret}, ciSecret)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to get secret '%s' for cluster profile '%s': %w", clusterProfile.Secret, profile.Name, err))
+		if err := validator.kubeClient.Get(context.Background(), ctrlruntimeclient.ObjectKey{Namespace: "ci", Name: profile.Secret}, ciSecret); err != nil {
+			errs = append(errs, fmt.Errorf("failed to get secret '%s' for cluster profile '%s': %w", profile.Secret, profile.Name, err))
 		}
 	}
 


### PR DESCRIPTION
There is a critical gap in the validation:
1. A user opens a PR in `openshift/release` to add new cluster profile `foobar`.
2. The `pull-ci-openshift-release-check-cluster-profiles-config` runs this tool to validate the PR.
3. `check-cluster-profiles-config` tries to resolve the new cluster profile `foobar` by querying the `ci-operator-configresolver`.
4.  `ci-operator-configresolver` return `404` since the cluster profile exists only on the PR.

There is no need to query `ci-operator-configresolver` because `check-cluster-profiles-config` alrady has the information it needs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates `check-cluster-profiles-config` to validate cluster profile secrets directly from the local configuration and Kubernetes `ci` namespace, instead of querying `ci-operator-configresolver`.

This allows validation to succeed for cluster profiles introduced in an `openshift/release` pull request before they are available to the external resolver, while preserving aggregated error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->