### PR TITLE
Konflux: Make sure ci-operator create unique namespaces

### DIFF
--- a/pkg/controller/ephemeralcluster/reconciler.go
+++ b/pkg/controller/ephemeralcluster/reconciler.go
@@ -553,6 +553,11 @@ func (r *reconciler) makeProwJob(ciOperatorConfig *api.ReleaseBuildConfiguration
 		Value: string(ciOperatorConfigYaml),
 	})
 
+	// This make sure that Ephemeral cluster requests never share a ci-operator's namespace.
+	// If this wasn't the case then two different requests would race at provisioning a cluster
+	// and the result is undefined.
+	ciOperatorContainer.Args = append(ciOperatorContainer.Args, "--input-hash="+ec.Name)
+
 	return &pj, nil
 }
 
@@ -573,6 +578,8 @@ func (r *reconciler) fetchSecrets(ctx context.Context, log *logrus.Entry, ec *ep
 		}
 		return nil
 	}
+
+	log = log.WithField("namespace", ns)
 
 	if ec.Spec.CIOperator.Test.ClusterClaim != nil {
 		r.fetchHiveSecrets(ctx, log, ec, buildClient, ns, oldStatus, ecStatus)
@@ -870,9 +877,8 @@ func (r *reconciler) notifyTestComplete(ctx context.Context, log *logrus.Entry, 
 		return nil
 	}
 
-	log = log.WithField("namespace", ns)
+	log = log.WithField("namespace", ns).WithField("secret", api.EphemeralClusterTestDoneSignalSecretName)
 
-	log = log.WithField("secret", api.EphemeralClusterTestDoneSignalSecretName)
 	if err := buildClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
 		Name:      api.EphemeralClusterTestDoneSignalSecretName,
 		Namespace: ns,

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
@@ -43,6 +43,7 @@ items:
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
         - --target=cluster-provisioning
+        - --input-hash=ec
         command:
         - ci-operator
         env:

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Hive_cluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Hive_cluster_request_creates_a_ProwJob.yaml
@@ -42,6 +42,7 @@ items:
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
         - --target=cluster-provisioning
+        - --input-hash=ec
         command:
         - ci-operator
         env:

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Privileged_tenant.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Privileged_tenant.yaml
@@ -43,6 +43,7 @@ items:
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
         - --target=cluster-provisioning
+        - --input-hash=ec
         command:
         - ci-operator
         env:


### PR DESCRIPTION
By retesting the same job in Konflux, we get two different `EphemeralCluster` object requests that generated the same `ci-operator` configuration. As a consequence, `ci-operator` is going to create just a single NS for both, causing troubles to the provisioning mechanism.

The `EphemeralCluster`'s name is guaranteed to be unique, therefore it can be safely used as an extra (unique) input that `ci-operator` takes into account when it generates a new namespace name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates the Konflux `EphemeralCluster` controller to pass each cluster request’s name as `ci-operator`’s input hash when creating ProwJobs. This gives retested jobs unique ci-operator namespaces, preventing identical configurations from sharing a namespace and interfering with provisioning.

Also improves reconciliation logs by including the resolved test namespace and credential secret during fetch and deprovisioning operations. Updated ProwJob fixtures cover the new argument.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->