### PR TITLE
clusterimageset-updater: bump integration fixtures to 4.21.25

### DIFF
--- a/test/integration/clusterimageset-updater/output/imagesets/ocp-release-4.21.25-multi-for-4.21.0-0-to-4.22.0-0_clusterimageset.yaml
+++ b/test/integration/clusterimageset-updater/output/imagesets/ocp-release-4.21.25-multi-for-4.21.0-0-to-4.22.0-0_clusterimageset.yaml
@@ -5,7 +5,7 @@ metadata:
     version_lower: 4.21.0-0
     version_upper: 4.22.0-0
   creationTimestamp: null
-  name: ocp-release-4.21.24-multi-for-4.21.0-0-to-4.22.0-0
+  name: ocp-release-4.21.25-multi-for-4.21.0-0-to-4.22.0-0
 spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.21.24-multi
+  releaseImage: quay.io/openshift-release-dev/ocp-release:4.21.25-multi
 status: {}

--- a/test/integration/clusterimageset-updater/output/pools/4-21-20_clusterpool.yaml
+++ b/test/integration/clusterimageset-updater/output/pools/4-21-20_clusterpool.yaml
@@ -18,7 +18,7 @@ spec:
   hibernationConfig:
     resumeTimeout: 20m0s
   imageSetRef:
-    name: ocp-release-4.21.24-multi-for-4.21.0-0-to-4.22.0-0
+    name: ocp-release-4.21.25-multi-for-4.21.0-0-to-4.22.0-0
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
     name: install-config-aws-us-east-1

--- a/test/integration/clusterimageset-updater/output/pools/4-21-auto_clusterpool.yaml
+++ b/test/integration/clusterimageset-updater/output/pools/4-21-auto_clusterpool.yaml
@@ -18,7 +18,7 @@ spec:
   hibernationConfig:
     resumeTimeout: 20m0s
   imageSetRef:
-    name: ocp-release-4.21.24-multi-for-4.21.0-0-to-4.22.0-0
+    name: ocp-release-4.21.25-multi-for-4.21.0-0-to-4.22.0-0
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
     name: install-config-aws-us-east-1


### PR DESCRIPTION
## Summary
- Bump `clusterimageset-updater` integration expected output from OCP **4.21.24** to **4.21.25**
- Unblocks `pull-ci-openshift-ci-tools-main-integration`, which started failing when 4.21.25 became the latest z-stream in the live release catalog

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates `clusterimageset-updater` integration fixtures to use OCP 4.21.25 instead of 4.21.24 for the 4.21 release image and corresponding ClusterPool references. This keeps integration expectations aligned with the live release catalog and unblocks `pull-ci-openshift-ci-tools-main-integration`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->