### PR TITLE
clusterimageset-updater: mock release API in integration test

### DIFF
--- a/cmd/clusterimageset-updater/main.go
+++ b/cmd/clusterimageset-updater/main.go
@@ -33,8 +33,9 @@ const (
 )
 
 type options struct {
-	poolDir   string
-	outputDir string
+	poolDir           string
+	outputDir         string
+	releaseServiceURL string
 }
 
 func gatherOptions() (options, error) {
@@ -43,6 +44,7 @@ func gatherOptions() (options, error) {
 
 	fs.StringVar(&o.poolDir, "pools", "", "Path to directory containing cluster pool specs (*_clusterpool.yaml files)")
 	fs.StringVar(&o.outputDir, "imagesets", "", "Path to directory containing clusterimagesets  (*_clusterimageset.yaml files)")
+	fs.StringVar(&o.releaseServiceURL, "release-service-url", "", "Optional override for the OCP release service base URL (e.g. http://127.0.0.1:8080/api/v1/releasestream)")
 
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		return o, fmt.Errorf("failed to parse flags: %w", err)
@@ -139,7 +141,7 @@ func main() {
 			},
 			VersionBounds: versionBounds,
 		}
-		pullSpec, err := prerelease.ResolvePullSpec(&http.Client{}, release)
+		pullSpec, err := prerelease.ResolvePullSpecWithServiceURL(&http.Client{}, release, o.releaseServiceURL)
 		if err != nil {
 			logrus.WithError(err).Fatalf("Failed to get pullspec for version range `%s`", versionBounds.Query())
 		}

--- a/pkg/release/candidate/client.go
+++ b/pkg/release/candidate/client.go
@@ -39,7 +39,15 @@ func architecture(architecture api.ReleaseArchitecture) string {
 }
 
 func Endpoint(d api.ReleaseDescriptor, version, stream, suffix string) string {
-	return fmt.Sprintf("%s/%s%s%s%s", ServiceHost(d), version, stream, architecture(d.Architecture), suffix)
+	return EndpointWithServiceURL(d, version, stream, suffix, "")
+}
+
+func EndpointWithServiceURL(d api.ReleaseDescriptor, version, stream, suffix, serviceURL string) string {
+	host := ServiceHost(d)
+	if serviceURL != "" {
+		host = serviceURL
+	}
+	return fmt.Sprintf("%s/%s%s%s%s", host, version, stream, architecture(d.Architecture), suffix)
 }
 
 // endpoint determines the API endpoint to use for a candidate release

--- a/pkg/release/prerelease/client.go
+++ b/pkg/release/prerelease/client.go
@@ -11,12 +11,16 @@ import (
 	"github.com/openshift/ci-tools/pkg/release/candidate"
 )
 
-func endpoint(prerelease api.Prerelease) string {
+func endpointWithServiceURL(prerelease api.Prerelease, serviceURL string) string {
 	stream := prerelease.VersionBounds.Stream
 	if stream == "" {
 		stream = deriveStreamFromBounds(prerelease.VersionBounds)
 	}
-	return candidate.Endpoint(prerelease.ReleaseDescriptor, "", stream, "/latest")
+	return candidate.EndpointWithServiceURL(prerelease.ReleaseDescriptor, "", stream, "/latest", serviceURL)
+}
+
+func endpoint(prerelease api.Prerelease) string {
+	return endpointWithServiceURL(prerelease, "")
 }
 
 func deriveStreamFromBounds(bounds api.VersionBounds) string {
@@ -41,7 +45,12 @@ func defaultFields(prerelease api.Prerelease) api.Prerelease {
 
 // ResolvePullSpec determines the pull spec for the candidate release
 func ResolvePullSpec(client release.HTTPClient, prerelease api.Prerelease) (string, error) {
-	return resolvePullSpec(client, endpoint(defaultFields(prerelease)), prerelease.VersionBounds, prerelease.Relative)
+	return ResolvePullSpecWithServiceURL(client, prerelease, "")
+}
+
+// ResolvePullSpecWithServiceURL resolves a pull spec, optionally overriding the release service URL.
+func ResolvePullSpecWithServiceURL(client release.HTTPClient, prerelease api.Prerelease, serviceURL string) (string, error) {
+	return resolvePullSpec(client, endpointWithServiceURL(defaultFields(prerelease), serviceURL), prerelease.VersionBounds, prerelease.Relative)
 }
 
 func resolvePullSpec(client release.HTTPClient, endpoint string, bounds api.VersionBounds, relative int) (string, error) {

--- a/pkg/release/prerelease/client_test.go
+++ b/pkg/release/prerelease/client_test.go
@@ -79,6 +79,45 @@ func TestEndpoint(t *testing.T) {
 	}
 }
 
+func TestEndpointWithServiceURL(t *testing.T) {
+	var testCases = []struct {
+		name       string
+		input      api.Prerelease
+		serviceURL string
+		output     string
+	}{
+		{
+			name: "override replaces default host",
+			input: api.Prerelease{
+				ReleaseDescriptor: api.ReleaseDescriptor{
+					Product:      api.ReleaseProductOCP,
+					Architecture: api.ReleaseArchitectureMULTI,
+				},
+			},
+			serviceURL: "http://127.0.0.1:9090/api/v1/releasestream",
+			output:     "http://127.0.0.1:9090/api/v1/releasestream/4-stable-multi/latest",
+		},
+		{
+			name: "empty override uses default host",
+			input: api.Prerelease{
+				ReleaseDescriptor: api.ReleaseDescriptor{
+					Product:      api.ReleaseProductOCP,
+					Architecture: api.ReleaseArchitectureAMD64,
+				},
+			},
+			serviceURL: "",
+			output:     "https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/latest",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if actual := endpointWithServiceURL(tc.input, tc.serviceURL); actual != tc.output {
+				t.Errorf("got incorrect endpoint: %v", cmp.Diff(actual, tc.output))
+			}
+		})
+	}
+}
+
 func TestDefaultFields(t *testing.T) {
 	var testCases = []struct {
 		name   string

--- a/test/integration/clusterimageset-updater.sh
+++ b/test/integration/clusterimageset-updater.sh
@@ -14,13 +14,13 @@ trap "cleanup" EXIT
 suite_dir="${OS_ROOT}/test/integration/clusterimageset-updater/"
 workdir="${BASETMPDIR}/clusterimageset-updater"
 mkdir -p "${workdir}"
-cp -a "${suite_dir}"/* "${workdir}"
+cp -a "${suite_dir}/input" "${suite_dir}/output" "${workdir}/"
 inputs="${workdir}/input"
 expected="${workdir}/output"
 mock_pullspec="quay.io/openshift-release-dev/ocp-release:4.21.25-multi"
 
-mock_binary="${workdir}/mock-release-server"
-go build -o "${mock_binary}" "${suite_dir}/mock-release-server"
+mock_binary="${workdir}/mock-release-server-bin"
+os::cmd::expect_success "go build -o ${mock_binary} ${suite_dir}/mock-release-server"
 release_service_url_file="${workdir}/release-service-url"
 "${mock_binary}" --pullspec "${mock_pullspec}" > "${release_service_url_file}" &
 mock_pid=$!

--- a/test/integration/clusterimageset-updater.sh
+++ b/test/integration/clusterimageset-updater.sh
@@ -19,8 +19,13 @@ inputs="${workdir}/input"
 expected="${workdir}/output"
 mock_pullspec="quay.io/openshift-release-dev/ocp-release:4.21.25-multi"
 
+os::test::junit::declare_suite_start "integration/clusterimageset-updater"
+
 mock_binary="${workdir}/mock-release-server-bin"
-os::cmd::expect_success "go build -o ${mock_binary} ${suite_dir}/mock-release-server"
+if ! go build -o "${mock_binary}" "${suite_dir}/mock-release-server"; then
+    os::log::fatal "failed to build mock release server"
+fi
+
 release_service_url_file="${workdir}/release-service-url"
 "${mock_binary}" --pullspec "${mock_pullspec}" > "${release_service_url_file}" &
 mock_pid=$!
@@ -34,8 +39,6 @@ release_service_url=$(< "${release_service_url_file}")
 if [[ -z "${release_service_url}" ]]; then
     os::log::fatal "mock release server did not publish its service URL"
 fi
-
-os::test::junit::declare_suite_start "integration/clusterimageset-updater"
 
 os::cmd::expect_success "clusterimageset-updater --pools ${inputs}/pools --imagesets ${inputs}/imagesets --release-service-url ${release_service_url}"
 os::integration::compare "${inputs}" "${expected}"

--- a/test/integration/clusterimageset-updater.sh
+++ b/test/integration/clusterimageset-updater.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 
+mock_pid=""
 function cleanup() {
+    if [[ -n "${mock_pid}" ]]; then
+        kill "${mock_pid}" 2>/dev/null || true
+    fi
     os::test::junit::reconcile_output
     os::cleanup::processes
 }
@@ -13,10 +17,27 @@ mkdir -p "${workdir}"
 cp -a "${suite_dir}"/* "${workdir}"
 inputs="${workdir}/input"
 expected="${workdir}/output"
+mock_pullspec="quay.io/openshift-release-dev/ocp-release:4.21.25-multi"
+
+mock_binary="${workdir}/mock-release-server"
+go build -o "${mock_binary}" "${suite_dir}/mock-release-server"
+release_service_url_file="${workdir}/release-service-url"
+"${mock_binary}" --pullspec "${mock_pullspec}" > "${release_service_url_file}" &
+mock_pid=$!
+for _ in $(seq 1 50); do
+    if [[ -s "${release_service_url_file}" ]]; then
+        break
+    fi
+    sleep 0.1
+done
+release_service_url=$(< "${release_service_url_file}")
+if [[ -z "${release_service_url}" ]]; then
+    os::log::fatal "mock release server did not publish its service URL"
+fi
 
 os::test::junit::declare_suite_start "integration/clusterimageset-updater"
 
-os::cmd::expect_success "clusterimageset-updater --pools ${inputs}/pools --imagesets ${inputs}/imagesets"
+os::cmd::expect_success "clusterimageset-updater --pools ${inputs}/pools --imagesets ${inputs}/imagesets --release-service-url ${release_service_url}"
 os::integration::compare "${inputs}" "${expected}"
 
 os::test::junit::declare_suite_end

--- a/test/integration/clusterimageset-updater/README.md
+++ b/test/integration/clusterimageset-updater/README.md
@@ -1,0 +1,7 @@
+# clusterimageset-updater integration test
+
+This suite runs `clusterimageset-updater` against fixture pool and imageset YAML under `input/`, then compares the result to `output/`.
+
+The test uses `mock-release-server` to serve a fixed OCP release response instead of calling the live release catalog. That keeps the suite stable when new z-streams ship; only change `output/` if the test scenario itself changes.
+
+The mocked pullspec must stay in sync with the expected `output/` fixtures (currently `4.21.25-multi`).

--- a/test/integration/clusterimageset-updater/mock-release-server/main.go
+++ b/test/integration/clusterimageset-updater/mock-release-server/main.go
@@ -53,5 +53,8 @@ func main() {
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, syscall.SIGINT, syscall.SIGTERM)
 	<-signalCh
-	_ = server.Shutdown(context.Background())
+	if err := server.Shutdown(context.Background()); err != nil {
+		fmt.Fprintf(os.Stderr, "shutdown mock release server: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/test/integration/clusterimageset-updater/mock-release-server/main.go
+++ b/test/integration/clusterimageset-updater/mock-release-server/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+const defaultPullSpec = "quay.io/openshift-release-dev/ocp-release:4.21.25-multi"
+
+func main() {
+	pullSpec := flag.String("pullspec", defaultPullSpec, "pullSpec value returned by the mock release service")
+	flag.Parse()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]string{
+			"name":        "4.21.25",
+			"phase":       "Accepted",
+			"pullSpec":    *pullSpec,
+			"downloadURL": "https://example.com/4.21.25",
+		}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to listen: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("http://%s/api/v1/releasestream\n", listener.Addr())
+
+	server := &http.Server{Handler: mux}
+	go func() {
+		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+			fmt.Fprintf(os.Stderr, "mock release server failed: %v\n", err)
+			os.Exit(1)
+		}
+	}()
+
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, syscall.SIGINT, syscall.SIGTERM)
+	<-signalCh
+	_ = server.Shutdown(context.Background())
+}


### PR DESCRIPTION
## Summary
- Add `--release-service-host` to `clusterimageset-updater` for overriding the OCP release catalog endpoint
- Run the integration suite against a local mock release server with a fixed pullspec (`4.21.25-multi`) instead of the live catalog
- Document the fixture expectations in `test/integration/clusterimageset-updater/README.md`

Depends on #5322 (fixture bump to 4.21.25). Merge that first, then rebase this PR if needed.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds an optional `--release-service-url` CLI flag to `clusterimageset-updater` to override the OCP release service base URL used when resolving prerelease pullspecs. This allows CI integration tests (and operators) to point the updater at a local or alternate release catalog instead of the live service.

The release client code now supports resolving endpoints and pullspecs using the provided service URL while preserving the existing default behavior when the flag is unset. The `clusterimageset-updater` integration suite starts a mock release server and passes `--release-service-url` to ensure stable, catalog-independent results (mocking the pullspec to `4.21.25-multi`); fixture expectations are documented under `test/integration/clusterimageset-updater/README.md`.

This PR depends on `#5322` being merged first.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->