### PR TITLE
Konflux: Name the EphemeralCluster's Prowjob after the PipelineRun or TaskRun Name

### DIFF
--- a/pkg/api/ephemeralcluster/v1/types.go
+++ b/pkg/api/ephemeralcluster/v1/types.go
@@ -19,8 +19,10 @@ const (
 	KubeconfigNotReadyMsg   = "kubeconfig not ready"
 	HiveSecretsNotReadyMsg  = "hive secrets not ready"
 
-	KonfluxClusterAnnotation = "ephemeralcluster.ci.openshift.io/konflux-cluster"
-	KonfluxTenantAnnotation  = "ephemeralcluster.ci.openshift.io/konflux-tenant"
+	KonfluxClusterAnnotation  = "ephemeralcluster.ci.openshift.io/konflux-cluster"
+	KonfluxTenantAnnotation   = "ephemeralcluster.ci.openshift.io/konflux-tenant"
+	PipelineRunNameAnnotation = "ephemeralcluster.ci.openshift.io/pipeline-run-name"
+	TaskRunNameAnnotation     = "ephemeralcluster.ci.openshift.io/task-run-name"
 )
 
 // EphemeralClusterCondition is a valid value for EphemeralClusterCondition.Type
@@ -84,6 +86,20 @@ func (ec *EphemeralCluster) KonfluxCluster() string {
 
 func (ec *EphemeralCluster) KonfluxTenant() string {
 	if value, ok := ec.Annotations[KonfluxTenantAnnotation]; ok {
+		return value
+	}
+	return ""
+}
+
+func (ec *EphemeralCluster) PipelineRunName() string {
+	if value, ok := ec.Annotations[PipelineRunNameAnnotation]; ok {
+		return value
+	}
+	return ""
+}
+
+func (ec *EphemeralCluster) TaskRunName() string {
+	if value, ok := ec.Annotations[TaskRunNameAnnotation]; ok {
 		return value
 	}
 	return ""

--- a/pkg/controller/ephemeralcluster/reconciler.go
+++ b/pkg/controller/ephemeralcluster/reconciler.go
@@ -504,6 +504,23 @@ func (r *reconciler) createProwJob(ctx context.Context, log *logrus.Entry, ec *e
 	return nil
 }
 
+func (r *reconciler) prowJobName(periodic *prowconfig.Periodic, ec *ephemeralclusterv1.EphemeralCluster) (string, error) {
+	if pipelineRunName := ec.PipelineRunName(); pipelineRunName != "" {
+		return ProwJobNamePrefix + "-ci-" + pipelineRunName, nil
+	}
+
+	if taskRunName := ec.TaskRunName(); taskRunName != "" {
+		return ProwJobNamePrefix + "-ci-" + taskRunName, nil
+	}
+
+	jobNameWithoutPrefix, prefixCut := strings.CutPrefix(periodic.JobBase.Name, jobconfig.PeriodicPrefix)
+	if !prefixCut {
+		return "", fmt.Errorf("failed to strip %s prefix from %s", jobconfig.PeriodicPrefix, periodic.JobBase.Name)
+	}
+
+	return ProwJobNamePrefix + jobNameWithoutPrefix, nil
+}
+
 func (r *reconciler) makeProwJob(ciOperatorConfig *api.ReleaseBuildConfiguration, ec *ephemeralclusterv1.EphemeralCluster) (*prowv1.ProwJob, error) {
 	jobConfig, err := prowgen.GenerateJobs(ciOperatorConfig, &api.Metadata{
 		Org:    "org",
@@ -523,11 +540,12 @@ func (r *reconciler) makeProwJob(ciOperatorConfig *api.ReleaseBuildConfiguration
 		return nil, fmt.Errorf("default periodic: %w", err)
 	}
 
-	jobNameWithoutPrefix, prefixCut := strings.CutPrefix(periodic.JobBase.Name, jobconfig.PeriodicPrefix)
-	if !prefixCut {
-		return nil, fmt.Errorf("failed to strip %s prefix from %s", jobconfig.PeriodicPrefix, periodic.JobBase.Name)
+	pjName, err := r.prowJobName(periodic, ec)
+	if err != nil {
+		return nil, fmt.Errorf("generate prowjob name: %w", err)
 	}
-	periodic.JobBase.Name = ProwJobNamePrefix + jobNameWithoutPrefix
+
+	periodic.JobBase.Name = pjName
 	periodic.UtilityConfig.ExtraRefs = []prowv1.Refs{}
 
 	labels := make(map[string]string)

--- a/pkg/controller/ephemeralcluster/reconciler_test.go
+++ b/pkg/controller/ephemeralcluster/reconciler_test.go
@@ -193,8 +193,9 @@ func TestCreateProwJob(t *testing.T) {
 			ec: ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						ephemeralclusterv1.KonfluxClusterAnnotation: "kcluster",
-						ephemeralclusterv1.KonfluxTenantAnnotation:  "ktenant",
+						ephemeralclusterv1.KonfluxClusterAnnotation:  "kcluster",
+						ephemeralclusterv1.KonfluxTenantAnnotation:   "ktenant",
+						ephemeralclusterv1.PipelineRunNameAnnotation: "pipeline-run-name",
 					},
 					Namespace: "ns",
 					Name:      "ec",
@@ -330,6 +331,9 @@ func TestCreateProwJob(t *testing.T) {
 			name: "Hive cluster request creates a ProwJob",
 			ec: ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ephemeralclusterv1.TaskRunNameAnnotation: "task-run-name",
+					},
 					Namespace: "ns",
 					Name:      "ec",
 				},

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
@@ -2,6 +2,7 @@ metadata:
   annotations:
     ephemeralcluster.ci.openshift.io/konflux-cluster: kcluster
     ephemeralcluster.ci.openshift.io/konflux-tenant: ktenant
+    ephemeralcluster.ci.openshift.io/pipeline-run-name: pipeline-run-name
   creationTimestamp: null
   finalizers:
   - ephemeralcluster.ci.openshift.io/dependent-prowjob

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Hive_cluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Hive_cluster_request_creates_a_ProwJob.yaml
@@ -1,4 +1,6 @@
 metadata:
+  annotations:
+    ephemeralcluster.ci.openshift.io/task-run-name: task-run-name
   creationTimestamp: null
   finalizers:
   - ephemeralcluster.ci.openshift.io/dependent-prowjob

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
@@ -4,7 +4,7 @@ items:
   metadata:
     annotations:
       prow.k8s.io/context: ""
-      prow.k8s.io/job: ephemeralcluster-ci-org-repo-branch-cluster-provisioning
+      prow.k8s.io/job: ephemeralcluster-ci-pipeline-run-name
     creationTimestamp: null
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -13,7 +13,7 @@ items:
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       prow.k8s.io/context: ""
-      prow.k8s.io/job: ephemeralcluster-ci-org-repo-branch-cluster-provisioning
+      prow.k8s.io/job: ephemeralcluster-ci-pipeline-run-name
       prow.k8s.io/type: periodic
     name: foobar
     namespace: ci
@@ -32,7 +32,7 @@ items:
         entrypoint: entrypoint
         initupload: initupload
         sidecar: sidecar
-    job: ephemeralcluster-ci-org-repo-branch-cluster-provisioning
+    job: ephemeralcluster-ci-pipeline-run-name
     namespace: ci
     pod_spec:
       containers:

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Hive_cluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Hive_cluster_request_creates_a_ProwJob.yaml
@@ -4,14 +4,14 @@ items:
   metadata:
     annotations:
       prow.k8s.io/context: ""
-      prow.k8s.io/job: ephemeralcluster-ci-org-repo-branch-cluster-provisioning
+      prow.k8s.io/job: ephemeralcluster-ci-task-run-name
     creationTimestamp: null
     labels:
       ci.openshift.io/ephemeral-cluster: ec
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       prow.k8s.io/context: ""
-      prow.k8s.io/job: ephemeralcluster-ci-org-repo-branch-cluster-provisioning
+      prow.k8s.io/job: ephemeralcluster-ci-task-run-name
       prow.k8s.io/type: periodic
     name: foobar
     namespace: ci
@@ -30,7 +30,7 @@ items:
         entrypoint: entrypoint
         initupload: initupload
         sidecar: sidecar
-    job: ephemeralcluster-ci-org-repo-branch-cluster-provisioning
+    job: ephemeralcluster-ci-task-run-name
     namespace: ci
     pod_spec:
       containers:


### PR DESCRIPTION
As of today the ProwJob name is static: `ephemeralcluster-ci-org-repo-branch-cluster-provisioning`.
This is confusing and make it impossible to distinguish ProwJobs across different runs.

This PR introduce a new naming convention that follow these rules (in order of priority):
1. `ephemeralcluster-ci-${PIPELINERUN_NAME}`
2. `ephemeralcluster-ci-${TASKRUN_NAME}`
3. `ephemeralcluster-ci-org-repo-branch-cluster-provisioning`

`PIPELINERUN_NAME` is the name of the `PipelineRun` object that runs the [provision-ephemeral-cluster](https://github.com/openshift/konflux-tasks/tree/main/tasks/provision-ephemeral-cluster/0.1) task that in turns creates the `EphemeralCluster` object.

`TASKRUN_NAME` is the name the [provision-ephemeral-cluster](https://github.com/openshift/konflux-tasks/tree/main/tasks/provision-ephemeral-cluster/0.1) task that in turns creates the `EphemeralCluster` object (this covers a `TaskRun` running without any associated `PipelineRun`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updates the EphemeralCluster controller’s ProwJob naming to avoid collisions across PipelineRun/TaskRun executions. When reconciling an EphemeralCluster, it now names the created periodic ProwJob using (in order): `ephemeralcluster-ci-${PIPELINERUN_NAME}`, then `ephemeralcluster-ci-${TASKRUN_NAME}`, and falls back to the existing static derived name (`ephemeralcluster-ci-org-repo-branch-cluster-provisioning`) when neither annotation is present.

To support this, the EphemeralCluster API adds annotation constants and getters for `pipeline-run-name` and `task-run-name`, and the reconciler uses a new helper to compute the ProwJob name from those values (otherwise stripping the periodic prefix as before). Reconciliation tests and YAML fixtures were updated to validate both the PipelineRun and TaskRun naming paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->