### PR TITLE
fix: filter-by-os on quay float prune check

### DIFF
--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -462,7 +462,7 @@ func getQuayPromotionShell(imageMirrorTarget map[string]string, timeStr string, 
 	}
 	sort.Strings(floatTags)
 	for _, floatTag := range floatTags {
-		script = append(script, getStagedQuayFloatPromotionShell(registryConfig, floatTag, pruneTagForFloat[floatTag]))
+		script = append(script, getStagedQuayFloatPromotionShell(registryConfig, floatTag, pruneTagForFloat[floatTag], filterOS))
 	}
 	for _, pair := range resolveAndTagPairs {
 		script = append(script, getResolveAndTagRetryShell(registryConfig, pair[0], pair[1], 2, filterOS))
@@ -498,9 +498,11 @@ done
 		isTag, n, n, isTag, n, 120)
 }
 
-func getStagedQuayFloatPromotionShell(registryConfig, floatTag, pruneTag string) string {
+func getStagedQuayFloatPromotionShell(registryConfig, floatTag, pruneTag, filterByOS string) string {
+	// Must use --filter-by-os: oc image info exits non-zero on multi-arch floats without it,
+	// which skipped _prune_ backups and let Quay GC prior digests under active payload jobs.
 	checkOld := fmt.Sprintf(`_OLD_EXISTS=false
-if oc image info --registry-config=%s %s >/dev/null 2>&1; then _OLD_EXISTS=true; fi`, registryConfig, floatTag)
+if oc image info --registry-config=%s --filter-by-os=%s %s >/dev/null 2>&1; then _OLD_EXISTS=true; fi`, registryConfig, filterByOS, floatTag)
 
 	var backupPairs []string
 	if pruneTag != "" {

--- a/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay.yaml
@@ -15,7 +15,7 @@ data:
     mirror 5 2 /etc/push-secret/.dockerconfigjson registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb=quay.io/openshift/ci:ci_a_latest_incoming
     mirror 5 2 /etc/push-secret/.dockerconfigjson registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:ddd=quay.io/openshift/ci:ci_c_latest_incoming
     _OLD_EXISTS=false
-    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_a_latest >/dev/null 2>&1; then _OLD_EXISTS=true; fi
+    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ci_a_latest >/dev/null 2>&1; then _OLD_EXISTS=true; fi
     if [ "${_OLD_EXISTS}" = "true" ]; then
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_a_latest=quay.io/openshift/ci:20240603235401_prune_ci_a_latest
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_a_latest=quay.io/openshift/ci:ci_a_latest__pre
@@ -25,7 +25,7 @@ data:
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_a_latest=quay.io/openshift/ci:ci_a_latest__post1
     fi
     _OLD_EXISTS=false
-    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_c_latest >/dev/null 2>&1; then _OLD_EXISTS=true; fi
+    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ci_c_latest >/dev/null 2>&1; then _OLD_EXISTS=true; fi
     if [ "${_OLD_EXISTS}" = "true" ]; then
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_c_latest=quay.io/openshift/ci:20240603235401_prune_ci_c_latest
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_c_latest=quay.io/openshift/ci:ci_c_latest__pre

--- a/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay_4.12.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay_4.12.yaml
@@ -15,7 +15,7 @@ data:
     mirror 5 2 /etc/push-secret/.dockerconfigjson registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:aaa=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes_incoming
     mirror 5 2 /etc/push-secret/.dockerconfigjson registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base_incoming
     _OLD_EXISTS=false
-    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.12_ovn-kubernetes >/dev/null 2>&1; then _OLD_EXISTS=true; fi
+    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes >/dev/null 2>&1; then _OLD_EXISTS=true; fi
     if [ "${_OLD_EXISTS}" = "true" ]; then
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.12_ovn-kubernetes=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.12_ovn-kubernetes=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes__pre
@@ -25,7 +25,7 @@ data:
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.12_ovn-kubernetes=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes__post1
     fi
     _OLD_EXISTS=false
-    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base >/dev/null 2>&1; then _OLD_EXISTS=true; fi
+    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base >/dev/null 2>&1; then _OLD_EXISTS=true; fi
     if [ "${_OLD_EXISTS}" = "true" ]; then
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes-base
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base__pre

--- a/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay_multiple_tags.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay_multiple_tags.yaml
@@ -16,7 +16,7 @@ data:
     mirror 5 2 /etc/push-secret/.dockerconfigjson registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base_incoming
     mirror 5 2 /etc/push-secret/.dockerconfigjson registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:ccc=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift_incoming
     _OLD_EXISTS=false
-    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes >/dev/null 2>&1; then _OLD_EXISTS=true; fi
+    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes >/dev/null 2>&1; then _OLD_EXISTS=true; fi
     if [ "${_OLD_EXISTS}" = "true" ]; then
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes__pre
@@ -26,7 +26,7 @@ data:
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes__post1
     fi
     _OLD_EXISTS=false
-    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base >/dev/null 2>&1; then _OLD_EXISTS=true; fi
+    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base >/dev/null 2>&1; then _OLD_EXISTS=true; fi
     if [ "${_OLD_EXISTS}" = "true" ]; then
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes-base
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base__pre
@@ -36,7 +36,7 @@ data:
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base__post1
     fi
     _OLD_EXISTS=false
-    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift >/dev/null 2>&1; then _OLD_EXISTS=true; fi
+    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift >/dev/null 2>&1; then _OLD_EXISTS=true; fi
     if [ "${_OLD_EXISTS}" = "true" ]; then
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes-microshift
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift__pre

--- a/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay_non_release_namespace.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay_non_release_namespace.yaml
@@ -15,7 +15,7 @@ data:
     mirror 5 2 /etc/push-secret/.dockerconfigjson registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb=quay.io/openshift/ci:ci_ci_sanitize-prow-jobs_incoming
     mirror 5 2 /etc/push-secret/.dockerconfigjson registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:aaa=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes_incoming
     _OLD_EXISTS=false
-    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_ci_sanitize-prow-jobs >/dev/null 2>&1; then _OLD_EXISTS=true; fi
+    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ci_ci_sanitize-prow-jobs >/dev/null 2>&1; then _OLD_EXISTS=true; fi
     if [ "${_OLD_EXISTS}" = "true" ]; then
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_ci_sanitize-prow-jobs=quay.io/openshift/ci:ci_ci_sanitize-prow-jobs__pre
     fi
@@ -24,7 +24,7 @@ data:
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_ci_sanitize-prow-jobs=quay.io/openshift/ci:ci_ci_sanitize-prow-jobs__post1
     fi
     _OLD_EXISTS=false
-    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes >/dev/null 2>&1; then _OLD_EXISTS=true; fi
+    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes >/dev/null 2>&1; then _OLD_EXISTS=true; fi
     if [ "${_OLD_EXISTS}" = "true" ]; then
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes__pre
     fi


### PR DESCRIPTION
/cc @danilo-gemoli 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates Quay float image promotion to filter existing-image checks by the promotion pod’s operating system. This ensures multi-architecture manifests are evaluated for the intended architecture, preventing incorrect prune or retag decisions during CI image promotion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->