### PR TITLE
fix(release): preserve multi-arch quay floats under promotion

### DIFF
--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -481,8 +481,14 @@ func getResolveAndTagRetryShell(registryConfig, quayProxyTag, isTag string, logl
 	repo := quayProxyTag[:colon]
 	quayIOTag := strings.Replace(quayProxyTag, api.QCIAPPCIDomain, "quay.io", 1)
 	n := quayPromotionDigestTagAttempts
+	// Prefer Manifest List dig so ocp IS references the multi-arch index (children stay
+	// reachable while a Quay tag holds that list). Fall back to Digest for single-arch.
 	return fmt.Sprintf(`for r in {1..%d}; do
-  _digest=$(oc image info --registry-config=%s --filter-by-os=%s %s | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+  _info=$(oc image info --registry-config=%s --filter-by-os=%s %s)
+  _digest=$(echo "${_info}" | sed -n '/^Manifest List:[[:space:]]/s/^Manifest List:[[:space:]]*//p' | head -n1)
+  if [ -z "${_digest}" ]; then
+    _digest=$(echo "${_info}" | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+  fi
   if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=%d --reference-policy='source' --import-mode='PreserveOriginal' --reference %s@${_digest} %s; then
     break
   fi

--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -462,7 +462,7 @@ func getQuayPromotionShell(imageMirrorTarget map[string]string, timeStr string, 
 	}
 	sort.Strings(floatTags)
 	for _, floatTag := range floatTags {
-		script = append(script, getStagedQuayFloatPromotionShell(registryConfig, floatTag, pruneTagForFloat[floatTag]))
+		script = append(script, getStagedQuayFloatPromotionShell(registryConfig, floatTag, pruneTagForFloat[floatTag], filterOS))
 	}
 	for _, pair := range resolveAndTagPairs {
 		script = append(script, getResolveAndTagRetryShell(registryConfig, pair[0], pair[1], 2, filterOS))
@@ -498,9 +498,11 @@ done
 		isTag, n, n, isTag, n, 120)
 }
 
-func getStagedQuayFloatPromotionShell(registryConfig, floatTag, pruneTag string) string {
+func getStagedQuayFloatPromotionShell(registryConfig, floatTag, pruneTag, filterByOS string) string {
+	// Must use --filter-by-os: oc image info exits non-zero on multi-arch floats without it,
+	// which skipped _prune_ backups and let Quay GC prior digests under active payload jobs.
 	checkOld := fmt.Sprintf(`_OLD_EXISTS=false
-if oc image info --registry-config=%s %s >/dev/null 2>&1; then _OLD_EXISTS=true; fi`, registryConfig, floatTag)
+if oc image info --registry-config=%s --filter-by-os=%s %s >/dev/null 2>&1; then _OLD_EXISTS=true; fi`, registryConfig, filterByOS, floatTag)
 
 	var backupPairs []string
 	if pruneTag != "" {

--- a/pkg/steps/release/promote_test.go
+++ b/pkg/steps/release/promote_test.go
@@ -1265,6 +1265,8 @@ func TestGetResolveAndTagRetryShell(t *testing.T) {
 	for _, sub := range []string{
 		"for r in {1..5}",
 		"oc image info --registry-config=" + regcfg + " --filter-by-os=linux/amd64 " + quayIOTag,
+		`sed -n '/^Manifest List:[[:space:]]/s/^Manifest List:[[:space:]]*//p'`,
+		`sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p'`,
 		"oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} " + isTag,
 		"promotion: digest-tag failed for " + isTag,
 		"promotion: retrying digest-tag for " + isTag,

--- a/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay.yaml
@@ -15,7 +15,7 @@ data:
     mirror 5 2 /etc/push-secret/.dockerconfigjson registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb=quay.io/openshift/ci:ci_a_latest_incoming
     mirror 5 2 /etc/push-secret/.dockerconfigjson registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:ddd=quay.io/openshift/ci:ci_c_latest_incoming
     _OLD_EXISTS=false
-    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_a_latest >/dev/null 2>&1; then _OLD_EXISTS=true; fi
+    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ci_a_latest >/dev/null 2>&1; then _OLD_EXISTS=true; fi
     if [ "${_OLD_EXISTS}" = "true" ]; then
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_a_latest=quay.io/openshift/ci:20240603235401_prune_ci_a_latest
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_a_latest=quay.io/openshift/ci:ci_a_latest__pre
@@ -25,7 +25,7 @@ data:
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_a_latest=quay.io/openshift/ci:ci_a_latest__post1
     fi
     _OLD_EXISTS=false
-    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_c_latest >/dev/null 2>&1; then _OLD_EXISTS=true; fi
+    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ci_c_latest >/dev/null 2>&1; then _OLD_EXISTS=true; fi
     if [ "${_OLD_EXISTS}" = "true" ]; then
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_c_latest=quay.io/openshift/ci:20240603235401_prune_ci_c_latest
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_c_latest=quay.io/openshift/ci:ci_c_latest__pre

--- a/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay_4.12.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay_4.12.yaml
@@ -15,7 +15,7 @@ data:
     mirror 5 2 /etc/push-secret/.dockerconfigjson registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:aaa=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes_incoming
     mirror 5 2 /etc/push-secret/.dockerconfigjson registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base_incoming
     _OLD_EXISTS=false
-    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.12_ovn-kubernetes >/dev/null 2>&1; then _OLD_EXISTS=true; fi
+    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes >/dev/null 2>&1; then _OLD_EXISTS=true; fi
     if [ "${_OLD_EXISTS}" = "true" ]; then
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.12_ovn-kubernetes=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.12_ovn-kubernetes=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes__pre
@@ -25,7 +25,7 @@ data:
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.12_ovn-kubernetes=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes__post1
     fi
     _OLD_EXISTS=false
-    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base >/dev/null 2>&1; then _OLD_EXISTS=true; fi
+    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base >/dev/null 2>&1; then _OLD_EXISTS=true; fi
     if [ "${_OLD_EXISTS}" = "true" ]; then
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes-base
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base__pre

--- a/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay_4.12.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay_4.12.yaml
@@ -35,7 +35,11 @@ data:
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base=quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base__post1
     fi
     for r in {1..5}; do
-      _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+      _info=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes)
+      _digest=$(echo "${_info}" | sed -n '/^Manifest List:[[:space:]]/s/^Manifest List:[[:space:]]*//p' | head -n1)
+      if [ -z "${_digest}" ]; then
+        _digest=$(echo "${_info}" | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+      fi
       if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.12:ovn-kubernetes; then
         break
       fi
@@ -49,7 +53,11 @@ data:
     done
 
     for r in {1..5}; do
-      _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+      _info=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base)
+      _digest=$(echo "${_info}" | sed -n '/^Manifest List:[[:space:]]/s/^Manifest List:[[:space:]]*//p' | head -n1)
+      if [ -z "${_digest}" ]; then
+        _digest=$(echo "${_info}" | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+      fi
       if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.12:ovn-kubernetes-base; then
         break
       fi

--- a/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay_multiple_tags.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay_multiple_tags.yaml
@@ -16,7 +16,7 @@ data:
     mirror 5 2 /etc/push-secret/.dockerconfigjson registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base_incoming
     mirror 5 2 /etc/push-secret/.dockerconfigjson registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:ccc=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift_incoming
     _OLD_EXISTS=false
-    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes >/dev/null 2>&1; then _OLD_EXISTS=true; fi
+    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes >/dev/null 2>&1; then _OLD_EXISTS=true; fi
     if [ "${_OLD_EXISTS}" = "true" ]; then
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes__pre
@@ -26,7 +26,7 @@ data:
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes__post1
     fi
     _OLD_EXISTS=false
-    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base >/dev/null 2>&1; then _OLD_EXISTS=true; fi
+    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base >/dev/null 2>&1; then _OLD_EXISTS=true; fi
     if [ "${_OLD_EXISTS}" = "true" ]; then
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes-base
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base__pre
@@ -36,7 +36,7 @@ data:
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base__post1
     fi
     _OLD_EXISTS=false
-    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift >/dev/null 2>&1; then _OLD_EXISTS=true; fi
+    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift >/dev/null 2>&1; then _OLD_EXISTS=true; fi
     if [ "${_OLD_EXISTS}" = "true" ]; then
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes-microshift
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift__pre

--- a/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay_multiple_tags.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay_multiple_tags.yaml
@@ -46,7 +46,11 @@ data:
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift__post1
     fi
     for r in {1..5}; do
-      _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+      _info=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes)
+      _digest=$(echo "${_info}" | sed -n '/^Manifest List:[[:space:]]/s/^Manifest List:[[:space:]]*//p' | head -n1)
+      if [ -z "${_digest}" ]; then
+        _digest=$(echo "${_info}" | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+      fi
       if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.21:ovn-kubernetes; then
         break
       fi
@@ -60,7 +64,11 @@ data:
     done
 
     for r in {1..5}; do
-      _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+      _info=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base)
+      _digest=$(echo "${_info}" | sed -n '/^Manifest List:[[:space:]]/s/^Manifest List:[[:space:]]*//p' | head -n1)
+      if [ -z "${_digest}" ]; then
+        _digest=$(echo "${_info}" | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+      fi
       if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.21:ovn-kubernetes-base; then
         break
       fi
@@ -74,7 +82,11 @@ data:
     done
 
     for r in {1..5}; do
-      _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+      _info=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift)
+      _digest=$(echo "${_info}" | sed -n '/^Manifest List:[[:space:]]/s/^Manifest List:[[:space:]]*//p' | head -n1)
+      if [ -z "${_digest}" ]; then
+        _digest=$(echo "${_info}" | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+      fi
       if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.21:ovn-kubernetes-microshift; then
         break
       fi

--- a/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay_non_release_namespace.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay_non_release_namespace.yaml
@@ -15,7 +15,7 @@ data:
     mirror 5 2 /etc/push-secret/.dockerconfigjson registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb=quay.io/openshift/ci:ci_ci_sanitize-prow-jobs_incoming
     mirror 5 2 /etc/push-secret/.dockerconfigjson registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:aaa=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes_incoming
     _OLD_EXISTS=false
-    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_ci_sanitize-prow-jobs >/dev/null 2>&1; then _OLD_EXISTS=true; fi
+    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ci_ci_sanitize-prow-jobs >/dev/null 2>&1; then _OLD_EXISTS=true; fi
     if [ "${_OLD_EXISTS}" = "true" ]; then
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_ci_sanitize-prow-jobs=quay.io/openshift/ci:ci_ci_sanitize-prow-jobs__pre
     fi
@@ -24,7 +24,7 @@ data:
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ci_ci_sanitize-prow-jobs=quay.io/openshift/ci:ci_ci_sanitize-prow-jobs__post1
     fi
     _OLD_EXISTS=false
-    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes >/dev/null 2>&1; then _OLD_EXISTS=true; fi
+    if oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes >/dev/null 2>&1; then _OLD_EXISTS=true; fi
     if [ "${_OLD_EXISTS}" = "true" ]; then
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes__pre
     fi

--- a/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay_non_release_namespace.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay_non_release_namespace.yaml
@@ -33,7 +33,11 @@ data:
       mirror 5 2 /etc/push-secret/.dockerconfigjson quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes__post1
     fi
     for r in {1..5}; do
-      _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+      _info=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes)
+      _digest=$(echo "${_info}" | sed -n '/^Manifest List:[[:space:]]/s/^Manifest List:[[:space:]]*//p' | head -n1)
+      if [ -z "${_digest}" ]; then
+        _digest=$(echo "${_info}" | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+      fi
       if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.21:ovn-kubernetes; then
         break
       fi


### PR DESCRIPTION
Before: Multi-arch images (hypershift) got re-promoted, Quay threw away the old digests, PR jobs building payloads blew up with “manifest unknown.”

Fix 1: Before moving the float tip, we actually notice the old image is there and keep a backup tag so Quay can’t GC it mid-flight.

Fix 2: We point the ocp imagestream at the full multi-arch image (manifest list), not just the amd64 slice, so what CI pins matches what Quay is keeping.

/cc @danilo-gemoli 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updates the release promotion tooling to safely preserve and promote multi-architecture Quay images.

- Filters Quay float checks by `linux/amd64` before creating `_prune_` backups, preventing valid multi-arch images from being treated as missing and garbage-collected.
- Resolves image tags from the `Manifest List` digest when available, falling back to the single-architecture `Digest`, so official image streams reference the correct multi-arch index.
- Adds targeted tests and updates promotion fixtures for filtered existence checks and manifest-list digest handling.
- Post-merge verification will confirm `_prune_` protection and multi-arch `from.name` references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->