### PR TITLE
KFLUXVNGD-1162: graceful teardown on EphemeralCluster deletion

### DIFF
--- a/pkg/controller/ephemeralcluster/prowjobreconciler.go
+++ b/pkg/controller/ephemeralcluster/prowjobreconciler.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -23,7 +22,6 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	ephemeralclusterv1 "github.com/openshift/ci-tools/pkg/api/ephemeralcluster/v1"
-	"github.com/openshift/ci-tools/pkg/steps"
 )
 
 const (
@@ -90,6 +88,12 @@ func (r *prowJobReconciler) Reconcile(ctx context.Context, req reconcile.Request
 		return reconcile.Result{}, err
 	}
 
+	switch pj.Status.State {
+	case prowv1.AbortedState, prowv1.ErrorState, prowv1.FailureState, prowv1.SuccessState:
+		log.Info("ProwJob already in a terminal state, nothing to do")
+		return reconcile.Result{}, nil
+	}
+
 	return r.gracefullyTerminateClusterProvisioning(ctx, log, pj)
 }
 
@@ -110,7 +114,7 @@ func (r *prowJobReconciler) gracefullyTerminateClusterProvisioning(ctx context.C
 		return reconcile.Result{}, reconcile.TerminalError(err)
 	}
 
-	ns, err := r.findCIOperatorTestNS(ctx, buildClient, pj)
+	ns, err := findCIOperatorTestNS(ctx, buildClient, pj)
 	if err != nil {
 		log.WithError(err).Error("Unable to retrieve ci-operator namespace")
 		return reconcile.Result{}, err
@@ -125,15 +129,12 @@ func (r *prowJobReconciler) gracefullyTerminateClusterProvisioning(ctx context.C
 	log.Info("ci-operator namespace found")
 
 	log = log.WithField("secret", api.EphemeralClusterTestDoneSignalSecretName)
-	if err := buildClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
-		Name:      api.EphemeralClusterTestDoneSignalSecretName,
-		Namespace: ns,
-	}}); err != nil {
-		if !apierrors.IsAlreadyExists(err) {
-			log.WithError(err).Warn("Failed to create the secret")
-			return reconcile.Result{}, err
-		}
-	} else {
+	created, err := createTestDoneSignalSecret(ctx, buildClient, ns)
+	if err != nil {
+		log.WithError(err).Warn("Failed to create the secret")
+		return reconcile.Result{}, err
+	}
+	if created {
 		log.Info("Secret created")
 	}
 
@@ -154,17 +155,4 @@ func (r *prowJobReconciler) abortProwJob(ctx context.Context, pj *prowv1.ProwJob
 	}
 
 	return reconcile.Result{}, nil
-}
-
-func (r *prowJobReconciler) findCIOperatorTestNS(ctx context.Context, buildClient ctrlruntimeclient.Client, pj *prowv1.ProwJob) (string, error) {
-	nss := corev1.NamespaceList{}
-	if err := buildClient.List(ctx, &nss, ctrlruntimeclient.MatchingLabels{steps.LabelJobID: pj.Name}); err != nil {
-		return "", fmt.Errorf("get namespace for %s: %w", pj.Name, err)
-	}
-
-	if len(nss.Items) == 0 {
-		return "", nil
-	}
-
-	return nss.Items[0].Name, nil
 }

--- a/pkg/controller/ephemeralcluster/prowjobreconciler_test.go
+++ b/pkg/controller/ephemeralcluster/prowjobreconciler_test.go
@@ -111,7 +111,7 @@ func TestReconcileProwJob(t *testing.T) {
 			wantErr: reconcile.TerminalError(errors.New("foo doesn't have the EC label")),
 		},
 		{
-			name: "EphemeralCluster not found, aborting the ProwJob",
+			name: "EphemeralCluster not found, ci-operator NS not found, abort ProwJob",
 			pj: &prowv1.ProwJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -140,6 +140,56 @@ func TestReconcileProwJob(t *testing.T) {
 					Description:    AbortECNotFound,
 					CompletionTime: ptr.To(metav1.NewTime(fakeNow)),
 				},
+			},
+		},
+		{
+			name: "EphemeralCluster not found, ProwJob already completed, no-op",
+			pj: &prowv1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						EphemeralClusterLabel: "ec",
+					},
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Spec:   prowv1.ProwJobSpec{Cluster: "build01"},
+				Status: prowv1.ProwJobStatus{State: prowv1.SuccessState},
+			},
+			wantPJ: &prowv1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						EphemeralClusterLabel: "ec",
+					},
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Spec:   prowv1.ProwJobSpec{Cluster: "build01"},
+				Status: prowv1.ProwJobStatus{State: prowv1.SuccessState},
+			},
+		},
+		{
+			name: "EphemeralCluster not found, ProwJob already aborted, no-op",
+			pj: &prowv1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						EphemeralClusterLabel: "ec",
+					},
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Spec:   prowv1.ProwJobSpec{Cluster: "build01"},
+				Status: prowv1.ProwJobStatus{State: prowv1.AbortedState},
+			},
+			wantPJ: &prowv1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						EphemeralClusterLabel: "ec",
+					},
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Spec:   prowv1.ProwJobSpec{Cluster: "build01"},
+				Status: prowv1.ProwJobStatus{State: prowv1.AbortedState},
 			},
 		},
 		{

--- a/pkg/controller/ephemeralcluster/reconciler.go
+++ b/pkg/controller/ephemeralcluster/reconciler.go
@@ -52,7 +52,6 @@ const (
 	EphemeralClusterTestName  = "cluster-provisioning"
 	EphemeralClusterLabel     = "ci.openshift.io/ephemeral-cluster"
 	EphemeralClusterNamespace = "ephemeral-cluster"
-	AbortProwJobDeleteEC      = "Ephemeral Cluster deleted"
 	DependentProwJobFinalizer = "ephemeralcluster.ci.openshift.io/dependent-prowjob"
 	UnresolvedConfigVar       = "UNRESOLVED_CONFIG"
 	ProwJobCreatingDoneReason = "ProwJob has been properly created"
@@ -588,8 +587,13 @@ func (r *reconciler) fetchSecrets(ctx context.Context, log *logrus.Entry, ec *ep
 		return reconcile.TerminalError(err)
 	}
 
-	ns, err := r.findCIOperatorTestNS(ctx, buildClient, pj)
+	ns, err := findCIOperatorTestNS(ctx, buildClient, pj)
 	if err != nil {
+		log.WithError(err).Error("Unable to retrieve ci-operator namespace")
+		upsertCondition(ecStatus, ephemeralclusterv1.ClusterReady, ephemeralclusterv1.ConditionFalse, r.now(), ephemeralclusterv1.SecretsFetchFailureReason, err.Error())
+		return err
+	}
+	if ns == "" {
 		upsertCondition(ecStatus, ephemeralclusterv1.ClusterReady, ephemeralclusterv1.ConditionFalse, r.now(), ephemeralclusterv1.SecretsFetchFailureReason, ephemeralclusterv1.CIOperatorNSNotFoundMsg)
 		if !hasCondition(oldStatus, ephemeralclusterv1.ClusterReady, ephemeralclusterv1.ConditionFalse, r.now(), ephemeralclusterv1.SecretsFetchFailureReason, ephemeralclusterv1.CIOperatorNSNotFoundMsg) {
 			log.Info("Fetching cluster credentials but ci-operator NS didn't show up yet")
@@ -855,26 +859,55 @@ func (r *reconciler) deleteEphemeralCluster(ctx context.Context, log *logrus.Ent
 		return removeFinalizer()
 	}
 
-	log.Info("Ephemeral Cluster is being deleted, aborting the ProwJob")
-	return r.abortProwJob(ctx, log, &pj, AbortProwJobDeleteEC)
-}
+	log.Info("Ephemeral Cluster is being deleted, signaling test completion to allow teardown")
 
-func (r *reconciler) abortProwJob(ctx context.Context, log *logrus.Entry, pj *prowv1.ProwJob, reason string) (reconcile.Result, error) {
-	if pj.Status.State == prowv1.AbortedState {
-		log.Info("ProwJob aborted already, skipping")
-		return reconcile.Result{}, nil
+	buildClient, err := r.buildClients.forCluster(pj.Spec.Cluster)
+	if err != nil {
+		log.WithField("cluster", pj.Spec.Cluster).WithError(err).Warn("Build client not found")
+		if err := r.abortProwJob(ctx, log, &pj, "Build client not found"); err != nil {
+			return reconcile.Result{}, err
+		}
+		return removeFinalizer()
 	}
 
+	ns, findErr := findCIOperatorTestNS(ctx, buildClient, &pj)
+	if findErr != nil {
+		log.WithError(findErr).Error("Unable to retrieve ci-operator namespace")
+		return reconcile.Result{}, findErr
+	}
+
+	if ns == "" {
+		if err := r.abortProwJob(ctx, log, &pj, "ci-operator namespace not found, no cloud resources to deprovision"); err != nil {
+			return reconcile.Result{}, err
+		}
+		return removeFinalizer()
+	}
+
+	log = log.WithField("namespace", ns).WithField("secret", api.EphemeralClusterTestDoneSignalSecretName)
+	created, err := createTestDoneSignalSecret(ctx, buildClient, ns)
+	if err != nil {
+		log.WithError(err).Warn("Failed to create the test-done-signal secret")
+		return reconcile.Result{}, err
+	}
+	if created {
+		log.Info("Test-done-signal secret created")
+	}
+
+	return reconcile.Result{RequeueAfter: r.polling()}, nil
+}
+
+func (r *reconciler) abortProwJob(ctx context.Context, log *logrus.Entry, pj *prowv1.ProwJob, reason string) error {
+	if pj.Status.State == prowv1.AbortedState {
+		return nil
+	}
+	log.WithField("reason", reason).Info("Aborting ProwJob")
 	pj.Status.State = prowv1.AbortedState
 	pj.Status.Description = reason
 	pj.Status.CompletionTime = ptr.To(metav1.NewTime(r.now()))
-
 	if err := r.masterClient.Update(ctx, pj); err != nil {
-		return reconcile.Result{}, fmt.Errorf("abort prowjob: %w", err)
+		return fmt.Errorf("abort prowjob: %w", err)
 	}
-	log.Info("ProwJob aborted")
-
-	return reconcile.Result{RequeueAfter: r.polling()}, nil
+	return nil
 }
 
 func (r *reconciler) notifyTestComplete(ctx context.Context, log *logrus.Entry, oldECStatus, ecStatus *ephemeralclusterv1.EphemeralClusterStatus, pj *prowv1.ProwJob) error {
@@ -888,8 +921,14 @@ func (r *reconciler) notifyTestComplete(ctx context.Context, log *logrus.Entry, 
 		return reconcile.TerminalError(err)
 	}
 
-	ns, err := r.findCIOperatorTestNS(ctx, buildClient, pj)
+	ns, err := findCIOperatorTestNS(ctx, buildClient, pj)
 	if err != nil {
+		log.WithError(err).Error("Unable to retrieve ci-operator namespace")
+		upsertCondition(ecStatus, ephemeralclusterv1.TestCompleted, ephemeralclusterv1.ConditionFalse, r.now(), ephemeralclusterv1.CreateTestCompletedSecretFailureReason, err.Error())
+		ecStatus.Phase = ephemeralclusterv1.EphemeralClusterFailed
+		return err
+	}
+	if ns == "" {
 		upsertCondition(ecStatus, ephemeralclusterv1.TestCompleted, ephemeralclusterv1.ConditionFalse, r.now(), ephemeralclusterv1.CreateTestCompletedSecretFailureReason, ephemeralclusterv1.CIOperatorNSNotFoundMsg)
 		ecStatus.Phase = ephemeralclusterv1.EphemeralClusterFailed
 		return nil
@@ -897,15 +936,10 @@ func (r *reconciler) notifyTestComplete(ctx context.Context, log *logrus.Entry, 
 
 	log = log.WithField("namespace", ns).WithField("secret", api.EphemeralClusterTestDoneSignalSecretName)
 
-	if err := buildClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
-		Name:      api.EphemeralClusterTestDoneSignalSecretName,
-		Namespace: ns,
-	}}); err != nil {
-		if !apierrors.IsAlreadyExists(err) {
-			log.WithError(err).Warn("Failed to create the secret")
-			upsertCondition(ecStatus, ephemeralclusterv1.TestCompleted, ephemeralclusterv1.ConditionFalse, r.now(), ephemeralclusterv1.CreateTestCompletedSecretFailureReason, err.Error())
-			return err
-		}
+	if _, err := createTestDoneSignalSecret(ctx, buildClient, ns); err != nil {
+		log.WithError(err).Warn("Failed to create the secret")
+		upsertCondition(ecStatus, ephemeralclusterv1.TestCompleted, ephemeralclusterv1.ConditionFalse, r.now(), ephemeralclusterv1.CreateTestCompletedSecretFailureReason, err.Error())
+		return err
 	}
 
 	upsertCondition(ecStatus, ephemeralclusterv1.TestCompleted, ephemeralclusterv1.ConditionTrue, r.now(), "", "")
@@ -916,18 +950,31 @@ func (r *reconciler) notifyTestComplete(ctx context.Context, log *logrus.Entry, 
 	return nil
 }
 
-func (r *reconciler) findCIOperatorTestNS(ctx context.Context, buildClient ctrlruntimeclient.Client, pj *prowv1.ProwJob) (string, error) {
+func findCIOperatorTestNS(ctx context.Context, buildClient ctrlruntimeclient.Client, pj *prowv1.ProwJob) (string, error) {
 	nss := corev1.NamespaceList{}
 	if err := buildClient.List(ctx, &nss, ctrlruntimeclient.MatchingLabels{steps.LabelJobID: pj.Name}); err != nil {
 		return "", fmt.Errorf("get namespace for %s: %w", pj.Name, err)
 	}
 
-	// The NS hasn't been created yet, requeuing.
+	// The NS hasn't been created yet.
 	if len(nss.Items) == 0 {
-		return "", errors.New("ci-operator NS not found")
+		return "", nil
 	}
 
 	return nss.Items[0].Name, nil
+}
+
+func createTestDoneSignalSecret(ctx context.Context, buildClient ctrlruntimeclient.Client, ns string) (bool, error) {
+	if err := buildClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Name:      api.EphemeralClusterTestDoneSignalSecretName,
+		Namespace: ns,
+	}}); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 func upsertCondition(ecStatus *ephemeralclusterv1.EphemeralClusterStatus, t ephemeralclusterv1.EphemeralClusterConditionType, status ephemeralclusterv1.ConditionStatus, now time.Time, reason, msg string) {

--- a/pkg/controller/ephemeralcluster/reconciler_test.go
+++ b/pkg/controller/ephemeralcluster/reconciler_test.go
@@ -1587,16 +1587,18 @@ func TestDeleteProwJob(t *testing.T) {
 	const pollingTime = 5
 
 	for _, tc := range []struct {
-		name    string
-		ec      *ephemeralclusterv1.EphemeralCluster
-		pj      *prowv1.ProwJob
-		wantEC  *ephemeralclusterv1.EphemeralCluster
-		wantPJ  *prowv1.ProwJob
-		wantRes reconcile.Result
-		wantErr error
+		name         string
+		ec           *ephemeralclusterv1.EphemeralCluster
+		pj           *prowv1.ProwJob
+		buildClients func() map[string]*ctrlruntimetest.FakeClient
+		wantEC       *ephemeralclusterv1.EphemeralCluster
+		wantPJ       *prowv1.ProwJob
+		wantSecret   *corev1.Secret
+		wantRes      reconcile.Result
+		wantErr      error
 	}{
 		{
-			name: "Delete EC: abort the ProwJob",
+			name: "Delete EC: signal test completion to allow teardown",
 			ec: &ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "foo",
@@ -1610,6 +1612,19 @@ func TestDeleteProwJob(t *testing.T) {
 			},
 			pj: &prowv1.ProwJob{
 				ObjectMeta: metav1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
+				Spec:       prowv1.ProwJobSpec{Cluster: "build01"},
+			},
+			buildClients: func() map[string]*ctrlruntimetest.FakeClient {
+				objs := []ctrlclient.Object{&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{steps.LabelJobID: "pj-123"},
+						Name:   "ci-op-1234",
+					},
+				}}
+				c := fake.NewClientBuilder().WithObjects(objs...).WithScheme(scheme).Build()
+				return map[string]*ctrlruntimetest.FakeClient{
+					"build01": ctrlruntimetest.NewFakeClient(c, scheme, ctrlruntimetest.WithInitObjects(objs...)),
+				}
 			},
 			wantEC: &ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1624,10 +1639,106 @@ func TestDeleteProwJob(t *testing.T) {
 			},
 			wantPJ: &prowv1.ProwJob{
 				ObjectMeta: metav1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
+				Spec:       prowv1.ProwJobSpec{Cluster: "build01"},
+			},
+			wantSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      api.EphemeralClusterTestDoneSignalSecretName,
+					Namespace: "ci-op-1234",
+				},
+			},
+			wantRes: reconcile.Result{RequeueAfter: pollingTime},
+		},
+		{
+			name: "Delete EC: ci-operator NS not found yet, abort ProwJob and remove finalizer",
+			ec: &ephemeralclusterv1.EphemeralCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "foo",
+					Namespace:         "bar",
+					DeletionTimestamp: ptr.To(metav1.NewTime(fakeNow)),
+					Finalizers:        []string{DependentProwJobFinalizer},
+				},
+				Status: ephemeralclusterv1.EphemeralClusterStatus{
+					ProwJobID: "pj-123",
+				},
+			},
+			pj: &prowv1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
+				Spec:       prowv1.ProwJobSpec{Cluster: "build01"},
+			},
+			buildClients: func() map[string]*ctrlruntimetest.FakeClient {
+				c := fake.NewClientBuilder().WithScheme(scheme).Build()
+				return map[string]*ctrlruntimetest.FakeClient{
+					"build01": ctrlruntimetest.NewFakeClient(c, scheme),
+				}
+			},
+			wantPJ: &prowv1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
+				Spec:       prowv1.ProwJobSpec{Cluster: "build01"},
 				Status: prowv1.ProwJobStatus{
 					State:          prowv1.AbortedState,
-					Description:    AbortProwJobDeleteEC,
+					Description:    "ci-operator namespace not found, no cloud resources to deprovision",
 					CompletionTime: ptr.To(metav1.NewTime(fakeNow)),
+				},
+			},
+			wantRes: reconcile.Result{},
+		},
+		{
+			name: "Delete EC: test-done-signal secret already exists",
+			ec: &ephemeralclusterv1.EphemeralCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "foo",
+					Namespace:         "bar",
+					DeletionTimestamp: ptr.To(metav1.NewTime(fakeNow)),
+					Finalizers:        []string{DependentProwJobFinalizer},
+				},
+				Status: ephemeralclusterv1.EphemeralClusterStatus{
+					ProwJobID: "pj-123",
+				},
+			},
+			pj: &prowv1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
+				Spec:       prowv1.ProwJobSpec{Cluster: "build01"},
+			},
+			buildClients: func() map[string]*ctrlruntimetest.FakeClient {
+				objs := []ctrlclient.Object{
+					&corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{steps.LabelJobID: "pj-123"},
+							Name:   "ci-op-1234",
+						},
+					},
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      api.EphemeralClusterTestDoneSignalSecretName,
+							Namespace: "ci-op-1234",
+						},
+					},
+				}
+				c := fake.NewClientBuilder().WithObjects(objs...).WithScheme(scheme).Build()
+				return map[string]*ctrlruntimetest.FakeClient{
+					"build01": ctrlruntimetest.NewFakeClient(c, scheme, ctrlruntimetest.WithInitObjects(objs...)),
+				}
+			},
+			wantEC: &ephemeralclusterv1.EphemeralCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "foo",
+					Namespace:         "bar",
+					DeletionTimestamp: ptr.To(metav1.NewTime(fakeNow)),
+					Finalizers:        []string{DependentProwJobFinalizer},
+				},
+				Status: ephemeralclusterv1.EphemeralClusterStatus{
+					ProwJobID: "pj-123",
+				},
+			},
+			wantPJ: &prowv1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
+				Spec:       prowv1.ProwJobSpec{Cluster: "build01"},
+			},
+			wantSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      api.EphemeralClusterTestDoneSignalSecretName,
+					Namespace: "ci-op-1234",
 				},
 			},
 			wantRes: reconcile.Result{RequeueAfter: pollingTime},
@@ -1668,6 +1779,32 @@ func TestDeleteProwJob(t *testing.T) {
 			},
 			wantRes: reconcile.Result{},
 		},
+		{
+			name: "Delete EC: build client not found, abort ProwJob and remove finalizer",
+			ec: &ephemeralclusterv1.EphemeralCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "foo",
+					Namespace:         "bar",
+					DeletionTimestamp: ptr.To(metav1.NewTime(fakeNow)),
+					Finalizers:        []string{DependentProwJobFinalizer},
+				},
+				Status: ephemeralclusterv1.EphemeralClusterStatus{ProwJobID: "pj-123"},
+			},
+			pj: &prowv1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
+				Spec:       prowv1.ProwJobSpec{Cluster: "unknown-cluster"},
+			},
+			wantPJ: &prowv1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
+				Spec:       prowv1.ProwJobSpec{Cluster: "unknown-cluster"},
+				Status: prowv1.ProwJobStatus{
+					State:          prowv1.AbortedState,
+					Description:    "Build client not found",
+					CompletionTime: ptr.To(metav1.NewTime(fakeNow)),
+				},
+			},
+			wantRes: reconcile.Result{},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -1683,10 +1820,19 @@ func TestDeleteProwJob(t *testing.T) {
 
 			client := bldr.Build()
 
+			clients := make(map[string]ctrlclient.Client)
+			var fakeClients map[string]*ctrlruntimetest.FakeClient
+			if tc.buildClients != nil {
+				fakeClients = tc.buildClients()
+				for cluster, c := range fakeClients {
+					clients[cluster] = c.WithWatch
+				}
+			}
+
 			r := reconciler{
 				logger:       logrus.NewEntry(logrus.StandardLogger()),
 				masterClient: client,
-				buildClients: map[string]ctrlclient.Client{},
+				buildClients: clients,
 				now:          func() time.Time { return fakeNow },
 				polling:      func() time.Duration { return pollingTime },
 				prowConfigAgent: prowConfigAgent(&prowconfig.Config{
@@ -1726,7 +1872,7 @@ func TestDeleteProwJob(t *testing.T) {
 			if tc.wantPJ != nil {
 				gotPJ := prowv1.ProwJob{}
 				if err := client.Get(context.TODO(), types.NamespacedName{Namespace: tc.wantPJ.Namespace, Name: tc.wantPJ.Name}, &gotPJ); err != nil {
-					t.Errorf("unexpected get ephemeralcluster error: %s", err)
+					t.Errorf("unexpected get prowjob error: %s", err)
 				}
 
 				ignoreFields := cmpopts.IgnoreFields(prowv1.ProwJob{}, "ResourceVersion")
@@ -1742,6 +1888,25 @@ func TestDeleteProwJob(t *testing.T) {
 
 				if len(pjList.Items) > 0 {
 					t.Error("prowjob has not been deleted")
+				}
+			}
+
+			if tc.wantSecret != nil && tc.pj != nil && fakeClients != nil {
+				buildClient := fakeClients[tc.pj.Spec.Cluster]
+				gotSecrets := &corev1.SecretList{}
+				if err := buildClient.WithWatch.List(context.TODO(), gotSecrets, ctrlclient.InNamespace(tc.wantSecret.Namespace)); err != nil {
+					t.Errorf("list secrets: %s", err)
+				}
+
+				found := false
+				for _, s := range gotSecrets.Items {
+					if s.Name == tc.wantSecret.Name {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected secret %s/%s not found", tc.wantSecret.Namespace, tc.wantSecret.Name)
 				}
 			}
 		})


### PR DESCRIPTION
When an EphemeralCluster is deleted, instead of hard-aborting the ProwJob, signal the test step to exit via the test-done-signal secret. This allows the ci-operator workflow to reach its post steps and deprovision the cluster, preventing leaked cloud resources.

When the graceful signal cannot be delivered — because the build client is unavailable or the ci-operator namespace does not exist yet — fall back to aborting the ProwJob and removing the finalizer. This prevents the EphemeralCluster from getting stuck in deletion indefinitely.

The EC reconciler's findCIOperatorTestNS now distinguishes API errors from "namespace not yet created", surfacing real failures instead of masking them as requeue-worthy.

Extract findCIOperatorTestNS and createTestDoneSignalSecret into shared package-level functions to eliminate duplication between the EC reconciler and the ProwJobReconciler.

The ProwJobReconciler also gains a terminal state guard so it no longer attempts to abort or signal ProwJobs that have already completed.

Assisted-by: Claude claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

EphemeralCluster deletion now performs a graceful ci-operator teardown instead of immediately aborting the ProwJob. The controller signals completion through the `test-done-signal` Secret, allowing post steps to run and the cluster to be deprovisioned before cleanup continues.

If the build client or ci-operator test namespace is unavailable, the controller falls back to aborting the ProwJob and removing the finalizer. Namespace lookup now distinguishes a missing namespace from API errors, with shared helpers used across reconcilers.

The ProwJob reconciler also ignores ProwJobs already in a terminal state, preventing unnecessary provisioning or termination actions. Tests cover graceful signaling, fallback abort behavior, missing namespaces, and completed ProwJobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->