### PR TITLE
Skip K8s secret refs in mount path collision validation

### DIFF
--- a/pkg/steps/csi_secrets/gsm_bundle_resolver.go
+++ b/pkg/steps/csi_secrets/gsm_bundle_resolver.go
@@ -27,6 +27,9 @@ func ValidateNoFileCollisionsOnMountPath(credentials []api.CredentialReference) 
 		}
 		seenFiles := make(map[string]credSource)
 		for _, cred := range creds {
+			if IsK8sSecretReference(cred) {
+				continue
+			}
 			fileName := cred.Field
 			if cred.As != "" {
 				fileName = cred.As

--- a/pkg/steps/csi_secrets/gsm_bundle_resolver_test.go
+++ b/pkg/steps/csi_secrets/gsm_bundle_resolver_test.go
@@ -551,6 +551,12 @@ func TestValidateNoFileCollisionsOnMountPath(t *testing.T) {
 				{Collection: "col-b", Group: "grp-y", Field: "token", MountPath: "/var/bundle"},
 			},
 		},
+		{
+			name: "sync_to_cluster bundle resolved to k8s secret reference is skipped",
+			credentials: []api.CredentialReference{
+				{Namespace: "ci", Name: "cluster-init", MountPath: "/etc/kubeconfigs"},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			actualErr := ValidateNoFileCollisionsOnMountPath(tc.credentials)


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/openshift/ci-tools/pull/5317

What was happening:
In `ci-secret-bootstrap/gsm-config.yaml`, the bundle with `sync_to_cluster: true` is synced to clusters as a K8s Secret:
```
bundles:
  - name: cluster-init
    sync_to_cluster: true 
    # ...
```

Job config references it as:
```
credentials:
  - bundle: cluster-init
    namespace: ci
    mount_path: /etc/kubeconfigs
```

At runtime this resolves to `{namespace: ci, name: cluster-init, mount_path: /etc/kubeconfigs}` — no `field`. [#5317](https://github.com/openshift/ci-tools/pull/5317)’s mount filename validation then failed:

`invalid field name "" at mount_path /etc/kubeconfigs: mount file name "" decodes to an empty string`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixes `ci-operator` mount validation for bundles synced to Kubernetes Secrets. Kubernetes Secret references now bypass filename collision checks, preventing valid `sync_to_cluster: true` configurations from being rejected due to their intentionally empty field name. Adds regression coverage for this behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->