### PR TITLE
Migrate CRI-O annotations to v2 format

### DIFF
--- a/pkg/steps/multi_stage/testdata/zz_fixture_TestGeneratePods_enable_nested_podman.yaml
+++ b/pkg/steps/multi_stage/testdata/zz_fixture_TestGeneratePods_enable_nested_podman.yaml
@@ -3,7 +3,7 @@
       ci-operator.openshift.io/container-sub-tests: test
       ci-operator.openshift.io/save-container-logs: "true"
       ci.openshift.io/job-spec: ""
-      io.kubernetes.cri-o.Devices: /dev/fuse,/dev/net/tun
+      devices.crio.io: /dev/fuse,/dev/net/tun
       openshift.io/required-scc: nested-podman
       openshift.io/scc: nested-podman
     creationTimestamp: null

--- a/pkg/steps/multi_stage/testdata/zz_fixture_TestGeneratePods_lease_proxy_server_available.yaml
+++ b/pkg/steps/multi_stage/testdata/zz_fixture_TestGeneratePods_lease_proxy_server_available.yaml
@@ -3,7 +3,7 @@
       ci-operator.openshift.io/container-sub-tests: test
       ci-operator.openshift.io/save-container-logs: "true"
       ci.openshift.io/job-spec: ""
-      io.kubernetes.cri-o.Devices: /dev/fuse,/dev/net/tun
+      devices.crio.io: /dev/fuse,/dev/net/tun
       openshift.io/required-scc: nested-podman
       openshift.io/scc: nested-podman
     creationTimestamp: null

--- a/pkg/util/pods.go
+++ b/pkg/util/pods.go
@@ -685,7 +685,7 @@ func ConfigurePodForNestedPodman(pod *corev1.Pod, containerName string, saName s
 
 	pod.Annotations["openshift.io/required-scc"] = api.NestedPodmanSCC
 	pod.Annotations["openshift.io/scc"] = api.NestedPodmanSCC
-	pod.Annotations["io.kubernetes.cri-o.Devices"] = "/dev/fuse,/dev/net/tun"
+	pod.Annotations["devices.crio.io"] = "/dev/fuse,/dev/net/tun"
 
 	pod.Spec.HostUsers = ptr.To(false)
 }


### PR DESCRIPTION
CRI-O migrated its annotations from v1 (`io.kubernetes.cri-o.*`) to v2 (`*.crio.io`) in December 2025. The old format is deprecated.

This updates the `io.kubernetes.cri-o.Devices` annotation to its v2 equivalent `devices.crio.io` in the pod utility code and related test fixtures.

Tracking: https://github.com/cri-o/cri-o/issues/10194