### PR TITLE
fix: point test-pod CloneRefs at oauth-<hash> secret

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -632,6 +632,10 @@ func (o *options) Complete() error {
 		if err != nil {
 			return fmt.Errorf("could not get secret from path %s: %w", cloneAuthSecretPath, err)
 		}
+		if o.cloneAuthConfig.Type == steps.CloneAuthTypeOAuth && o.jobSpec.DecorationConfig != nil && o.jobSpec.DecorationConfig.OauthTokenSecret != nil {
+			o.jobSpec.DecorationConfig.OauthTokenSecret.Name = o.cloneAuthConfig.Secret.Name
+			o.jobSpec.DecorationConfig.OauthTokenSecret.Key = steps.OauthSecretKey
+		}
 	}
 
 	for _, path := range o.secretDirectories.values {


### PR DESCRIPTION
Test-pod CloneRefs inherited the prowjob `DecorationConfig.OauthTokenSecret` (`github-credentials-…` in `ci`). Retarget it to the `oauth-<hash>` secret ci-operator already creates in `ci-op-*` (name + `oauth-token` key).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

`ci-operator` (in `cmd/ci-operator/main.go`) now ensures test-pod `CloneRefs` uses the OAuth secret generated for the job’s clone-auth configuration when clone auth is OAuth. Concretely, during `(*options).Complete`, if `DecorationConfig.OauthTokenSecret` is set, `ci-operator` rewrites it to point at the freshly created `oauth-<hash>` secret and the `oauth-token` key, instead of inheriting the prowjob’s default `DecorationConfig.OauthTokenSecret` reference (e.g., `github-credentials-…` from the `ci` namespace).

This prevents cloned-repo authentication from depending on a secret in the wrong namespace, fixing behavior specifically for `ci-op-*` test-pod execution.

## Comments

- The PR author issued `/hold`.

## Testing

- Unit and build CI
- Private container test with `clone: true` after rollout
<!-- end of auto-generated comment: release notes by coderabbit.ai -->