### PR TITLE
fix clonerefs in test pods to use the correct oauth secret from the temp namespace

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -385,7 +385,7 @@ func stepForTest(cfg *Config, inputImages inputImageSet, c *api.TestStepConfigur
 		ret = append(ret, stepsForStepImages(cfg.kubeClient, cfg.JobSpec, inputImages, test, imageConfigs)...)
 		return ret
 	}
-	step := steps.TestStep(*c, cfg.CIConfig.Resources, cfg.podClient, cfg.JobSpec, cfg.NodeName, cfg.EnableSecretsStoreCSIDriver, cfg.GSMConfig)
+	step := steps.TestStep(*c, cfg.CIConfig.Resources, cfg.podClient, cfg.JobSpec, cfg.NodeName, cfg.EnableSecretsStoreCSIDriver, cfg.GSMConfig, cfg.CloneAuthConfig)
 	if c.ClusterClaim != nil {
 		step = steps.ClusterClaimStep(c.As, c.ClusterClaim, cfg.hiveClient, cfg.kubeClient, cfg.JobSpec, step, cfg.Censor)
 	}

--- a/pkg/steps/artifacts.go
+++ b/pkg/steps/artifacts.go
@@ -306,6 +306,9 @@ func addPodUtils(
 		decorationConfig := *decorationConfig
 		decorationConfig.SkipCloning = nil
 		decorationConfig.SparseCheckoutFiles = nil
+		if c := generatePodOptions.CloneAuthConfig; c != nil && c.Secret != nil {
+			decorationConfig.OauthTokenSecret = &prowv1.OauthTokenSecret{Name: c.Secret.Name, Key: OauthSecretKey}
+		}
 
 		var cloneRefs *prowv1.Refs
 		if jobSpec.Refs != nil {

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -58,6 +58,7 @@ type PodStepConfiguration struct {
 	Secrets                     []*api.Secret
 	MemoryBackedVolume          *api.MemoryBackedVolume
 	Clone                       bool
+	CloneAuthConfig             *CloneAuthConfig
 	NodeArchitecture            api.NodeArchitecture
 	NestedPodman                bool
 	EnableSecretsStoreCSIDriver bool
@@ -68,6 +69,7 @@ type GeneratePodOptions struct {
 	Clone             bool
 	PropagateExitCode bool
 	NodeArchitecture  string
+	CloneAuthConfig   *CloneAuthConfig
 }
 
 type podStep struct {
@@ -196,7 +198,7 @@ func (s *podStep) ResolveMultiArch() sets.Set[string] {
 
 func (s *podStep) AddArchitectures(archs []string) {}
 
-func TestStep(config api.TestStepConfiguration, resources api.ResourceConfiguration, client kubernetes.PodClient, jobSpec *api.JobSpec, nodeName string, enableCSI bool, gsmConfig *csi_secrets.GSMConfiguration) api.Step {
+func TestStep(config api.TestStepConfiguration, resources api.ResourceConfiguration, client kubernetes.PodClient, jobSpec *api.JobSpec, nodeName string, enableCSI bool, gsmConfig *csi_secrets.GSMConfiguration, cloneAuthConfig *CloneAuthConfig) api.Step {
 	return PodStep(
 		"test",
 		PodStepConfiguration{
@@ -207,6 +209,7 @@ func TestStep(config api.TestStepConfiguration, resources api.ResourceConfigurat
 			Secrets:                     config.Secrets,
 			MemoryBackedVolume:          config.ContainerTestConfiguration.MemoryBackedVolume,
 			Clone:                       *config.ContainerTestConfiguration.Clone,
+			CloneAuthConfig:             cloneAuthConfig,
 			NodeArchitecture:            config.NodeArchitecture,
 			NestedPodman:                config.NestedPodman,
 			EnableSecretsStoreCSIDriver: enableCSI,
@@ -363,7 +366,7 @@ func (s *podStep) generatePodForStep(image string, containerResources coreapi.Re
 	pod, err := GenerateBasePod(s.jobSpec, s.config.Labels, s.config.As,
 		s.config.NodeName, s.name, []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\n" + s.config.Commands},
 		image, containerResources, artifactDir, s.jobSpec.DecorationConfig, s.jobSpec.RawSpec(),
-		secretVolumeMounts, &GeneratePodOptions{Clone: clone, PropagateExitCode: false, NodeArchitecture: string(s.config.NodeArchitecture)})
+		secretVolumeMounts, &GeneratePodOptions{Clone: clone, PropagateExitCode: false, NodeArchitecture: string(s.config.NodeArchitecture), CloneAuthConfig: s.config.CloneAuthConfig})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/steps/pod_test.go
+++ b/pkg/steps/pod_test.go
@@ -355,7 +355,7 @@ func TestTestStepAndRequires(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := TestStep(tc.config, nil, nil, nil, "", false, nil).Requires()
+			actual := TestStep(tc.config, nil, nil, nil, "", false, nil, nil).Requires()
 			if len(actual) == len(tc.expected) {
 				matches := true
 				for i := range actual {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates ci-operator test pod generation so clonerefs uses the correct OAuth secret from the temporary namespace. Clone authentication now flows from test configuration into pod generation and sets the pod decoration’s OAuth token secret when cloning is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->