### PR TITLE
repo-brancher-controller: fix forwarding for disabled promotions

### DIFF
--- a/cmd/repo-brancher-controller/config.go
+++ b/cmd/repo-brancher-controller/config.go
@@ -29,7 +29,7 @@ func loadDesiredState(configDir string, forwardingConfig *forwardingConfig) (map
 			return nil
 		}
 
-		if current := forwardingConfig.DefaultBranch; current != nil && (info.Branch == "main" || info.Branch == "master") && api.PromotesOfficialImage(configuration, api.WithoutOKD, current.ConfigsPromotingTo) {
+		if current := forwardingConfig.DefaultBranch; current != nil && (info.Branch == "main" || info.Branch == "master") && api.TargetsOfficialImage(configuration, api.WithoutOKD, current.ConfigsPromotingTo) {
 			for _, forward := range current.forwardBlocks() {
 				if err := addTargets(current.ConfigsPromotingTo, forward, true); err != nil {
 					return err
@@ -38,7 +38,7 @@ func loadDesiredState(configDir string, forwardingConfig *forwardingConfig) (map
 		}
 
 		for _, forwarding := range forwardingConfig.ReleaseBranches {
-			if !api.PromotesOfficialImage(configuration, api.WithoutOKD, forwarding.Source) {
+			if !api.TargetsOfficialImage(configuration, api.WithoutOKD, forwarding.Source) {
 				continue
 			}
 			for _, forward := range forwarding.forwardBlocks() {

--- a/cmd/repo-brancher-controller/config_test.go
+++ b/cmd/repo-brancher-controller/config_test.go
@@ -91,7 +91,9 @@ func TestLoadDesiredStateUsesBranchCategoriesAndScopedIgnores(t *testing.T) {
 	}
 	want := map[repoKey]sets.Set[string]{
 		{org: "org", repo: "default", source: "main"}:                    sets.New("release-5.0", "release-5.1"),
+		{org: "org", repo: "disabled-default", source: "main"}:           sets.New("release-5.0", "release-5.1"),
 		{org: "org", repo: "release", source: "release-5.0"}:             sets.New("release-4.23"),
+		{org: "org", repo: "disabled-release", source: "release-5.0"}:    sets.New("release-4.23"),
 		{org: "org", repo: "openshift-release", source: "openshift-5.0"}: sets.New("openshift-4.23"),
 	}
 	if len(state) != len(want) {

--- a/pkg/api/promotion.go
+++ b/pkg/api/promotion.go
@@ -71,6 +71,19 @@ func PromotesOfficialImage(configSpec *ReleaseBuildConfiguration, includeOKD OKD
 	return false
 }
 
+// TargetsOfficialImage determines if a configuration targets promotionName in an
+// official stream, regardless of whether promotion is disabled. Use this instead
+// of PromotesOfficialImage when the disabled flag is irrelevant, e.g. for branch
+// forwarding where release branches always have promotion disabled.
+func TargetsOfficialImage(configSpec *ReleaseBuildConfiguration, includeOKD OKDInclusion, promotionName string) bool {
+	for _, target := range PromotionTargets(configSpec.PromotionConfiguration) {
+		if BuildsOfficialImages(target, includeOKD) && target.Name == promotionName {
+			return true
+		}
+	}
+	return false
+}
+
 // BuildsOfficialImages determines if a configuration will result in official images
 // being built.
 func BuildsOfficialImages(configSpec PromotionTarget, includeOKD OKDInclusion) bool {


### PR DESCRIPTION
## Summary
- `PromotesOfficialImage` skips configs with `disabled: true` on their promotion target, but release branch configs (e.g. `release-5.0`) always have promotion disabled because `main`/`master` is the active promoter for that stream.
- This caused the controller to silently skip **all** `release_branches` forwarding — no `release-5.0 → release-4.23` forwarding happened for any repo.
- Add `api.TargetsOfficialImage` that matches on release stream name and namespace but ignores the `Disabled` flag, and use it in `loadDesiredState`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixes `repo-brancher-controller` forwarding for release branches whose promotion is disabled because `main` or `master` is the active promoter.

Branch forwarding now recognizes matching official-image targets regardless of their disabled flag, ensuring disabled default and release configurations are included in the desired state. Adds `api.TargetsOfficialImage` and updates coverage for these scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->