### PR TITLE
omit import-mode flag for OCP CLI versions older than 4.13

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -104,6 +104,7 @@ func fromConfig(ctx context.Context, cfg *Config) ([]api.Step, []api.Step, error
 	var buildSteps []api.Step
 	var imageStepLinks []api.StepLink
 	var hasReleaseStep bool
+	var cliVersion string
 	resolver := rootImageResolver(cfg.kubeClient, ctx, cfg.Promote)
 	imageConfigs := cfg.GraphConf.InputImages()
 	rawSteps, err := runtimeStepConfigsForBuild(cfg.CIConfig, cfg.JobSpec, os.ReadFile, resolver, imageConfigs, cfg.InjectedTest)
@@ -135,19 +136,9 @@ func fromConfig(ctx context.Context, cfg *Config) ([]api.Step, []api.Step, error
 			var value string
 			var err error
 			var overrideCLIReleaseExtractImage *coreapi.ObjectReference
-			var overrideCLIResolveErr error
-			switch {
-			case resolveConfig.Integration != nil:
-				overrideCLIReleaseExtractImage, overrideCLIResolveErr = resolveCLIOverrideImage(api.ReleaseArchitectureAMD64, resolveConfig.Integration.Name)
-			case resolveConfig.Candidate != nil:
-				overrideCLIReleaseExtractImage, overrideCLIResolveErr = resolveCLIOverrideImage(resolveConfig.Candidate.Architecture, resolveConfig.Candidate.Version)
-			case resolveConfig.Release != nil:
-				overrideCLIReleaseExtractImage, overrideCLIResolveErr = resolveCLIOverrideImage(resolveConfig.Release.Architecture, resolveConfig.Release.Version)
-			case resolveConfig.Prerelease != nil:
-				overrideCLIReleaseExtractImage, overrideCLIResolveErr = resolveCLIOverrideImage(resolveConfig.Prerelease.Architecture, resolveConfig.Prerelease.VersionBounds.Lower)
-			}
-			if overrideCLIResolveErr != nil {
-				return nil, nil, results.ForReason("resolving_cli_override").ForError(fmt.Errorf("failed to resolve override CLI image for release %s: %w", resolveConfig.Name, overrideCLIResolveErr))
+			overrideCLIReleaseExtractImage, cliVersion, err = resolveReleaseCLIOverride(resolveConfig.UnresolvedRelease)
+			if err != nil {
+				return nil, nil, results.ForReason("resolving_cli_override").ForError(fmt.Errorf("failed to resolve override CLI image for release %s: %w", resolveConfig.Name, err))
 			}
 			referencePolicy := imagev1.SourceTagReferencePolicy
 			if resolveConfig.Integration != nil && resolveConfig.Integration.ReferencePolicy != nil {
@@ -304,13 +295,13 @@ func fromConfig(ctx context.Context, cfg *Config) ([]api.Step, []api.Step, error
 		}
 
 		if !api.PromotesOfficialImages(cfg.CIConfig, api.WithoutOKD) {
-			promotionSteps = append(promotionSteps, releasesteps.PromotionStep(api.PromotionStepName, cfg.CIConfig, requiredNames, cfg.SkippedImages, cfg.JobSpec, cfg.podClient, cfg.PushSecret, registryDomain(cfg.CIConfig.PromotionConfiguration), api.DefaultMirrorFunc, api.DefaultTargetNameFunc, cfg.NodeArchitectures))
+			promotionSteps = append(promotionSteps, releasesteps.PromotionStep(api.PromotionStepName, cfg.CIConfig, requiredNames, cfg.SkippedImages, cfg.JobSpec, cfg.podClient, cfg.PushSecret, registryDomain(cfg.CIConfig.PromotionConfiguration), api.DefaultMirrorFunc, api.DefaultTargetNameFunc, cfg.NodeArchitectures, cliVersion))
 		}
 		// Used primarily (only?) by the ci-chat-bot
 		if cfg.CIConfig.PromotionConfiguration.RegistryOverride != "" {
 			logrus.Info("No images to promote to quay.io if the registry is overridden")
 		} else {
-			promotionSteps = append(promotionSteps, releasesteps.PromotionStep(api.PromotionQuayStepName, cfg.CIConfig, requiredNames, cfg.SkippedImages, cfg.JobSpec, cfg.podClient, cfg.PushSecret, api.QuayOpenShiftCIRepo, api.QuayCombinedMirrorFunc, api.QuayTargetNameFunc, cfg.NodeArchitectures))
+			promotionSteps = append(promotionSteps, releasesteps.PromotionStep(api.PromotionQuayStepName, cfg.CIConfig, requiredNames, cfg.SkippedImages, cfg.JobSpec, cfg.podClient, cfg.PushSecret, api.QuayOpenShiftCIRepo, api.QuayCombinedMirrorFunc, api.QuayTargetNameFunc, cfg.NodeArchitectures, cliVersion))
 		}
 	}
 
@@ -1161,6 +1152,23 @@ func buildRootImageStreamFromRepository(path string, readFile readFile) (*api.Im
 	}
 
 	return &config.BuildRootImage, validateCIOperatorInrepoConfig(&config)
+}
+
+func resolveReleaseCLIOverride(release api.UnresolvedRelease) (*coreapi.ObjectReference, string, error) {
+	var version string
+	var architecture api.ReleaseArchitecture
+	switch {
+	case release.Integration != nil:
+		version, architecture = release.Integration.Name, api.ReleaseArchitectureAMD64
+	case release.Candidate != nil:
+		version, architecture = release.Candidate.Version, release.Candidate.Architecture
+	case release.Release != nil:
+		version, architecture = release.Release.Version, release.Release.Architecture
+	case release.Prerelease != nil:
+		version, architecture = release.Prerelease.VersionBounds.Lower, release.Prerelease.Architecture
+	}
+	override, err := resolveCLIOverrideImage(architecture, version)
+	return override, version, err
 }
 
 func resolveCLIOverrideImage(architecture api.ReleaseArchitecture, version string) (*coreapi.ObjectReference, error) {

--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -47,6 +47,7 @@ type promotionStep struct {
 	mirrorFunc        func(source, target string, tag api.ImageStreamTagReference, date string, imageMirror map[string]string)
 	targetNameFunc    func(string, api.PromotionTarget) string
 	nodeArchitectures []string
+	cliVersion        string
 }
 
 func (s *promotionStep) Inputs() (api.InputDefinition, error) {
@@ -98,7 +99,7 @@ func (s *promotionStep) run(ctx context.Context) error {
 	}
 
 	timeStr := time.Now().Format("20060102150405")
-	imageMirrorTarget, namespaces := getImageMirrorTarget(tags, pipeline, s.registry, timeStr, s.mirrorFunc, s.targetNameFunc)
+	imageMirrorTarget, namespaces := s.getImageMirrorTarget(tags, pipeline, timeStr)
 	if len(imageMirrorTarget) == 0 {
 		logger.Info("Nothing to promote, skipping...")
 		return nil
@@ -119,7 +120,7 @@ func (s *promotionStep) run(ctx context.Context) error {
 		return s.runQuayPromotion(ctx, imageMirrorTarget, timeStr, cliImage)
 	}
 
-	if _, err := steps.RunPod(ctx, s.client, getPromotionPod(imageMirrorTarget, timeStr, s.jobSpec.Namespace(), s.name, cliImage, s.nodeArchitectures), false); err != nil {
+	if _, err := steps.RunPod(ctx, s.client, s.getPromotionPod(imageMirrorTarget, timeStr, cliImage), false); err != nil {
 		return fmt.Errorf("unable to run promotion pod: %w", err)
 	}
 	return nil
@@ -169,7 +170,7 @@ func (s *promotionStep) ensureNamespaces(ctx context.Context, namespaces sets.Se
 	return nil
 }
 
-func getImageMirrorTarget(tags map[string][]api.ImageStreamTagReference, pipeline *imagev1.ImageStream, registry string, time string, mirrorFunc func(source, target string, tag api.ImageStreamTagReference, time string, imageMirror map[string]string), targetNameFunc func(string, api.PromotionTarget) string) (map[string]string, sets.Set[string]) {
+func (s *promotionStep) getImageMirrorTarget(tags map[string][]api.ImageStreamTagReference, pipeline *imagev1.ImageStream, time string) (map[string]string, sets.Set[string]) {
 	if pipeline == nil {
 		return nil, nil
 	}
@@ -184,27 +185,27 @@ func getImageMirrorTarget(tags map[string][]api.ImageStreamTagReference, pipelin
 		dockerImageReference = getPublicImageReference(dockerImageReference, pipeline.Status.PublicDockerImageRepository)
 		for _, dst := range dsts {
 			var target string
-			if targetNameFunc != nil {
+			if s.targetNameFunc != nil {
 				// Use targetNameFunc to generate template and substitute ${component} with actual component name
 				promotionTarget := api.PromotionTarget{
 					Namespace: dst.Namespace,
 					Name:      dst.Name,
 					Tag:       dst.Tag,
 				}
-				template := targetNameFunc(registry, promotionTarget)
-				target = strings.Replace(template, api.ComponentFormatReplacement, dst.Tag, -1)
+				template := s.targetNameFunc(s.registry, promotionTarget)
+				target = strings.ReplaceAll(template, api.ComponentFormatReplacement, dst.Tag)
 			} else {
 				// Fallback to direct target construction for backwards compatibility
-				target = fmt.Sprintf("%s/%s", registry, dst.ISTagName())
+				target = fmt.Sprintf("%s/%s", s.registry, dst.ISTagName())
 			}
-			mirrorFunc(dockerImageReference, target, dst, time, imageMirror)
+			s.mirrorFunc(dockerImageReference, target, dst, time, imageMirror)
 			namespaces.Insert(dst.Namespace)
 		}
 	}
 	if len(imageMirror) == 0 {
 		return nil, nil
 	}
-	if registry == api.QuayOpenShiftCIRepo {
+	if s.registry == api.QuayOpenShiftCIRepo {
 		namespaces = nil
 	}
 	return imageMirror, namespaces
@@ -287,18 +288,32 @@ func promotionCLIImageFromRegistryWithResolver(stableVersionResolver func(*http.
 	return image, nil
 }
 
+func (s *promotionStep) ocTagCommand(loglevel int, extra ...string) string {
+	args := []string{
+		"oc", "tag",
+		"--source=docker",
+		fmt.Sprintf("--loglevel=%d", loglevel),
+		"--reference-policy='source'",
+	}
+	if v, err := api.ParseVersion(s.cliVersion); err != nil || v.Major != 4 || v.Minor >= 13 {
+		args = append(args, "--import-mode='PreserveOriginal'")
+	}
+	args = append(args, extra...)
+	return strings.Join(args, " ")
+}
+
 func getMirrorCommand(registryConfig string, images []string, loglevel int) string {
 	return fmt.Sprintf("oc image mirror --loglevel=%d --keep-manifest-list --registry-config=%s --max-per-registry=10 %s",
 		loglevel, registryConfig, strings.Join(images, " "))
 }
 
-func getTagLoopCommand(tagSpecs []string, loglevel int) string {
+func (s *promotionStep) getTagLoopCommand(tagSpecs []string, loglevel int) string {
 	return fmt.Sprintf(`
 while read tag; do
-oc tag --source=docker --loglevel=%d --reference-policy='source' --import-mode='PreserveOriginal' --reference $tag || break
+%s || break
 done <<'EOF'
 %s
-EOF`, loglevel, strings.Join(tagSpecs, "\n"))
+EOF`, s.ocTagCommand(loglevel, "--reference", "$tag"), strings.Join(tagSpecs, "\n"))
 }
 
 // quayProxyTagFromISKey derives the quay-proxy floating tag from an IS tag key.
@@ -337,8 +352,8 @@ func quayProxyTagFromISKey(isTagKey string) (string, bool) {
 
 // promotionCLIImageInfoFilterOS returns the --filter-by-os value matching the promotion pod's
 // node architecture (amd64 vs arm64-only) so oc image info resolves one digest for manifest lists.
-func promotionCLIImageInfoFilterOS(nodeArchitectures []string) string {
-	archs := sets.New[string](nodeArchitectures...)
+func (s *promotionStep) promotionCLIImageInfoFilterOS() string {
+	archs := sets.New(s.nodeArchitectures...)
 	if !archs.Has("amd64") && archs.Has("arm64") {
 		return "linux/arm64"
 	}
@@ -404,7 +419,7 @@ func (s *promotionStep) runQuayPromotion(ctx context.Context, imageMirrorTarget 
 			Namespace: s.jobSpec.Namespace(),
 		},
 		Data: map[string]string{
-			quayPromotionScriptKey: getQuayPromotionShell(imageMirrorTarget, timeStr, s.nodeArchitectures),
+			quayPromotionScriptKey: s.getQuayPromotionShell(imageMirrorTarget, timeStr),
 		},
 	}
 	if err := s.client.Create(ctx, configMap); err != nil {
@@ -418,7 +433,7 @@ func (s *promotionStep) runQuayPromotion(ctx context.Context, imageMirrorTarget 
 		}
 	}()
 
-	pod := newPromotionPod(s.jobSpec.Namespace(), s.name, s.name, cliImage, s.nodeArchitectures,
+	pod := s.newPromotionPod(s.name, cliImage,
 		[]string{"/bin/sh", quayPromotionScriptMountPath + "/" + quayPromotionScriptKey}, nil, configMap.Name)
 	if _, err := steps.RunPod(ctx, s.client, pod, false); err != nil {
 		return fmt.Errorf("unable to run promotion-quay pod: %w", err)
@@ -426,7 +441,7 @@ func (s *promotionStep) runQuayPromotion(ctx context.Context, imageMirrorTarget 
 	return nil
 }
 
-func getQuayPromotionShell(imageMirrorTarget map[string]string, timeStr string, nodeArchitectures []string) string {
+func (s *promotionStep) getQuayPromotionShell(imageMirrorTarget map[string]string, timeStr string) string {
 	var incomingImages, floatTags []string
 	pruneTagForFloat := map[string]string{}
 	var tags []string
@@ -455,25 +470,24 @@ func getQuayPromotionShell(imageMirrorTarget map[string]string, timeStr string, 
 	}
 
 	registryConfig := promotionRegistryConfigPath()
-	filterOS := promotionCLIImageInfoFilterOS(nodeArchitectures)
 	script := []string{mirrorShellFunction}
 	if len(incomingImages) > 0 {
 		script = append(script, getMirrorRetryShell(registryConfig, incomingImages))
 	}
 	sort.Strings(floatTags)
 	for _, floatTag := range floatTags {
-		script = append(script, getStagedQuayFloatPromotionShell(registryConfig, floatTag, pruneTagForFloat[floatTag], filterOS))
+		script = append(script, s.getStagedQuayFloatPromotionShell(registryConfig, floatTag, pruneTagForFloat[floatTag]))
 	}
 	for _, pair := range resolveAndTagPairs {
-		script = append(script, getResolveAndTagRetryShell(registryConfig, pair[0], pair[1], 2, filterOS))
+		script = append(script, s.getResolveAndTagRetryShell(registryConfig, pair[0], pair[1], 2))
 	}
 	if len(tags) > 0 {
-		script = append(script, tagRetryShell(2, `"Tag attempt $r"`, getTagLoopCommand(tags, 2), ""))
+		script = append(script, tagRetryShell(2, `"Tag attempt $r"`, s.getTagLoopCommand(tags, 2), ""))
 	}
 	return strings.Join(script, "\n")
 }
 
-func getResolveAndTagRetryShell(registryConfig, quayProxyTag, isTag string, loglevel int, filterByOS string) string {
+func (s *promotionStep) getResolveAndTagRetryShell(registryConfig, quayProxyTag, isTag string, loglevel int) string {
 	colon := strings.LastIndex(quayProxyTag, ":")
 	if colon == -1 {
 		return fmt.Sprintf("echo promotion-quay: malformed quay proxy tag %q >&2\nexit 1", quayProxyTag)
@@ -489,7 +503,7 @@ func getResolveAndTagRetryShell(registryConfig, quayProxyTag, isTag string, logl
   if [ -z "${_digest}" ]; then
     _digest=$(echo "${_info}" | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
   fi
-  if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=%d --reference-policy='source' --import-mode='PreserveOriginal' --reference %s@${_digest} %s; then
+  if [ -n "${_digest}" ] && %s; then
     break
   fi
   echo "promotion: digest-tag failed for %s attempt ${r}/%d (QCI digest may have moved after mirror)" >&2
@@ -500,15 +514,16 @@ func getResolveAndTagRetryShell(registryConfig, quayProxyTag, isTag string, logl
   backoff=$(($RANDOM %% %d))s
   sleep "${backoff}"
 done
-`, n, registryConfig, filterByOS, quayIOTag, loglevel, repo, isTag,
+`, n, registryConfig, s.promotionCLIImageInfoFilterOS(), quayIOTag,
+		s.ocTagCommand(loglevel, "--reference", repo+"@${_digest}", isTag),
 		isTag, n, n, isTag, n, 120)
 }
 
-func getStagedQuayFloatPromotionShell(registryConfig, floatTag, pruneTag, filterByOS string) string {
+func (s *promotionStep) getStagedQuayFloatPromotionShell(registryConfig, floatTag, pruneTag string) string {
 	// Must use --filter-by-os: oc image info exits non-zero on multi-arch floats without it,
 	// which skipped _prune_ backups and let Quay GC prior digests under active payload jobs.
 	checkOld := fmt.Sprintf(`_OLD_EXISTS=false
-if oc image info --registry-config=%s --filter-by-os=%s %s >/dev/null 2>&1; then _OLD_EXISTS=true; fi`, registryConfig, filterByOS, floatTag)
+if oc image info --registry-config=%s --filter-by-os=%s %s >/dev/null 2>&1; then _OLD_EXISTS=true; fi`, registryConfig, s.promotionCLIImageInfoFilterOS(), floatTag)
 
 	var backupPairs []string
 	if pruneTag != "" {
@@ -544,7 +559,7 @@ func promotionMirrorPair(src, dst string) string {
 	return fmt.Sprintf("%s=%s", src, dst)
 }
 
-func getPromotionPod(imageMirrorTarget map[string]string, timeStr string, namespace string, name string, cliImage string, nodeArchitectures []string) *coreapi.Pod {
+func (s *promotionStep) getPromotionPod(imageMirrorTarget map[string]string, timeStr, cliImage string) *coreapi.Pod {
 	var images, pruneImages, tags []string
 
 	for _, k := range slices.Sorted(maps.Keys(imageMirrorTarget)) {
@@ -568,7 +583,7 @@ func getPromotionPod(imageMirrorTarget map[string]string, timeStr string, namesp
 		commands = append(commands, getMirrorRetryShell(registryConfig, images))
 	}
 	if len(tags) > 0 {
-		commands = append(commands, tagRetryShell(5, "Tag attempt $r", getTagLoopCommand(tags, 2), tagRetryBackoff))
+		commands = append(commands, tagRetryShell(5, "Tag attempt $r", s.getTagLoopCommand(tags, 2), tagRetryBackoff))
 	}
 
 	script := []string{mirrorShellFunction}
@@ -577,10 +592,10 @@ func getPromotionPod(imageMirrorTarget map[string]string, timeStr string, namesp
 		script = append(script, fmt.Sprintf("%s || true", getMirrorCommand(registryConfig, pruneImages, 2)))
 	}
 	script = append(script, commands...)
-	return newPromotionPod(namespace, name, "promotion", cliImage, nodeArchitectures, []string{"/bin/sh", "-c"}, []string{strings.Join(script, "\n")}, "")
+	return s.newPromotionPod("promotion", cliImage, []string{"/bin/sh", "-c"}, []string{strings.Join(script, "\n")}, "")
 }
 
-func newPromotionPod(namespace, name, containerName, cliImage string, nodeArchitectures []string, command, args []string, configMapName string) *coreapi.Pod {
+func (s *promotionStep) newPromotionPod(containerName, cliImage string, command, args []string, configMapName string) *coreapi.Pod {
 	volumes := promotionPodVolumes()
 	mounts := promotionPodVolumeMounts()
 	if configMapName != "" {
@@ -614,12 +629,12 @@ func newPromotionPod(namespace, name, containerName, cliImage string, nodeArchit
 
 	return &coreapi.Pod{
 		ObjectMeta: meta.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name:      s.name,
+			Namespace: s.jobSpec.Namespace(),
 			Labels:    map[string]string{steps.AnnotationSaveContainerLogs: "true"},
 		},
 		Spec: coreapi.PodSpec{
-			NodeSelector:  promotionPodNodeSelector(cliImage, nodeArchitectures),
+			NodeSelector:  s.promotionPodNodeSelector(cliImage),
 			RestartPolicy: coreapi.RestartPolicyNever,
 			Containers:    []coreapi.Container{container},
 			Volumes:       volumes,
@@ -627,9 +642,9 @@ func newPromotionPod(namespace, name, containerName, cliImage string, nodeArchit
 	}
 }
 
-func promotionPodNodeSelector(cliImage string, nodeArchitectures []string) map[string]string {
+func (s *promotionStep) promotionPodNodeSelector(cliImage string) map[string]string {
 	nodeSelector := map[string]string{"kubernetes.io/arch": "amd64"}
-	archs := sets.New[string](nodeArchitectures...)
+	archs := sets.New[string](s.nodeArchitectures...)
 	if cliImage == "stable:cli" && !archs.Has("amd64") && archs.Has("arm64") {
 		nodeSelector = map[string]string{"kubernetes.io/arch": "arm64"}
 	}
@@ -871,6 +886,7 @@ func PromotionStep(
 	mirrorFunc func(source, target string, tag api.ImageStreamTagReference, date string, imageMirror map[string]string),
 	targetNameFunc func(string, api.PromotionTarget) string,
 	nodeArchitectures []string,
+	cliVersion string,
 ) api.Step {
 	return &promotionStep{
 		name:              name,
@@ -884,5 +900,6 @@ func PromotionStep(
 		mirrorFunc:        mirrorFunc,
 		targetNameFunc:    targetNameFunc,
 		nodeArchitectures: nodeArchitectures,
+		cliVersion:        cliVersion,
 	}
 }

--- a/pkg/steps/release/promote_test.go
+++ b/pkg/steps/release/promote_test.go
@@ -874,7 +874,14 @@ func TestGetPromotionPod(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			testhelper.CompareWithFixture(t, getPromotionPod(testCase.imageMirror, "20240603235401", testCase.namespace, testCase.stepName, "stable:cli", testCase.nodeArchitectures))
+			jobSpec := &api.JobSpec{}
+			jobSpec.SetNamespace(testCase.namespace)
+			s := &promotionStep{
+				name:              testCase.stepName,
+				jobSpec:           jobSpec,
+				nodeArchitectures: testCase.nodeArchitectures,
+			}
+			testhelper.CompareWithFixture(t, s.getPromotionPod(testCase.imageMirror, "20240603235401", "stable:cli"))
 		})
 	}
 }
@@ -1132,7 +1139,12 @@ func TestGetImageMirror(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			if actual, _ := getImageMirrorTarget(testCase.tags, testCase.pipeline, testCase.registry, "20240603235401", testCase.mirrorFunc, testCase.targetNameFunc); !reflect.DeepEqual(actual, testCase.expected) {
+			s := &promotionStep{
+				registry:       testCase.registry,
+				mirrorFunc:     testCase.mirrorFunc,
+				targetNameFunc: testCase.targetNameFunc,
+			}
+			if actual, _ := s.getImageMirrorTarget(testCase.tags, testCase.pipeline, "20240603235401"); !reflect.DeepEqual(actual, testCase.expected) {
 				t.Errorf("%s: got incorrect ImageMirror mapping: %v", testCase.name, diff.ObjectDiff(actual, testCase.expected))
 			}
 		})
@@ -1173,12 +1185,44 @@ func TestGetMirrorRetryShell(t *testing.T) {
 }
 
 func TestGetTagLoopCommandQuotesHeredoc(t *testing.T) {
-	got := getTagLoopCommand([]string{"quay-proxy.ci.openshift.org/openshift/ci@sha256:bbb ci/ci-quay:${component}"}, 2)
+	s := &promotionStep{}
+	got := s.getTagLoopCommand([]string{"quay-proxy.ci.openshift.org/openshift/ci@sha256:bbb ci/ci-quay:${component}"}, 2)
 	if !strings.Contains(got, "<<'EOF'") {
 		t.Fatalf("expected quoted heredoc delimiter, got:\n%s", got)
 	}
 	if !strings.Contains(got, "ci/ci-quay:${component}") {
 		t.Fatalf("expected literal ${component} in tag loop, got:\n%s", got)
+	}
+}
+
+func TestOcTagCommand(t *testing.T) {
+	const importMode = "--import-mode='PreserveOriginal'"
+	testCases := []struct {
+		name           string
+		cliVersion     string
+		wantImportMode bool
+	}{
+		{name: "empty version keeps import-mode", cliVersion: "", wantImportMode: true},
+		{name: "4.11 omits import-mode", cliVersion: "4.11", wantImportMode: false},
+		{name: "4.12 omits import-mode", cliVersion: "4.12", wantImportMode: false},
+		{name: "4.13 keeps import-mode", cliVersion: "4.13", wantImportMode: true},
+		{name: "4.21 keeps import-mode", cliVersion: "4.21", wantImportMode: true},
+		{name: "invalid version keeps import-mode", cliVersion: "not-a-version", wantImportMode: true},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := (&promotionStep{cliVersion: tc.cliVersion}).ocTagCommand(2, "--reference", "$tag")
+			has := strings.Contains(got, importMode)
+			if has != tc.wantImportMode {
+				t.Fatalf("cliVersion=%q: import-mode present=%v, want %v\ngot: %s", tc.cliVersion, has, tc.wantImportMode, got)
+			}
+			if !strings.HasPrefix(got, "oc tag --source=docker --loglevel=2 --reference-policy='source'") {
+				t.Fatalf("unexpected command prefix: %s", got)
+			}
+			if !strings.HasSuffix(got, "--reference $tag") {
+				t.Fatalf("unexpected command suffix: %s", got)
+			}
+		})
 	}
 }
 
@@ -1196,6 +1240,7 @@ func TestGetQuayPromotionShell(t *testing.T) {
 		name              string
 		imageMirror       map[string]string
 		nodeArchitectures []string
+		cliVersion        string
 	}{
 		{
 			name:              "promotion-quay",
@@ -1227,6 +1272,7 @@ func TestGetQuayPromotionShell(t *testing.T) {
 		{
 			name:              "promotion-quay-4.12",
 			nodeArchitectures: []string{"amd64"},
+			cliVersion:        "4.12",
 			imageMirror: map[string]string{
 				"quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes":      "quay.io/openshift/ci:ocp_4.12_ovn-kubernetes",
 				"quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes-base": "quay.io/openshift/ci:ocp_4.12_ovn-kubernetes-base",
@@ -1250,7 +1296,11 @@ func TestGetQuayPromotionShell(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			testhelper.CompareWithFixture(t, quayPromotionScriptConfigMap(getQuayPromotionShell(testCase.imageMirror, timeStr, testCase.nodeArchitectures)))
+			s := &promotionStep{
+				nodeArchitectures: testCase.nodeArchitectures,
+				cliVersion:        testCase.cliVersion,
+			}
+			testhelper.CompareWithFixture(t, quayPromotionScriptConfigMap(s.getQuayPromotionShell(testCase.imageMirror, timeStr)))
 		})
 	}
 }
@@ -1259,7 +1309,8 @@ func TestGetResolveAndTagRetryShell(t *testing.T) {
 	regcfg := "/etc/push-secret/.dockerconfigjson"
 	proxyTag := "quay-proxy.ci.openshift.org/openshift/ci:ocp_4.21_ovn-kubernetes"
 	isTag := "ocp/4.21:ovn-kubernetes"
-	got := getResolveAndTagRetryShell(regcfg, proxyTag, isTag, 2, "linux/amd64")
+	s := &promotionStep{nodeArchitectures: []string{"amd64"}}
+	got := s.getResolveAndTagRetryShell(regcfg, proxyTag, isTag, 2)
 
 	quayIOTag := "quay.io/openshift/ci:ocp_4.21_ovn-kubernetes"
 	for _, sub := range []string{
@@ -1280,20 +1331,34 @@ func TestGetResolveAndTagRetryShell(t *testing.T) {
 		}
 	}
 
-	got = getResolveAndTagRetryShell(regcfg, "quay-proxy.ci.openshift.org/openshift/ci", isTag, 2, "linux/amd64")
+	got = s.getResolveAndTagRetryShell(regcfg, "quay-proxy.ci.openshift.org/openshift/ci", isTag, 2)
 	if !strings.Contains(got, "malformed quay proxy tag") || !strings.Contains(got, "exit 1") {
 		t.Fatalf("expected malformed-tag shell guard, got:\n%s", got)
 	}
 }
 
 func TestGetQuayPromotionPod(t *testing.T) {
-	pod := newPromotionPod("ci-op-foo", api.PromotionQuayStepName, api.PromotionQuayStepName, "stable:cli", []string{"amd64"},
+	jobSpec := &api.JobSpec{}
+	jobSpec.SetNamespace("ci-op-foo")
+	s := &promotionStep{
+		name:              api.PromotionQuayStepName,
+		jobSpec:           jobSpec,
+		nodeArchitectures: []string{"amd64"},
+	}
+	pod := s.newPromotionPod(api.PromotionQuayStepName, "stable:cli",
 		[]string{"/bin/sh", quayPromotionScriptMountPath + "/" + quayPromotionScriptKey}, nil, "promotion-quay-123")
 	testhelper.CompareWithFixture(t, pod)
 }
 
 func TestGetQuayPromotionPodArm64Only(t *testing.T) {
-	pod := newPromotionPod("ci-op-foo", api.PromotionQuayStepName, api.PromotionQuayStepName, "stable:cli", []string{"arm64"},
+	jobSpec := &api.JobSpec{}
+	jobSpec.SetNamespace("ci-op-foo")
+	s := &promotionStep{
+		name:              api.PromotionQuayStepName,
+		jobSpec:           jobSpec,
+		nodeArchitectures: []string{"arm64"},
+	}
+	pod := s.newPromotionPod(api.PromotionQuayStepName, "stable:cli",
 		[]string{"/bin/sh", quayPromotionScriptMountPath + "/" + quayPromotionScriptKey}, nil, "promotion-quay-123")
 	if got := pod.Spec.NodeSelector["kubernetes.io/arch"]; got != "arm64" {
 		t.Fatalf("expected arm64 node selector, got %q", got)
@@ -1391,7 +1456,7 @@ func TestPromotionCLIImageInfoFilterOS(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := promotionCLIImageInfoFilterOS(tt.nodeArchitectures); got != tt.want {
+			if got := (&promotionStep{nodeArchitectures: tt.nodeArchitectures}).promotionCLIImageInfoFilterOS(); got != tt.want {
 				t.Fatalf("got %q, want %q", got, tt.want)
 			}
 		})
@@ -1426,13 +1491,17 @@ func TestPromotionCLIImageFromRegistry(t *testing.T) {
 func TestGetPromotionPodFallbackImageDoesNotPinArm64Node(t *testing.T) {
 	t.Parallel()
 
-	pod := getPromotionPod(
+	jobSpec := &api.JobSpec{}
+	jobSpec.SetNamespace("ci-op-test")
+	s := &promotionStep{
+		name:              "promotion",
+		jobSpec:           jobSpec,
+		nodeArchitectures: []string{"arm64"},
+	}
+	pod := s.getPromotionPod(
 		map[string]string{"registry.ci.openshift.org/ci/bin:latest": "docker-registry.default.svc:5000/ci-op-test/pipeline@sha256:bbb"},
 		"20240603235401",
-		"ci-op-test",
-		"promotion",
 		api.QCIAPPCIDomain+"/openshift/ci:ocp_4.22_cli",
-		[]string{"arm64"},
 	)
 	if got := pod.Spec.NodeSelector["kubernetes.io/arch"]; got != "amd64" {
 		t.Fatalf("expected fallback cli image to run on amd64 node, got selector %v", pod.Spec.NodeSelector)

--- a/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay_4.12.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetQuayPromotionShell_promotion_quay_4.12.yaml
@@ -40,7 +40,7 @@ data:
       if [ -z "${_digest}" ]; then
         _digest=$(echo "${_info}" | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
       fi
-      if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.12:ovn-kubernetes; then
+      if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=2 --reference-policy='source' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.12:ovn-kubernetes; then
         break
       fi
       echo "promotion: digest-tag failed for ocp/4.12:ovn-kubernetes attempt ${r}/5 (QCI digest may have moved after mirror)" >&2
@@ -58,7 +58,7 @@ data:
       if [ -z "${_digest}" ]; then
         _digest=$(echo "${_info}" | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
       fi
-      if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.12:ovn-kubernetes-base; then
+      if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=2 --reference-policy='source' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.12:ovn-kubernetes-base; then
         break
       fi
       echo "promotion: digest-tag failed for ocp/4.12:ovn-kubernetes-base attempt ${r}/5 (QCI digest may have moved after mirror)" >&2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates release image promotion to omit `--import-mode='PreserveOriginal'` for OpenShift CLI versions older than 4.13, while retaining it for newer versions.

The release configuration resolver now determines the CLI version once and passes it through standard and Quay promotion steps. Promotion command generation uses that version consistently, with updated tests and 4.12 fixtures covering the legacy behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->