### PR TITLE
Added hosted-mgmt2 as an exception exactly as hosted-mgmt

### DIFF
--- a/cmd/cluster-display/main.go
+++ b/cmd/cluster-display/main.go
@@ -138,7 +138,7 @@ func (g *clusterInfoGetter) GetClusterDetails(ctx context.Context, cluster strin
 		return nil, fmt.Errorf("failed to resolve the console host for cluster %s: %w", cluster, err)
 	}
 	registryHost := "unset"
-	if cluster != string(api.ClusterHive) {
+	if cluster != string(api.ClusterHostedMgmt1) && cluster != string(api.ClusterHostedMgmt2) {
 		host, err := api.ResolveImageRegistryHost(ctx, client)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve the image registry host for cluster %s: %w", cluster, err)
@@ -172,23 +172,23 @@ func (g *clusterInfoGetter) GetClusterDetails(ctx context.Context, cluster strin
 		"product":      product,
 		"cloud":        cloud,
 	}
-	if cluster == string(api.ClusterHive) {
+	if cluster == string(api.ClusterHostedMgmt1) || cluster == string(api.ClusterHostedMgmt2) {
 		hypershiftCM := &corev1.ConfigMap{}
 		if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: "hypershift", Name: "supported-versions"}, hypershiftCM); err != nil {
-			return nil, fmt.Errorf("failed to get ConfigMap supported-versions in hypershift for cluster hive: %w", err)
+			return nil, fmt.Errorf("failed to get ConfigMap supported-versions in hypershift namespace for cluster %s: %w", cluster, err)
 		}
 		versions, ok := hypershiftCM.Data["supported-versions"]
 		if !ok {
-			return nil, fmt.Errorf("failed to get supported-versions from ConfigMap supported-versions in hypershift for cluster hive: %w", err)
+			return nil, fmt.Errorf("failed to get ConfigMap supported-versions in hypershift namespace for cluster %s: %w", cluster, err)
 		}
 
 		sVersions := &hypershiftSupportedVersions{}
 		if err := json.Unmarshal([]byte(versions), sVersions); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal hive's supported versions: %w", err)
+			return nil, fmt.Errorf("failed to unmarshal hypershift's supported versions: %w", err)
 		}
 		d, err := json.Marshal(sVersions.Versions)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal hive's supported versions: %w", err)
+			return nil, fmt.Errorf("failed to marshal hypershift's supported versions: %w", err)
 		}
 		ret["hypershiftSupportedVersions"] = string(d)
 	}
@@ -228,7 +228,7 @@ func (c *memoryCache) GetClusterPoolPage(ctx context.Context, client ctrlruntime
 	return &Page{Data: c.ClusterPoolData}, nil
 }
 
-func (c *memoryCache) GetClusterPage(ctx context.Context, clients map[string]ctrlruntimeclient.Client, skipHive bool, getter ClusterInfoGetter) *Page {
+func (c *memoryCache) GetClusterPage(ctx context.Context, clients map[string]ctrlruntimeclient.Client, skipHostedMgmt bool, getter ClusterInfoGetter) *Page {
 	c.clusterDataMutex.Lock()
 	defer c.clusterDataMutex.Unlock()
 	if c.clusterData == nil || time.Now().After(c.clusterDataLastUpdatedAt.Add(c.CacheDuration)) {
@@ -236,21 +236,21 @@ func (c *memoryCache) GetClusterPage(ctx context.Context, clients map[string]ctr
 		c.clusterDataLastUpdatedAt = time.Now()
 		c.clusterData = data
 	}
-	if skipHive {
-		var skipHiveData []map[string]string
+	if skipHostedMgmt {
+		var skipHostedMgmtData []map[string]string
 		for _, d := range c.clusterData {
-			var hive bool
+			var hostedMgmt bool
 			for k, v := range d {
-				if k == "cluster" && v == string(api.HiveCluster) {
-					hive = true
+				if k == "cluster" && (v == string(api.ClusterHostedMgmt1) || v == string(api.ClusterHostedMgmt2)) {
+					hostedMgmt = true
 					break
 				}
 			}
-			if !hive {
-				skipHiveData = append(skipHiveData, d)
+			if !hostedMgmt {
+				skipHostedMgmtData = append(skipHostedMgmtData, d)
 			}
 		}
-		return &Page{Data: skipHiveData}
+		return &Page{Data: skipHostedMgmtData}
 	}
 	return &Page{Data: c.clusterData}
 }
@@ -312,14 +312,14 @@ func getRouter(ctx context.Context, hiveClient ctrlruntimeclient.Client, clients
 		case "clusterpools":
 			page, err = cache.GetClusterPoolPage(ctx, hiveClient)
 		case "clusters":
-			skipHive := r.URL.Query().Get("skipHive") == "true"
+			skipHostedMgmt := r.URL.Query().Get("skipHostedMgmt") == "true"
 			prowDisabledClusters, err := prowDisabledClustersGetter(ctx)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
 			disabledClusters := sets.New(prowDisabledClusters...)
-			page = cache.GetClusterPage(ctx, allClients, skipHive, &clusterInfoGetter{})
+			page = cache.GetClusterPage(ctx, allClients, skipHostedMgmt, &clusterInfoGetter{})
 			var enabled []map[string]string
 			for _, d := range page.Data {
 				c, ok := d["cluster"]

--- a/pkg/api/constant.go
+++ b/pkg/api/constant.go
@@ -46,7 +46,7 @@ const (
 	NoBuildsValue = "true"
 
 	// HiveCluster is the cluster where Hive is deployed
-	HiveCluster = ClusterHive
+	HiveCluster = ClusterHostedMgmt1
 
 	// HiveAdminKubeconfigSecret is the name of the secret in ci-op-<hash> namespace that stores the Admin's kubeconfig for the ephemeral cluster provisioned by Hive.
 	HiveAdminKubeconfigSecret = "hive-admin-kubeconfig"

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -782,14 +782,15 @@ func (config PipelineImageCacheStepConfiguration) TargetName() string {
 type Cluster string
 
 const (
-	ClusterAPPCI     Cluster = "app.ci"
-	ClusterBuild01   Cluster = "build01"
-	ClusterBuild02   Cluster = "build02"
-	ClusterBuild03   Cluster = "build03"
-	ClusterBuild10   Cluster = "build10"
-	ClusterVSphere02 Cluster = "vsphere02"
-	ClusterARM01     Cluster = "arm01"
-	ClusterHive      Cluster = "hosted-mgmt"
+	ClusterAPPCI       Cluster = "app.ci"
+	ClusterBuild01     Cluster = "build01"
+	ClusterBuild02     Cluster = "build02"
+	ClusterBuild03     Cluster = "build03"
+	ClusterBuild10     Cluster = "build10"
+	ClusterVSphere02   Cluster = "vsphere02"
+	ClusterARM01       Cluster = "arm01"
+	ClusterHostedMgmt1 Cluster = "hosted-mgmt"
+	ClusterHostedMgmt2 Cluster = "hosted-mgmt2"
 )
 
 // TestStepConfiguration describes a step that runs a


### PR DESCRIPTION
Since `hosted-mgmt2` is almost the same as `hosted-mgmt` we need to skip the registry verification and do an extra logic for hypershift supported Openshift versions.

Also, renamed `ClusterHive` to `ClusterHostedMgmt1`, it makes more sense.

This also implies a modification on https://github.com/openshift/ci-docs/pull/610

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updates the `cluster-display` service’s cluster handling to align HyperShift “special-case” behavior for HostedMgmt clusters. It now treats `hosted-mgmt` (renamed internally to `ClusterHostedMgmt1`) and the new `hosted-mgmt2` (`ClusterHostedMgmt2`) as the special cases instead of `hosted-mgmt`’s prior Hive alias (`ClusterHive`). As a result, the service skips registry verification/resolution for these HostedMgmt clusters and populates HyperShift-supported OpenShift versions by reading/parsing the `hypershift/supported-versions` ConfigMap for HostedMgmt rather than for Hive. The clusters list endpoint is also updated so callers can skip these HostedMgmt clusters via a new `skipHostedMgmt` query flag (replacing `skipHive`), with the backing memory cache filtering out `hosted-mgmt`/`hosted-mgmt2` when requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->