### PR TITLE
feat: add QCI to app.ci emergency mirror list

### DIFF
--- a/cmd/ci-images-mirror/README.md
+++ b/cmd/ci-images-mirror/README.md
@@ -17,6 +17,7 @@ For example, `registry.ci.openshift.org/namespace/name:tag` is mirrored to
 This tool is extended with the following features (and thus is no longer temporary):
 - mirror images from external registries to QCI: See `.supplementalCIImages` of [the configuration file](https://github.com/openshift/release/blob/main/core-services/image-mirroring/_config.yaml).
 - mirror ART images from app.ci to QCI: See `.artImages` of [the configuration file](https://github.com/openshift/release/blob/main/core-services/image-mirroring/_config.yaml).
+- backfill images from QCI to app.ci (emergency): See `.qciToAppCIImages` of the same config file. Key is `namespace/name:tag` on app.ci; optional `image` must be under `quay.io/openshift/ci` or `quay-proxy.ci.openshift.org/openshift/ci` (defaults to `quay-proxy.ci.openshift.org/openshift/ci:<namespace>_<name>_<tag>`). Those targets are excluded from the normal app.ci→QCI distributor.
 
 ## Run the tool locally
 

--- a/cmd/ci-images-mirror/main.go
+++ b/cmd/ci-images-mirror/main.go
@@ -114,6 +114,20 @@ func (o *options) loadConfig(caller string) error {
 	return nil
 }
 
+// syncQCIIgnoreImageStreamTags keeps ignore in sync with current QCIToAppCIImages keys.
+// tracked holds keys previously added from this config section so removals are deleted from ignore.
+func syncQCIIgnoreImageStreamTags(ignore, tracked sets.Set[string], current map[string]quayiociimagesdistributor.Source) {
+	next := sets.KeySet(current)
+	removed := tracked.Difference(next)
+	ignore.Delete(removed.UnsortedList()...)
+	tracked.Delete(removed.UnsortedList()...)
+	for _, k := range next.Difference(tracked).UnsortedList() {
+		logrus.WithField("target", k).Debug("Ignore target of QCI-to-app.ci backfill on mirroring")
+		ignore.Insert(k)
+		tracked.Insert(k)
+	}
+}
+
 func (o *options) validate() error {
 	var errs []error
 	if o.leaderElectionNamespace == "" && !o.validateConfigOnly {
@@ -299,6 +313,18 @@ func main() {
 		// TODO: multi-arch support
 		FilterByOS: "linux/amd64",
 	}
+
+	// Shared with the distributor; mutated on QCI config reload so adds/removes take effect without restart.
+	ignoreImageStreamTags := sets.New[string](opts.quayIOCIImagesDistributorOptions.ignoreImageStreamTagsRaw.Strings()...)
+	qciIgnoredTags := sets.New[string]()
+	if opts.config != nil {
+		for k := range opts.config.SupplementalCIImages {
+			logrus.WithField("target", k).Debug("Ignore target of supplemental CI images on mirroring")
+			ignoreImageStreamTags.Insert(k)
+		}
+		syncQCIIgnoreImageStreamTags(ignoreImageStreamTags, qciIgnoredTags, opts.config.QCIToAppCIImages)
+	}
+
 	if opts.configFile != "" {
 		supplementalCIImagesService := newSupplementalCIImagesServiceWithMirrorStore(mirrorStore, logrus.WithField("subcomponent", "supplementalCIImagesService"), quayIOImageHelper, ocImageInfoOptions)
 		interrupts.TickLiteral(func() {
@@ -324,6 +350,18 @@ func main() {
 			}
 			if err := artImagesService.Mirror(m); err != nil {
 				logrus.WithError(err).Error("Failed to mirror ART images")
+			}
+		}, time.Hour)
+
+		qciLogger := logrus.WithField("subcomponent", "qciToAppCIImages")
+		interrupts.TickLiteral(func() {
+			if err := opts.loadConfig("qciToAppCIImages"); err != nil {
+				logrus.WithError(err).Error("Failed to reload config")
+				return
+			}
+			syncQCIIgnoreImageStreamTags(ignoreImageStreamTags, qciIgnoredTags, opts.config.QCIToAppCIImages)
+			if err := quayiociimagesdistributor.MirrorQCIToAppCI(mirrorStore, qciLogger, quayIOImageHelper, ocImageInfoOptions, opts.config.QCIToAppCIImages); err != nil {
+				logrus.WithError(err).Error("Failed to mirror QCI images to app.ci")
 			}
 		}, time.Hour)
 	}
@@ -367,13 +405,6 @@ func main() {
 			logrus.WithError(err).Fatal("failed to construct registryAgent")
 		}
 
-		ignoreImageStreamTags := sets.New[string](opts.quayIOCIImagesDistributorOptions.ignoreImageStreamTagsRaw.Strings()...)
-		if opts.config != nil {
-			for k := range opts.config.SupplementalCIImages {
-				logrus.WithField("target", k).Debug("Ignore target of supplemental CI images on mirroring")
-				ignoreImageStreamTags.Insert(k)
-			}
-		}
 		logrus.WithField("tags", ignoreImageStreamTags.UnsortedList()).Infof("%s will ignore mirroring those tags", quayiociimagesdistributor.ControllerName)
 		if err := quayiociimagesdistributor.AddToManager(mgr,
 			ciOPConfigAgent,

--- a/pkg/controller/quay_io_ci_images_distributor/qci_to_appci.go
+++ b/pkg/controller/quay_io_ci_images_distributor/qci_to_appci.go
@@ -1,0 +1,65 @@
+package quay_io_ci_images_distributor
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	"github.com/openshift/ci-tools/pkg/api"
+)
+
+// MirrorQCIToAppCI enqueues syncs for m (key: app.ci ISTag namespace/name:tag; value.image: QCI pullspec).
+// Empty image derives quay-proxy float from the key. Config load already restricts sources to QCI.
+// Per-entry failures are collected so one bad entry does not block the rest.
+func MirrorQCIToAppCI(mirrorStore MirrorStore, logger *logrus.Entry, quayIOImageHelper QuayIOImageHelper, ocImageInfoOptions OCImageInfoOptions, m map[string]Source) error {
+	if len(m) == 0 {
+		return nil
+	}
+	logger.WithField("count", len(m)).Info("Mirroring QCI images to app.ci ...")
+	var errs []error
+	for target, v := range m {
+		source := v.Image
+		if source == "" {
+			ref, err := parseISTagName(target)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("invalid target %s: %w", target, err))
+				continue
+			}
+			source = api.QuayImageReference(ref)
+		}
+		destination := fmt.Sprintf("%s/%s", api.ServiceDomainAPPCIRegistry, target)
+
+		sourceInfo, err := quayIOImageHelper.ImageInfo(source, ocImageInfoOptions)
+		if err != nil {
+			// ImageInfo returns a zero value on error, so Digest is empty; do not enqueue.
+			logger.WithError(err).WithField("source", source).Warning("Failed to get QCI image info, skipping")
+			continue
+		}
+		if sourceInfo.Digest == "" {
+			logger.WithField("source", source).Debug("Source image does not exist, skipping mirror")
+			continue
+		}
+
+		targetInfo, err := quayIOImageHelper.ImageInfo(destination, ocImageInfoOptions)
+		if err != nil {
+			logger.WithError(err).WithField("target", destination).Warning("Failed to get app.ci image info, will attempt mirror")
+		} else if targetInfo.Digest != "" && sourceInfo.Digest == targetInfo.Digest {
+			logger.WithField("source", source).WithField("target", destination).
+				WithField("digest", sourceInfo.Digest).Debug("Image already in sync, skipping")
+			continue
+		}
+		logger.WithField("source", source).WithField("target", destination).
+			WithField("sourceDigest", sourceInfo.Digest).WithField("targetDigest", targetInfo.Digest).
+			Info("Image needs sync")
+		if err := mirrorStore.Put(MirrorTask{
+			Source:      source,
+			Destination: destination,
+			Owner:       "qciToAppCIImages",
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("failed to put mirror task for %s: %w", target, err))
+		}
+	}
+	return utilerrors.NewAggregate(errs)
+}

--- a/pkg/controller/quay_io_ci_images_distributor/qci_to_appci_test.go
+++ b/pkg/controller/quay_io_ci_images_distributor/qci_to_appci_test.go
@@ -1,0 +1,195 @@
+package quay_io_ci_images_distributor
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sirupsen/logrus"
+
+	"github.com/openshift/ci-tools/pkg/api"
+)
+
+func TestLoadConfigQCIToAppCIImages(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    map[string]Source
+		wantErr bool
+	}{
+		{
+			name: "derive QCI float from target key",
+			raw: `qciToAppCIImages:
+  ci/foo:latest: {}
+`,
+			want: map[string]Source{
+				"ci/foo:latest": {Image: api.QuayImageReference(api.ImageStreamTagReference{Namespace: "ci", Name: "foo", Tag: "latest"})},
+			},
+		},
+		{
+			name: "explicit image",
+			raw: `qciToAppCIImages:
+  ci/foo:latest:
+    image: quay-proxy.ci.openshift.org/openshift/ci:ci_foo_custom
+`,
+			want: map[string]Source{
+				"ci/foo:latest": {Image: "quay-proxy.ci.openshift.org/openshift/ci:ci_foo_custom"},
+			},
+		},
+		{
+			name: "rejects non-QCI explicit image",
+			raw: `qciToAppCIImages:
+  ci/foo:latest:
+    image: registry.redhat.io/ubi9/ubi:latest
+`,
+			wantErr: true,
+		},
+		{
+			name: "rejects namespace name tag source fields",
+			raw: `qciToAppCIImages:
+  ci/foo:latest:
+    namespace: ci
+    name: foo
+    tag: latest
+`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := LoadConfig([]byte(tt.raw))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("LoadConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if diff := cmp.Diff(tt.want, got.QCIToAppCIImages); diff != "" {
+				t.Errorf("QCIToAppCIImages mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+type fakeQuayHelper struct {
+	info map[string]ImageInfo
+	errs map[string]error
+}
+
+func (f *fakeQuayHelper) ImageInfo(image string, _ OCImageInfoOptions) (ImageInfo, error) {
+	if err := f.errs[image]; err != nil {
+		return ImageInfo{}, err
+	}
+	return f.info[image], nil
+}
+
+func (f *fakeQuayHelper) ImageMirror(_ []string, _ OCImageMirrorOptions) error {
+	return nil
+}
+
+type putFailStore struct {
+	MirrorStore
+	failFor string
+}
+
+func (s *putFailStore) Put(tasks ...MirrorTask) error {
+	for _, t := range tasks {
+		if t.Destination == s.failFor {
+			return fmt.Errorf("store full")
+		}
+	}
+	return s.MirrorStore.Put(tasks...)
+}
+
+func TestMirrorQCIToAppCI(t *testing.T) {
+	const (
+		src   = "quay-proxy.ci.openshift.org/openshift/ci:ci_foo_latest"
+		dest  = "registry.ci.openshift.org/ci/foo:latest"
+		src2  = "quay-proxy.ci.openshift.org/openshift/ci:ci_bar_latest"
+		dest2 = "registry.ci.openshift.org/ci/bar:latest"
+	)
+	derived := api.QuayImageReference(api.ImageStreamTagReference{Namespace: "ci", Name: "foo", Tag: "latest"})
+	tests := []struct {
+		name      string
+		mirrors   map[string]Source
+		info      map[string]ImageInfo
+		errs      map[string]error
+		failPut   string
+		wantTasks []MirrorTask
+		wantErr   bool
+	}{
+		{
+			name:    "enqueues when digests differ",
+			mirrors: map[string]Source{"ci/foo:latest": {Image: src}},
+			info: map[string]ImageInfo{
+				src:  {Digest: "sha256:aaa"},
+				dest: {Digest: "sha256:bbb"},
+			},
+			wantTasks: []MirrorTask{{Source: src, Destination: dest, Owner: "qciToAppCIImages"}},
+		},
+		{
+			name:    "skips when digests match",
+			mirrors: map[string]Source{"ci/foo:latest": {Image: src}},
+			info: map[string]ImageInfo{
+				src:  {Digest: "sha256:aaa"},
+				dest: {Digest: "sha256:aaa"},
+			},
+			wantTasks: []MirrorTask{},
+		},
+		{
+			name:      "skips when source missing",
+			mirrors:   map[string]Source{"ci/foo:latest": {Image: src}},
+			info:      map[string]ImageInfo{dest: {Digest: "sha256:bbb"}},
+			wantTasks: []MirrorTask{},
+		},
+		{
+			name:    "derives source from target key",
+			mirrors: map[string]Source{"ci/foo:latest": {}},
+			info:    map[string]ImageInfo{derived: {Digest: "sha256:aaa"}},
+			wantTasks: []MirrorTask{{
+				Source:      derived,
+				Destination: dest,
+				Owner:       "qciToAppCIImages",
+			}},
+		},
+		{
+			name: "continues after put failure",
+			mirrors: map[string]Source{
+				"ci/foo:latest": {Image: src},
+				"ci/bar:latest": {Image: src2},
+			},
+			info: map[string]ImageInfo{
+				src:  {Digest: "sha256:aaa"},
+				src2: {Digest: "sha256:bbb"},
+			},
+			failPut: dest,
+			wantTasks: []MirrorTask{{
+				Source: src2, Destination: dest2, Owner: "qciToAppCIImages",
+			}},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := NewMirrorStore()
+			if tt.failPut != "" {
+				store = &putFailStore{MirrorStore: store, failFor: tt.failPut}
+			}
+			err := MirrorQCIToAppCI(store, logrus.WithField("test", tt.name), &fakeQuayHelper{info: tt.info, errs: tt.errs}, OCImageInfoOptions{}, tt.mirrors)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("MirrorQCIToAppCI() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			got, _, showErr := store.Show(10)
+			if showErr != nil {
+				t.Fatalf("Show() error = %v", showErr)
+			}
+			normalized := make([]MirrorTask, 0, len(got))
+			for _, task := range got {
+				normalized = append(normalized, MirrorTask{Source: task.Source, Destination: task.Destination, Owner: task.Owner})
+			}
+			if diff := cmp.Diff(tt.wantTasks, normalized); diff != "" {
+				t.Errorf("tasks mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/quay_io_ci_images_distributor/supplemental_images.go
+++ b/pkg/controller/quay_io_ci_images_distributor/supplemental_images.go
@@ -38,17 +38,30 @@ func LoadConfig(bytes []byte) (*CIImagesMirrorConfig, error) {
 	}
 	var errs []error
 	for k, v := range c.SupplementalCIImages {
-		splits := strings.Split(k, "/")
-		if len(splits) != 2 || splits[0] == "" || splits[1] == "" {
-			errs = append(errs, fmt.Errorf("invalid target: %s", k))
-		} else {
-			splits = strings.Split(splits[1], ":")
-			if len(splits) != 2 || splits[0] == "" || splits[1] == "" {
-				errs = append(errs, fmt.Errorf("invalid target: %s", k))
-			}
+		if err := validateTargetISTag(k); err != nil {
+			errs = append(errs, err)
 		}
 		if err := validateSource(v); err != nil {
 			errs = append(errs, err)
+		}
+	}
+
+	for k, v := range c.QCIToAppCIImages {
+		if err := validateTargetISTag(k); err != nil {
+			errs = append(errs, fmt.Errorf("qciToAppCIImages: %w", err))
+			continue
+		}
+		if v.Image == "" {
+			ref, err := parseISTagName(k)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("qciToAppCIImages: %w", err))
+				continue
+			}
+			v.Image = api.QuayImageReference(ref)
+			c.QCIToAppCIImages[k] = v
+		}
+		if err := validateQCISource(v); err != nil {
+			errs = append(errs, fmt.Errorf("qciToAppCIImages[%s]: %w", k, err))
 		}
 	}
 
@@ -92,7 +105,36 @@ func LoadConfig(bytes []byte) (*CIImagesMirrorConfig, error) {
 		}
 	}
 	c.SupplementalCIImages = remained
+
+	qciRemained := map[string]Source{}
+	for k, v := range c.QCIToAppCIImages {
+		if !ignored(c.IgnoredSources, v, "QCIToAppCIImages") {
+			qciRemained[k] = v
+		}
+	}
+	c.QCIToAppCIImages = qciRemained
 	return c, nil
+}
+
+func validateTargetISTag(k string) error {
+	splits := strings.Split(k, "/")
+	if len(splits) != 2 || splits[0] == "" || splits[1] == "" {
+		return fmt.Errorf("invalid target: %s", k)
+	}
+	nameTag := strings.Split(splits[1], ":")
+	if len(nameTag) != 2 || nameTag[0] == "" || nameTag[1] == "" {
+		return fmt.Errorf("invalid target: %s", k)
+	}
+	return nil
+}
+
+func parseISTagName(k string) (api.ImageStreamTagReference, error) {
+	if err := validateTargetISTag(k); err != nil {
+		return api.ImageStreamTagReference{}, err
+	}
+	ns, rest, _ := strings.Cut(k, "/")
+	name, tag, _ := strings.Cut(rest, ":")
+	return api.ImageStreamTagReference{Namespace: ns, Name: name, Tag: tag}, nil
 }
 
 func ignored(ignoredSources []IgnoredSource, s Source, section string) bool {
@@ -135,10 +177,45 @@ func validateSource(v Source) error {
 	return nil
 }
 
+// validateQCISource requires an explicit pullspec under quay.io/openshift/ci or the QCI proxy.
+// Namespace/Name/Tag on Source are not used for reverse mirrors; reject them so config is not silently ignored.
+func validateQCISource(v Source) error {
+	if v.As != "" {
+		return errors.New("as cannot be set")
+	}
+	if v.Namespace != "" || v.Name != "" || v.Tag != "" {
+		return errors.New("namespace/name/tag must not be set; use image or omit to derive from the key")
+	}
+	if v.Image == "" {
+		return errors.New("image must resolve to a QCI pullspec")
+	}
+	if !isQCIPullspec(v.Image) {
+		return fmt.Errorf("image %q must be under %s or %s/openshift/ci", v.Image, api.QuayOpenShiftCIRepo, api.QCIAPPCIDomain)
+	}
+	return nil
+}
+
+func isQCIPullspec(image string) bool {
+	for _, prefix := range []string{
+		api.QuayOpenShiftCIRepo + ":",
+		api.QuayOpenShiftCIRepo + "@",
+		api.QCIAPPCIDomain + "/openshift/ci:",
+		api.QCIAPPCIDomain + "/openshift/ci@",
+	} {
+		if strings.HasPrefix(image, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 type CIImagesMirrorConfig struct {
 	SupplementalCIImages map[string]Source `json:"supplementalCIImages"`
-	IgnoredSources       []IgnoredSource   `json:"ignoredSources"`
-	ArtImages            []ArtImage        `json:"artImages,omitempty"`
+	// QCIToAppCIImages backfills app.ci ISTags from QCI. Key is namespace/name:tag.
+	// Only Source.Image is honored (or derived from the key); do not set namespace/name/tag.
+	QCIToAppCIImages map[string]Source `json:"qciToAppCIImages,omitempty"`
+	IgnoredSources   []IgnoredSource   `json:"ignoredSources"`
+	ArtImages        []ArtImage        `json:"artImages,omitempty"`
 }
 
 type ArtImage struct {


### PR DESCRIPTION
Extends ci-images-mirror with a qciToAppCIImages config section to emergency-mirror selected images from QCI back onto app.ci (registry.ci.openshift.org/<ns>/<name>:<tag>). Reuses the existing mirror queue; empty image defaults to the matching quay-proxy float. Intended as a break-glass path when promotion is QCI-only and something still needs an app.ci copy.

**This will be removed once migration is fully completed!!!**

/cc @openshift/test-platform 

Required before https://github.com/openshift/ci-tools/pull/5278 merges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds an emergency QCI→app.ci backfill mode to `ci-images-mirror` via a new `.qciToAppCIImages` config section. Operators can specify app.ci ImageStreamTags as keys in `namespace/name:tag` form, with an optional `image` field pointing to a QCI pullspec under `quay.io/openshift/ci` or `quay-proxy.ci.openshift.org/openshift/ci`. If `image` is omitted, the controller derives the QCI pullspec from the target key. The controller validates the targets strictly and rejects configs that try to set `namespace/name/tag` in the source instead of using `image` (or omitting it to derive).

When configured, `ci-images-mirror` runs an additional hourly mirroring loop for `qciToAppCIImages` and adds these targets to `ignoreImageStreamTags`, preventing them from being handled by the normal app.ci→QCI distributor. For each target, it compares QCI and app.ci digests and enqueues mirror work into the existing mirror queue only when a sync is needed; it skips when the QCI digest is missing, when the digests already match, or when QCI digest lookup fails, while destination digest lookup failures are logged and mirror work is still attempted.

Updates documentation and includes unit tests covering config parsing/validation and the enqueue/skip behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->