### PR TITLE
hook-reverse-proxy: First implementation

### DIFF
--- a/cmd/hook-reverse-proxy/config.go
+++ b/cmd/hook-reverse-proxy/config.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+
+	"github.com/sirupsen/logrus"
+	"gopkg.in/fsnotify.v1"
+
+	aggerrs "k8s.io/apimachinery/pkg/util/errors"
+
+	"github.com/openshift/ci-tools/pkg/load/agents"
+)
+
+// URL enhances url.URL by adding the unmarshal capability.
+type URL struct {
+	*url.URL
+}
+
+// UnmarshalText implements [encoding.UnmarshalText].
+func (u *URL) UnmarshalText(text []byte) error {
+	parsed, err := url.Parse(string(text))
+	if err != nil {
+		return err
+	}
+	u.URL = parsed
+	return nil
+}
+
+type Config struct {
+	Routes       []Route `yaml:"routes,omitempty"`
+	DefaultRoute *Route  `yaml:"default_route,omitempty"`
+}
+
+func (c *Config) validate() error {
+	var errs []error
+
+	if c.DefaultRoute == nil {
+		errs = append(errs, errors.New("default route is not defined"))
+	} else if c.DefaultRoute.Target == nil {
+		errs = append(errs, errors.New("default route target URL is not defined"))
+	}
+
+	for i, route := range c.Routes {
+		if route.Target == nil {
+			errs = append(errs, fmt.Errorf("route[%d]: target is nil", i))
+		}
+	}
+
+	return aggerrs.NewAggregate(errs)
+}
+
+type Route struct {
+	Target  *URL    `yaml:"target,omitempty"`
+	Matches []Match `yaml:"matches,omitempty"`
+}
+
+type Match struct {
+	Org   string   `yaml:"org,omitempty"`
+	Repos []string `yaml:"repos,omitempty"`
+}
+
+func watchConfig(ctx context.Context, log *logrus.Entry, path string, onNewConfig func() error) error {
+	log = log.WithField("config_path", path)
+
+	events := make(chan fsnotify.Event)
+	errs := make(chan error)
+	w := agents.UniversalSymlinkWatcher{
+		EventCh:   events,
+		ErrCh:     errs,
+		WatchPath: path,
+	}
+
+	startWatching, err := w.GetWatcher()
+	if err != nil {
+		return fmt.Errorf("get watcher: %w", err)
+	}
+
+	go func() {
+		for {
+			select {
+			case _, ok := <-events:
+				if !ok {
+					log.Warn("Watch config: events channel closed")
+					return
+				}
+				if err := onNewConfig(); err != nil {
+					log.WithError(err).Error("Failed to reload the configuration")
+				} else {
+					log.Info("Configuration reloaded")
+				}
+			case err, ok := <-errs:
+				if !ok {
+					log.Warn("Watch config: errors channel closed")
+					return
+				}
+				log.WithError(err).Error("Failed to watch the configuration file")
+			case <-ctx.Done():
+				log.WithError(context.Cause(ctx)).Info("Configuration watcher stopped")
+				return
+			}
+		}
+	}()
+
+	go startWatching(ctx)
+
+	return nil
+}

--- a/cmd/hook-reverse-proxy/main.go
+++ b/cmd/hook-reverse-proxy/main.go
@@ -1,0 +1,276 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+
+	aggerrs "k8s.io/apimachinery/pkg/util/errors"
+	"sigs.k8s.io/prow/pkg/flagutil"
+	prowflagutil "sigs.k8s.io/prow/pkg/flagutil"
+	"sigs.k8s.io/prow/pkg/github"
+	"sigs.k8s.io/prow/pkg/interrupts"
+	"sigs.k8s.io/prow/pkg/pjutil"
+	"sigs.k8s.io/prow/pkg/version"
+)
+
+// URL enhances url.URL by adding the unmarshal capability.
+type URL struct {
+	*url.URL
+}
+
+// UnmarshalText implements [encoding.UnmarshalText].
+func (u *URL) UnmarshalText(text []byte) error {
+	parsed, err := url.Parse(string(text))
+	if err != nil {
+		return err
+	}
+	u.URL = parsed
+	return nil
+}
+
+type Config struct {
+	Routes       []Route `yaml:"routes,omitempty"`
+	DefaultRoute *Route  `yaml:"default_route,omitempty"`
+}
+
+func (c *Config) validate() error {
+	var errs []error
+
+	if c.DefaultRoute == nil {
+		errs = append(errs, errors.New("default route is not defined"))
+	} else if c.DefaultRoute.Target == nil {
+		errs = append(errs, errors.New("default route target URL is not defined"))
+	}
+
+	for i, route := range c.Routes {
+		if route.Target == nil {
+			errs = append(errs, fmt.Errorf("route[%d]: target is nil", i))
+		}
+	}
+
+	return aggerrs.NewAggregate(errs)
+}
+
+type Route struct {
+	Target  *URL    `yaml:"target,omitempty"`
+	Matches []Match `yaml:"matches,omitempty"`
+}
+
+type Match struct {
+	Org   string   `yaml:"org,omitempty"`
+	Repos []string `yaml:"repos,omitempty"`
+}
+
+type router struct {
+	log    *logrus.Entry
+	config *Config
+}
+
+func (r *router) rewrite(pr *httputil.ProxyRequest) {
+	var targetURL *url.URL
+	var body []byte
+
+	defer func() {
+		if body != nil {
+			pr.Out.Body = io.NopCloser(bytes.NewBuffer(body))
+		}
+
+		if targetURL == nil {
+			targetURL = r.config.DefaultRoute.Target.URL
+		}
+
+		pr.SetXForwarded()
+		pr.SetURL(targetURL)
+		pr.Out.URL = targetURL
+	}()
+
+	req := pr.In
+	log := r.log
+
+	eventType := req.Header.Get("X-GitHub-Event")
+	if eventType == "" {
+		log.Error("Missing X-GitHub-Event Header")
+		return
+	}
+	log = log.WithField("event-type", eventType)
+
+	eventGUID := req.Header.Get("X-GitHub-Delivery")
+	if eventGUID == "" {
+		log.Error("Missing X-GitHub-Delivery Header")
+		return
+	}
+	log = log.WithField("event-guid", eventGUID)
+
+	if req.Method != http.MethodPost {
+		log.Error("POST method only is allowed")
+		return
+	}
+
+	if req.Header.Get("content-type") != "application/json" {
+		log.Error("Invalid content-type: application/json only")
+		return
+	}
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		body = nil
+		log.WithError(err).Error("Failed to read request body")
+		return
+	}
+
+	var event github.GenericEvent
+	if err := json.Unmarshal(body, &event); err != nil {
+		log.WithError(err).Error("Failed to unmarshal request in a generic event")
+		return
+	}
+
+	targetURL = r.matchRoute(log, event)
+}
+
+func (r *router) matchRoute(log *logrus.Entry, event github.GenericEvent) *url.URL {
+	org, repo := event.Org.Login, event.Repo.Name
+
+	if org == "" {
+		log.Info("Org is empty")
+		return nil
+	}
+
+	if repo == "" {
+		log.Info("Repo is empty")
+		return nil
+	}
+
+	log = log.WithField("org", org).WithField("repo", repo)
+
+	for _, route := range r.config.Routes {
+		log = log.WithField("target-url", route.Target)
+
+	matchLoop:
+		for _, m := range route.Matches {
+			if m.Org == "*" {
+				log.Info("Match found: match * org wildcard")
+				return route.Target.URL
+			}
+
+			if m.Org != org {
+				continue matchLoop
+			}
+
+			for _, r := range m.Repos {
+				if r == "*" {
+					log.Infof("Match found: match org %q and * repo wildcard", org)
+					return route.Target.URL
+				}
+
+				if r == repo {
+					log.Infof("Match found: match org %q and repo %q", org, repo)
+					return route.Target.URL
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func newRouter(log *logrus.Entry, config *Config) *router {
+	return &router{
+		log:    log,
+		config: config,
+	}
+}
+
+type options struct {
+	port        int
+	configPath  string
+	gracePeriod time.Duration
+
+	instrumentationOptions prowflagutil.InstrumentationOptions
+}
+
+func (o *options) Validate() error {
+	return nil
+}
+
+func gatherOptions(fs *flag.FlagSet, args ...string) (options, error) {
+	var o options
+
+	for _, group := range []flagutil.OptionGroup{&o.instrumentationOptions} {
+		group.AddFlags(fs)
+	}
+
+	fs.IntVar(&o.port, "port", 8888, "Port to listen on")
+	fs.StringVar(&o.configPath, "config-path", "/etc/config/config.yaml", "Configuration path")
+	fs.DurationVar(&o.gracePeriod, "grace-period", 180*time.Second, "On shutdown, try to handle remaining events for the specified duration.")
+
+	if err := fs.Parse(args); err != nil {
+		return o, err
+	}
+
+	return o, nil
+}
+
+func loadConfig(configPath string) (*Config, error) {
+	configBytes, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("read config %s: %w", configPath, err)
+	}
+
+	c := Config{}
+	if err := yaml.Unmarshal(configBytes, &c); err != nil {
+		return nil, fmt.Errorf("unmarshal config: %w", err)
+	}
+
+	if err := c.validate(); err != nil {
+		return nil, fmt.Errorf("validate config: %w", err)
+	}
+
+	return &c, nil
+}
+
+func main() {
+	logger := logrus.NewEntry(logrus.StandardLogger())
+	logger.Logger.SetFormatter(&logrus.JSONFormatter{})
+	logrus.Infof("%s version %s", version.Name, version.Version)
+
+	o, err := gatherOptions(flag.NewFlagSet(os.Args[0], flag.ExitOnError), os.Args[1:]...)
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to gather options")
+	}
+
+	if err := o.Validate(); err != nil {
+		logrus.WithError(err).Fatal("Invalid options")
+	}
+
+	config, err := loadConfig(o.configPath)
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to load the configuration")
+	}
+
+	router := newRouter(logger, config)
+	server := &http.Server{
+		Addr: ":" + strconv.Itoa(o.port),
+		Handler: &httputil.ReverseProxy{
+			Rewrite: router.rewrite,
+		},
+	}
+
+	health := pjutil.NewHealthOnPort(o.instrumentationOptions.HealthPort)
+	health.ServeReady()
+
+	interrupts.ListenAndServe(server, o.gracePeriod)
+	interrupts.WaitForGracefulShutdown()
+}

--- a/cmd/hook-reverse-proxy/main.go
+++ b/cmd/hook-reverse-proxy/main.go
@@ -1,197 +1,22 @@
 package main
 
 import (
-	"bytes"
-	"encoding/json"
+	"context"
 	"errors"
 	"flag"
-	"fmt"
-	"io"
 	"net/http"
 	"net/http/httputil"
-	"net/url"
 	"os"
 	"strconv"
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v3"
 
-	aggerrs "k8s.io/apimachinery/pkg/util/errors"
-	"sigs.k8s.io/prow/pkg/flagutil"
 	prowflagutil "sigs.k8s.io/prow/pkg/flagutil"
-	"sigs.k8s.io/prow/pkg/github"
 	"sigs.k8s.io/prow/pkg/interrupts"
 	"sigs.k8s.io/prow/pkg/pjutil"
 	"sigs.k8s.io/prow/pkg/version"
 )
-
-// URL enhances url.URL by adding the unmarshal capability.
-type URL struct {
-	*url.URL
-}
-
-// UnmarshalText implements [encoding.UnmarshalText].
-func (u *URL) UnmarshalText(text []byte) error {
-	parsed, err := url.Parse(string(text))
-	if err != nil {
-		return err
-	}
-	u.URL = parsed
-	return nil
-}
-
-type Config struct {
-	Routes       []Route `yaml:"routes,omitempty"`
-	DefaultRoute *Route  `yaml:"default_route,omitempty"`
-}
-
-func (c *Config) validate() error {
-	var errs []error
-
-	if c.DefaultRoute == nil {
-		errs = append(errs, errors.New("default route is not defined"))
-	} else if c.DefaultRoute.Target == nil {
-		errs = append(errs, errors.New("default route target URL is not defined"))
-	}
-
-	for i, route := range c.Routes {
-		if route.Target == nil {
-			errs = append(errs, fmt.Errorf("route[%d]: target is nil", i))
-		}
-	}
-
-	return aggerrs.NewAggregate(errs)
-}
-
-type Route struct {
-	Target  *URL    `yaml:"target,omitempty"`
-	Matches []Match `yaml:"matches,omitempty"`
-}
-
-type Match struct {
-	Org   string   `yaml:"org,omitempty"`
-	Repos []string `yaml:"repos,omitempty"`
-}
-
-type router struct {
-	log    *logrus.Entry
-	config *Config
-}
-
-func (r *router) rewrite(pr *httputil.ProxyRequest) {
-	var targetURL *url.URL
-	var body []byte
-
-	defer func() {
-		if body != nil {
-			pr.Out.Body = io.NopCloser(bytes.NewBuffer(body))
-		}
-
-		if targetURL == nil {
-			targetURL = r.config.DefaultRoute.Target.URL
-		}
-
-		pr.SetXForwarded()
-		pr.SetURL(targetURL)
-		pr.Out.URL = targetURL
-	}()
-
-	req := pr.In
-	log := r.log
-
-	eventType := req.Header.Get("X-GitHub-Event")
-	if eventType == "" {
-		log.Error("Missing X-GitHub-Event Header")
-		return
-	}
-	log = log.WithField("event-type", eventType)
-
-	eventGUID := req.Header.Get("X-GitHub-Delivery")
-	if eventGUID == "" {
-		log.Error("Missing X-GitHub-Delivery Header")
-		return
-	}
-	log = log.WithField("event-guid", eventGUID)
-
-	if req.Method != http.MethodPost {
-		log.Error("POST method only is allowed")
-		return
-	}
-
-	if req.Header.Get("content-type") != "application/json" {
-		log.Error("Invalid content-type: application/json only")
-		return
-	}
-
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		body = nil
-		log.WithError(err).Error("Failed to read request body")
-		return
-	}
-
-	var event github.GenericEvent
-	if err := json.Unmarshal(body, &event); err != nil {
-		log.WithError(err).Error("Failed to unmarshal request in a generic event")
-		return
-	}
-
-	targetURL = r.matchRoute(log, event)
-}
-
-func (r *router) matchRoute(log *logrus.Entry, event github.GenericEvent) *url.URL {
-	org, repo := event.Org.Login, event.Repo.Name
-
-	if org == "" {
-		log.Info("Org is empty")
-		return nil
-	}
-
-	if repo == "" {
-		log.Info("Repo is empty")
-		return nil
-	}
-
-	log = log.WithField("org", org).WithField("repo", repo)
-
-	for _, route := range r.config.Routes {
-		log = log.WithField("target-url", route.Target)
-
-	matchLoop:
-		for _, m := range route.Matches {
-			if m.Org == "*" {
-				log.Info("Match found: match * org wildcard")
-				return route.Target.URL
-			}
-
-			if m.Org != org {
-				continue matchLoop
-			}
-
-			for _, r := range m.Repos {
-				if r == "*" {
-					log.Infof("Match found: match org %q and * repo wildcard", org)
-					return route.Target.URL
-				}
-
-				if r == repo {
-					log.Infof("Match found: match org %q and repo %q", org, repo)
-					return route.Target.URL
-				}
-			}
-		}
-	}
-
-	return nil
-}
-
-func newRouter(log *logrus.Entry, config *Config) *router {
-	return &router{
-		log:    log,
-		config: config,
-	}
-}
 
 type options struct {
 	port        int
@@ -201,14 +26,10 @@ type options struct {
 	instrumentationOptions prowflagutil.InstrumentationOptions
 }
 
-func (o *options) Validate() error {
-	return nil
-}
-
 func gatherOptions(fs *flag.FlagSet, args ...string) (options, error) {
 	var o options
 
-	for _, group := range []flagutil.OptionGroup{&o.instrumentationOptions} {
+	for _, group := range []prowflagutil.OptionGroup{&o.instrumentationOptions} {
 		group.AddFlags(fs)
 	}
 
@@ -223,24 +44,6 @@ func gatherOptions(fs *flag.FlagSet, args ...string) (options, error) {
 	return o, nil
 }
 
-func loadConfig(configPath string) (*Config, error) {
-	configBytes, err := os.ReadFile(configPath)
-	if err != nil {
-		return nil, fmt.Errorf("read config %s: %w", configPath, err)
-	}
-
-	c := Config{}
-	if err := yaml.Unmarshal(configBytes, &c); err != nil {
-		return nil, fmt.Errorf("unmarshal config: %w", err)
-	}
-
-	if err := c.validate(); err != nil {
-		return nil, fmt.Errorf("validate config: %w", err)
-	}
-
-	return &c, nil
-}
-
 func main() {
 	logger := logrus.NewEntry(logrus.StandardLogger())
 	logger.Logger.SetFormatter(&logrus.JSONFormatter{})
@@ -251,16 +54,16 @@ func main() {
 		logrus.WithError(err).Fatal("Failed to gather options")
 	}
 
-	if err := o.Validate(); err != nil {
-		logrus.WithError(err).Fatal("Invalid options")
-	}
-
-	config, err := loadConfig(o.configPath)
+	router, err := newRouter(logger, o.configPath)
 	if err != nil {
-		logrus.WithError(err).Fatal("Failed to load the configuration")
+		logrus.WithError(err).Fatal("Failed to create the router")
 	}
 
-	router := newRouter(logger, config)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	if err := watchConfig(ctx, logger, o.configPath, router.loadConfig); err != nil {
+		logrus.WithError(err).Fatal("Failed to start configuration watcher")
+	}
+
 	server := &http.Server{
 		Addr: ":" + strconv.Itoa(o.port),
 		Handler: &httputil.ReverseProxy{
@@ -272,5 +75,8 @@ func main() {
 	health.ServeReady()
 
 	interrupts.ListenAndServe(server, o.gracePeriod)
+	interrupts.OnInterrupt(func() {
+		cancel(errors.New("interrupt received"))
+	})
 	interrupts.WaitForGracefulShutdown()
 }

--- a/cmd/hook-reverse-proxy/main_test.go
+++ b/cmd/hook-reverse-proxy/main_test.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/prow/pkg/github"
+)
+
+func req(method, target string, body io.Reader, headers map[string]string) *http.Request {
+	r := httptest.NewRequest(method, target, body)
+	for k, v := range headers {
+		r.Header.Add(k, v)
+	}
+	return r
+}
+
+func TestRewrite(t *testing.T) {
+	t.Parallel()
+
+	u := func(rawURL string) *URL {
+		parsed, err := url.Parse(rawURL)
+		if err != nil {
+			t.Fatalf("parse url %s: %s", rawURL, err.Error())
+		}
+		return &URL{URL: parsed}
+	}
+	ge := func(genericEvent github.GenericEvent) *bytes.Buffer {
+		geBytes, err := json.Marshal(genericEvent)
+		if err != nil {
+			t.Fatalf("marshal github event: %s", err)
+		}
+		return bytes.NewBuffer(geBytes)
+	}
+	stdHeaders := map[string]string{
+		"X-GitHub-Event":    "gh-event",
+		"X-GitHub-Delivery": "gh-delivery",
+		"content-type":      "application/json",
+	}
+
+	for _, tc := range []struct {
+		name    string
+		config  Config
+		pr      *httputil.ProxyRequest
+		wantURL string
+	}{
+		{
+			name:   "GH event header missing: match default route",
+			config: Config{DefaultRoute: &Route{Target: u("https://hook/")}},
+			pr: &httputil.ProxyRequest{
+				In:  req("POST", "https://in", nil, nil),
+				Out: req("POST", "https://out", nil, nil),
+			},
+			wantURL: "https://hook/",
+		},
+		{
+			name:   "GH delivery header missing: match default route",
+			config: Config{DefaultRoute: &Route{Target: u("https://hook/")}},
+			pr: &httputil.ProxyRequest{
+				In:  req("POST", "https://in", nil, map[string]string{"X-GitHub-Event": "gh-event"}),
+				Out: req("POST", "https://out", nil, nil),
+			},
+			wantURL: "https://hook/",
+		},
+		{
+			name:   "Wrong content-type: match default route",
+			config: Config{DefaultRoute: &Route{Target: u("https://hook/")}},
+			pr: &httputil.ProxyRequest{
+				In: req("POST", "https://in", nil, map[string]string{
+					"X-GitHub-Event":    "gh-event",
+					"X-GitHub-Delivery": "gh-delivery",
+					"content-type":      "application/yaml",
+				}),
+				Out: req("POST", "https://out", nil, nil),
+			},
+			wantURL: "https://hook/",
+		},
+		{
+			name:   "Invalid payload: match default route",
+			config: Config{DefaultRoute: &Route{Target: u("https://hook/")}},
+			pr: &httputil.ProxyRequest{
+				In:  req("POST", "https://in", bytes.NewBuffer([]byte("xxx")), stdHeaders),
+				Out: req("POST", "https://out", nil, nil),
+			},
+			wantURL: "https://hook/",
+		},
+		{
+			name:   "Invalid HTTP method: match default route",
+			config: Config{DefaultRoute: &Route{Target: u("https://hook/")}},
+			pr: &httputil.ProxyRequest{
+				In:  req("GET", "https://in", bytes.NewBuffer([]byte("xxx")), stdHeaders),
+				Out: req("GET", "https://out", nil, nil),
+			},
+			wantURL: "https://hook/",
+		},
+		{
+			name:   "No routes defined: match default",
+			config: Config{DefaultRoute: &Route{Target: u("https://hook/")}},
+			pr: &httputil.ProxyRequest{
+				In:  req("POST", "https://in", nil, stdHeaders),
+				Out: req("POST", "https://out", nil, nil),
+			},
+			wantURL: "https://hook/",
+		},
+		{
+			name: "Match org and repo",
+			config: Config{
+				Routes: []Route{{
+					Target: u("https://hook-proxy"),
+					Matches: []Match{{
+						Org:   "openshift",
+						Repos: []string{"ci-tools"},
+					}},
+				}},
+				DefaultRoute: &Route{Target: u("https://hook/")},
+			},
+			pr: &httputil.ProxyRequest{
+				In: req("POST", "https://in", ge(github.GenericEvent{
+					Org:  github.Organization{Login: "openshift"},
+					Repo: github.Repo{Name: "ci-tools"},
+				}), stdHeaders),
+				Out: req("POST", "https://out/", nil, nil),
+			},
+			wantURL: "https://hook-proxy",
+		},
+		{
+			name: "Match org wildcard",
+			config: Config{
+				Routes: []Route{{
+					Target: u("https://hook-proxy"),
+					Matches: []Match{{
+						Org: "*",
+					}},
+				}},
+				DefaultRoute: &Route{Target: u("https://hook/")},
+			},
+			pr: &httputil.ProxyRequest{
+				In: req("POST", "https://in", ge(github.GenericEvent{
+					Org:  github.Organization{Login: "openshift"},
+					Repo: github.Repo{Name: "ci-tools"},
+				}), stdHeaders),
+				Out: req("POST", "https://out/", nil, nil),
+			},
+			wantURL: "https://hook-proxy",
+		},
+		{
+			name: "Match repo wildcard",
+			config: Config{
+				Routes: []Route{{
+					Target: u("https://hook-proxy"),
+					Matches: []Match{{
+						Org:   "openshift",
+						Repos: []string{"*"},
+					}},
+				}},
+				DefaultRoute: &Route{Target: u("https://hook/")},
+			},
+			pr: &httputil.ProxyRequest{
+				In: req("POST", "https://in", ge(github.GenericEvent{
+					Org:  github.Organization{Login: "openshift"},
+					Repo: github.Repo{Name: "ci-tools"},
+				}), stdHeaders),
+				Out: req("POST", "https://out/", nil, nil),
+			},
+			wantURL: "https://hook-proxy",
+		},
+		{
+			name: "Repo missing: match default route",
+			config: Config{
+				Routes: []Route{{
+					Target: u("https://hook-proxy"),
+					Matches: []Match{{
+						Org:   "openshift",
+						Repos: []string{"api"},
+					}},
+				}},
+				DefaultRoute: &Route{Target: u("https://hook/")},
+			},
+			pr: &httputil.ProxyRequest{
+				In: req("POST", "https://in", ge(github.GenericEvent{
+					Org: github.Organization{Login: "openshift"},
+				}), stdHeaders),
+				Out: req("POST", "https://out/", nil, nil),
+			},
+			wantURL: "https://hook/",
+		},
+		{
+			name: "Org missing: match default route",
+			config: Config{
+				Routes: []Route{{
+					Target: u("https://hook-proxy"),
+					Matches: []Match{{
+						Org:   "openshift",
+						Repos: []string{"api"},
+					}},
+				}},
+				DefaultRoute: &Route{Target: u("https://hook/")},
+			},
+			pr: &httputil.ProxyRequest{
+				In:  req("POST", "https://in", ge(github.GenericEvent{}), stdHeaders),
+				Out: req("POST", "https://out/", nil, nil),
+			},
+			wantURL: "https://hook/",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			logger := logrus.NewEntry(logrus.StandardLogger())
+			router := newRouter(logger, &tc.config)
+			router.rewrite(tc.pr)
+
+			gotURL := tc.pr.Out.URL.String()
+			if tc.wantURL != gotURL {
+				t.Errorf("want URL %s but got %s", tc.wantURL, gotURL)
+			}
+		})
+	}
+}

--- a/cmd/hook-reverse-proxy/router.go
+++ b/cmd/hook-reverse-proxy/router.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+
+	"sigs.k8s.io/prow/pkg/github"
+)
+
+type router struct {
+	log        *logrus.Entry
+	m          *sync.RWMutex
+	configPath string
+	conf       *Config
+}
+
+func (r *router) rewrite(pr *httputil.ProxyRequest) {
+	var targetURL *url.URL
+	var body []byte
+	conf := r.config()
+
+	defer func() {
+		if body != nil {
+			pr.Out.Body = io.NopCloser(bytes.NewBuffer(body))
+		}
+
+		if targetURL == nil {
+			targetURL = conf.DefaultRoute.Target.URL
+		}
+
+		pr.SetXForwarded()
+		pr.SetURL(targetURL)
+		// Overwrite the URL since we don't want the path-joining feature of SetURL()
+		pr.Out.URL = targetURL
+	}()
+
+	req := pr.In
+	log := r.log
+
+	eventType := req.Header.Get("X-GitHub-Event")
+	if eventType == "" {
+		log.Error("Missing X-GitHub-Event Header")
+		return
+	}
+	log = log.WithField("event-type", eventType)
+
+	eventGUID := req.Header.Get("X-GitHub-Delivery")
+	if eventGUID == "" {
+		log.Error("Missing X-GitHub-Delivery Header")
+		return
+	}
+	log = log.WithField("event-guid", eventGUID)
+
+	if req.Method != http.MethodPost {
+		log.Error("POST method only is allowed")
+		return
+	}
+
+	if req.Header.Get("content-type") != "application/json" {
+		log.Error("Invalid content-type: application/json only")
+		return
+	}
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		body = nil
+		log.WithError(err).Error("Failed to read request body")
+		return
+	}
+
+	var event github.GenericEvent
+	if err := json.Unmarshal(body, &event); err != nil {
+		log.WithError(err).Error("Failed to unmarshal request in a generic event")
+		return
+	}
+
+	targetURL = r.matchRoute(log, conf, event)
+}
+
+func (r *router) matchRoute(log *logrus.Entry, conf *Config, event github.GenericEvent) *url.URL {
+	org, repo := event.Org.Login, event.Repo.Name
+
+	if org == "" {
+		log.Info("Org is empty")
+		return nil
+	}
+
+	if repo == "" {
+		log.Info("Repo is empty")
+		return nil
+	}
+
+	log = log.WithField("org", org).WithField("repo", repo)
+
+	for _, route := range conf.Routes {
+		log = log.WithField("target-url", route.Target)
+
+	matchLoop:
+		for _, m := range route.Matches {
+			if m.Org == "*" {
+				log.Info("Match found: match * org wildcard")
+				return route.Target.URL
+			}
+
+			if m.Org != org {
+				continue matchLoop
+			}
+
+			for _, r := range m.Repos {
+				if r == "*" {
+					log.Infof("Match found: match org %q and * repo wildcard", org)
+					return route.Target.URL
+				}
+
+				if r == repo {
+					log.Infof("Match found: match org %q and repo %q", org, repo)
+					return route.Target.URL
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (r *router) config() *Config {
+	r.m.RLock()
+	defer r.m.RUnlock()
+	return r.conf
+}
+
+func (r *router) loadConfig() error {
+	configBytes, err := os.ReadFile(r.configPath)
+	if err != nil {
+		return fmt.Errorf("read config %s: %w", r.configPath, err)
+	}
+
+	c := Config{}
+	if err := yaml.Unmarshal(configBytes, &c); err != nil {
+		return fmt.Errorf("unmarshal config: %w", err)
+	}
+
+	if err := c.validate(); err != nil {
+		return fmt.Errorf("validate config: %w", err)
+	}
+
+	r.m.Lock()
+	defer r.m.Unlock()
+	r.conf = &c
+
+	return nil
+}
+
+func newRouter(log *logrus.Entry, configPath string) (*router, error) {
+	r := router{
+		log:        log,
+		m:          &sync.RWMutex{},
+		configPath: configPath,
+	}
+
+	if err := r.loadConfig(); err != nil {
+		return nil, fmt.Errorf("load config %s: %w", configPath, err)
+	}
+
+	return &r, nil
+}

--- a/cmd/hook-reverse-proxy/router_test.go
+++ b/cmd/hook-reverse-proxy/router_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/http/httputil"
 	"net/url"
+	"sync"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -215,7 +216,11 @@ func TestRewrite(t *testing.T) {
 			t.Parallel()
 
 			logger := logrus.NewEntry(logrus.StandardLogger())
-			router := newRouter(logger, &tc.config)
+			router := router{
+				log:  logger,
+				m:    &sync.RWMutex{},
+				conf: &tc.config,
+			}
 			router.rewrite(tc.pr)
 
 			gotURL := tc.pr.Out.URL.String()

--- a/images/hook-reverse-proxy/Dockerfile
+++ b/images/hook-reverse-proxy/Dockerfile
@@ -1,0 +1,4 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+ADD hook-reverse-proxy /usr/bin/hook-reverse-proxy
+ENTRYPOINT ["/usr/bin/hook-reverse-proxy"]


### PR DESCRIPTION
This is an ad-hoc reverse proxy that will sit in front of hook, created to ease the migration of Prow from `app.ci` to `core-ci`.

Since shutting down Prow on `app.ci`, recreating it on `core-ci` and migrate everything is too risk, we are going to follow this plan:
1. Deploy Prow on `core-ci`.
2. Deploy `hook-reverse-proxy` on `app.ci`.
3. Incrementally migrate repos and orgs by leveraging `hook-reverse-proxy`.  
    - Fix any error along the way 

The reverse proxy reads a config file in order to match an endpoint to dispatch the next GitHub event to:
```yaml
routes:
- target: http://hook.ci.svc.cluster.local:8888/hook
  matches:
  - org: openshift
    repos:
    - ci-tools
default_route:
  target:  https://hook-ci.apps.master.ci.devcluster.openshift.com/hook
```

GitHub events generated by `openshift/ci-tools` will be forwarded to hook on `core-ci`, everything else to standard hook on `app.ci`. In this way we can gradually add new orgs/repos and assess the result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds an ad-hoc reverse proxy for Hook to support the Prow migration from `app.ci` to `core-ci`.
- Routes GitHub webhook events by organization and repository. Configured repositories can use `core-ci`, while unmatched events use the default `app.ci` Hook endpoint.
- Adds YAML configuration validation and hot reload support.
- Adds request validation, route matching, wildcard support, URL rewriting, health readiness, structured logging, and graceful shutdown.
- Adds a container image definition for deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->