### PR TITLE
release: wait for CLI tag spec visibility

### DIFF
--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -512,7 +512,7 @@ func waitForCLIImageTagInSpec(ctx context.Context, client ctrlruntimeclient.With
 	imageStream := &imagev1.ImageStream{}
 	evaluate := func(obj runtime.Object) (bool, error) {
 		stream, ok := obj.(*imagev1.ImageStream)
-		if !ok {
+		if !ok || stream == nil {
 			return false, fmt.Errorf("got an event that did not contain an imagestream: %v", obj)
 		}
 		for _, tag := range stream.Spec.Tags {

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -14,6 +14,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
@@ -365,6 +366,8 @@ func ImportReleaseStep(
 
 const overrideCLIStreamName = "amd64-cli"
 
+const cliImageSpecVisibilityTimeout = 3 * time.Minute
+
 func (s *importReleaseStep) ensureCLIStream(ctx context.Context, streamName string) error {
 	stableIS := &imagev1.ImageStream{
 		ObjectMeta: meta.ObjectMeta{
@@ -389,6 +392,10 @@ func (s *importReleaseStep) resolveCLIImageFromStream(ctx context.Context, strea
 			return nil, nil
 		}
 		return nil, fmt.Errorf("unable to get existing %s imagestreamtag: %w", streamTagName, err)
+	}
+
+	if err := waitForCLIImageTagInSpec(ctx, s.client, s.jobSpec.Namespace(), streamName, cliImageSpecVisibilityTimeout); err != nil {
+		return nil, fmt.Errorf("unable to wait for the existing 'cli' image tag to appear in the stable stream spec: %w", err)
 	}
 
 	if err := utils.WaitForImportingISTag(ctx, s.client, s.jobSpec.Namespace(), streamName, nil, sets.New("cli"), 10*time.Minute, s.client.MetricsAgent()); err != nil {
@@ -487,11 +494,36 @@ func (s *importReleaseStep) extractAndTagCLIImage(ctx context.Context, targetCLI
 		return nil, fmt.Errorf("unable to tag the 'cli' image into the stable stream: %w", err)
 	}
 
+	if err := waitForCLIImageTagInSpec(ctx, s.client, s.jobSpec.Namespace(), streamName, cliImageSpecVisibilityTimeout); err != nil {
+		return nil, fmt.Errorf("unable to wait for the 'cli' image tag to appear in the stable stream spec: %w", err)
+	}
+
 	if err := utils.WaitForImportingISTag(ctx, s.client, s.jobSpec.Namespace(), streamName, nil, sets.New("cli"), 10*time.Minute, s.client.MetricsAgent()); err != nil {
 		return nil, fmt.Errorf("unable to wait for the 'cli' image in the stable stream to populate: %w", err)
 	}
 
 	return &cliImageRef, nil
+}
+
+// waitForCLIImageTagInSpec waits for the CLI tag definition to be visible before
+// inspecting its import status. An ImageStreamTag update can succeed before the
+// corresponding tag is returned in the parent ImageStream spec.
+func waitForCLIImageTagInSpec(ctx context.Context, client ctrlruntimeclient.WithWatch, namespace, streamName string, timeout time.Duration) error {
+	imageStream := &imagev1.ImageStream{}
+	evaluate := func(obj runtime.Object) (bool, error) {
+		stream, ok := obj.(*imagev1.ImageStream)
+		if !ok {
+			return false, fmt.Errorf("got an event that did not contain an imagestream: %v", obj)
+		}
+		for _, tag := range stream.Spec.Tags {
+			if tag.Name == "cli" {
+				return true, nil
+			}
+		}
+		logrus.Debugf("CLI tag has not shown up in the spec of imagestream %s/%s, waiting ...", stream.Namespace, stream.Name)
+		return false, nil
+	}
+	return kubernetes.WaitForConditionOnObject(ctx, client, ctrlruntimeclient.ObjectKey{Namespace: namespace, Name: streamName}, &imagev1.ImageStreamList{}, imageStream, evaluate, timeout)
 }
 
 func (s *importReleaseStep) getCLIImage(ctx context.Context, target, streamName string) (*api.ImageStreamTagReference, error) {

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -391,7 +391,7 @@ func (s *importReleaseStep) resolveCLIImageFromStream(ctx context.Context, strea
 		return nil, fmt.Errorf("unable to get existing %s imagestreamtag: %w", streamTagName, err)
 	}
 
-	if err := utils.WaitForImportingISTagWithSpecVisibility(ctx, s.client, s.jobSpec.Namespace(), streamName, nil, sets.New("cli"), 10*time.Minute, s.client.MetricsAgent()); err != nil {
+	if err := utils.WaitForImportingISTag(ctx, s.client, s.jobSpec.Namespace(), streamName, nil, sets.New("cli"), 10*time.Minute, s.client.MetricsAgent(), utils.WaitForSpecTags()); err != nil {
 		return nil, fmt.Errorf("unable to wait for the existing 'cli' image in the stable stream to populate: %w", err)
 	}
 
@@ -487,7 +487,7 @@ func (s *importReleaseStep) extractAndTagCLIImage(ctx context.Context, targetCLI
 		return nil, fmt.Errorf("unable to tag the 'cli' image into the stable stream: %w", err)
 	}
 
-	if err := utils.WaitForImportingISTagWithSpecVisibility(ctx, s.client, s.jobSpec.Namespace(), streamName, nil, sets.New("cli"), 10*time.Minute, s.client.MetricsAgent()); err != nil {
+	if err := utils.WaitForImportingISTag(ctx, s.client, s.jobSpec.Namespace(), streamName, nil, sets.New("cli"), 10*time.Minute, s.client.MetricsAgent(), utils.WaitForSpecTags()); err != nil {
 		return nil, fmt.Errorf("unable to wait for the 'cli' image in the stable stream to populate: %w", err)
 	}
 

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -14,7 +14,6 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
@@ -366,8 +365,6 @@ func ImportReleaseStep(
 
 const overrideCLIStreamName = "amd64-cli"
 
-const cliImageSpecVisibilityTimeout = 3 * time.Minute
-
 func (s *importReleaseStep) ensureCLIStream(ctx context.Context, streamName string) error {
 	stableIS := &imagev1.ImageStream{
 		ObjectMeta: meta.ObjectMeta{
@@ -394,11 +391,7 @@ func (s *importReleaseStep) resolveCLIImageFromStream(ctx context.Context, strea
 		return nil, fmt.Errorf("unable to get existing %s imagestreamtag: %w", streamTagName, err)
 	}
 
-	if err := waitForCLIImageTagInSpec(ctx, s.client, s.jobSpec.Namespace(), streamName, cliImageSpecVisibilityTimeout); err != nil {
-		return nil, fmt.Errorf("unable to wait for the existing 'cli' image tag to appear in the stable stream spec: %w", err)
-	}
-
-	if err := utils.WaitForImportingISTag(ctx, s.client, s.jobSpec.Namespace(), streamName, nil, sets.New("cli"), 10*time.Minute, s.client.MetricsAgent()); err != nil {
+	if err := utils.WaitForImportingISTagWithSpecVisibility(ctx, s.client, s.jobSpec.Namespace(), streamName, nil, sets.New("cli"), 10*time.Minute, s.client.MetricsAgent()); err != nil {
 		return nil, fmt.Errorf("unable to wait for the existing 'cli' image in the stable stream to populate: %w", err)
 	}
 
@@ -494,36 +487,11 @@ func (s *importReleaseStep) extractAndTagCLIImage(ctx context.Context, targetCLI
 		return nil, fmt.Errorf("unable to tag the 'cli' image into the stable stream: %w", err)
 	}
 
-	if err := waitForCLIImageTagInSpec(ctx, s.client, s.jobSpec.Namespace(), streamName, cliImageSpecVisibilityTimeout); err != nil {
-		return nil, fmt.Errorf("unable to wait for the 'cli' image tag to appear in the stable stream spec: %w", err)
-	}
-
-	if err := utils.WaitForImportingISTag(ctx, s.client, s.jobSpec.Namespace(), streamName, nil, sets.New("cli"), 10*time.Minute, s.client.MetricsAgent()); err != nil {
+	if err := utils.WaitForImportingISTagWithSpecVisibility(ctx, s.client, s.jobSpec.Namespace(), streamName, nil, sets.New("cli"), 10*time.Minute, s.client.MetricsAgent()); err != nil {
 		return nil, fmt.Errorf("unable to wait for the 'cli' image in the stable stream to populate: %w", err)
 	}
 
 	return &cliImageRef, nil
-}
-
-// waitForCLIImageTagInSpec waits for the CLI tag definition to be visible before
-// inspecting its import status. An ImageStreamTag update can succeed before the
-// corresponding tag is returned in the parent ImageStream spec.
-func waitForCLIImageTagInSpec(ctx context.Context, client ctrlruntimeclient.WithWatch, namespace, streamName string, timeout time.Duration) error {
-	imageStream := &imagev1.ImageStream{}
-	evaluate := func(obj runtime.Object) (bool, error) {
-		stream, ok := obj.(*imagev1.ImageStream)
-		if !ok || stream == nil {
-			return false, fmt.Errorf("got an event that did not contain an imagestream: %v", obj)
-		}
-		for _, tag := range stream.Spec.Tags {
-			if tag.Name == "cli" {
-				return true, nil
-			}
-		}
-		logrus.Debugf("CLI tag has not shown up in the spec of imagestream %s/%s, waiting ...", stream.Namespace, stream.Name)
-		return false, nil
-	}
-	return kubernetes.WaitForConditionOnObject(ctx, client, ctrlruntimeclient.ObjectKey{Namespace: namespace, Name: streamName}, &imagev1.ImageStreamList{}, imageStream, evaluate, timeout)
 }
 
 func (s *importReleaseStep) getCLIImage(ctx context.Context, target, streamName string) (*api.ImageStreamTagReference, error) {

--- a/pkg/steps/release/import_release_test.go
+++ b/pkg/steps/release/import_release_test.go
@@ -174,12 +174,17 @@ func (c *releaseImportGuardClient) Watch(ctx context.Context, list ctrlruntimecl
 		Name: "cli",
 		From: &corev1.ObjectReference{Kind: "DockerImage", Name: testCLIImage},
 	}}
-	stream.Status.Tags = []imagev1.NamedTagEventList{{
-		Tag: "cli",
-		Items: []imagev1.TagEvent{{
-			DockerImageReference: "quay.io/test/cli@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-		}},
-	}}
+	// Reveal import status only after a separate watch has exposed the spec tag.
+	// Without the production spec-visibility guard, the import wait sees only
+	// this first spec-only event and the direct regression tests time out.
+	if c.imageStreamWatchCount > 1 {
+		stream.Status.Tags = []imagev1.NamedTagEventList{{
+			Tag: "cli",
+			Items: []imagev1.TagEvent{{
+				DockerImageReference: "quay.io/test/cli@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			}},
+		}}
+	}
 	if err := c.FakePodExecutor.LoggingClient.Update(ctx, stream); err != nil {
 		return nil, err
 	}

--- a/pkg/steps/release/import_release_test.go
+++ b/pkg/steps/release/import_release_test.go
@@ -1,0 +1,225 @@
+package release
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	imagev1 "github.com/openshift/api/image/v1"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/steps/loggingclient"
+	testhelperkube "github.com/openshift/ci-tools/pkg/testhelper/kubernetes"
+)
+
+const testCLIImage = "quay.io/test/cli:latest"
+
+func TestWaitForCLIImageTagInSpec(t *testing.T) {
+	const (
+		namespace  = "test-namespace"
+		streamName = "stable-initial"
+	)
+
+	t.Run("waits for CLI tag to become visible", func(t *testing.T) {
+		client := newReleaseImportGuardClient(t, namespace, streamName, &imagev1.ImageStream{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: streamName},
+		})
+
+		if err := waitForCLIImageTagInSpec(context.Background(), client, namespace, streamName, time.Second); err != nil {
+			t.Fatalf("wait for CLI tag in spec: %v", err)
+		}
+		if client.imageStreamWatchCount == 0 {
+			t.Fatal("expected an ImageStream watch before the CLI tag became visible")
+		}
+	})
+
+	t.Run("returns a bounded timeout when CLI tag remains absent", func(t *testing.T) {
+		client := newImageStreamFakeClient(t, &imagev1.ImageStream{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: streamName},
+		})
+
+		err := waitForCLIImageTagInSpec(context.Background(), client, namespace, streamName, 100*time.Millisecond)
+		if err == nil {
+			t.Fatal("expected timeout while CLI tag remains absent")
+		}
+		if !strings.Contains(err.Error(), "timed out waiting for the condition") {
+			t.Fatalf("expected bounded wait timeout, got: %v", err)
+		}
+	})
+}
+
+func TestResolveCLIImageFromStreamWaitsForSpecVisibility(t *testing.T) {
+	const (
+		namespace  = "test-namespace"
+		streamName = "stable-initial"
+	)
+	client := newReleaseImportGuardClient(t, namespace, streamName,
+		&imagev1.ImageStream{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: streamName}},
+		&imagev1.ImageStreamTag{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: streamName + ":cli"},
+			Tag: &imagev1.TagReference{From: &corev1.ObjectReference{
+				Kind: "DockerImage",
+				Name: testCLIImage,
+			}},
+		},
+	)
+	jobSpec := &api.JobSpec{}
+	jobSpec.SetNamespace(namespace)
+	step := &importReleaseStep{client: client, jobSpec: jobSpec}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	got, err := step.resolveCLIImageFromStream(ctx, streamName)
+	if err != nil {
+		t.Fatalf("resolve CLI image from stream: %v", err)
+	}
+	assertTestCLIReference(t, got)
+	if client.imageStreamWatchCount == 0 {
+		t.Fatal("expected resolveCLIImageFromStream to wait for CLI spec visibility")
+	}
+}
+
+func TestExtractAndTagCLIImageWaitsForSpecVisibility(t *testing.T) {
+	const (
+		namespace  = "test-namespace"
+		streamName = "stable"
+		targetCLI  = "release-images-latest-cli"
+	)
+	client := newReleaseImportGuardClient(t, namespace, streamName,
+		&imagev1.ImageStream{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: streamName}},
+		&imagev1.ImageStreamTag{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: streamName + ":cli"}},
+	)
+	jobSpec := &api.JobSpec{}
+	jobSpec.SetNamespace(namespace)
+	step := &importReleaseStep{name: api.LatestReleaseName, client: client, jobSpec: jobSpec}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	got, err := step.extractAndTagCLIImage(ctx, targetCLI, streamName)
+	if err != nil {
+		t.Fatalf("extract and tag CLI image: %v", err)
+	}
+	assertTestCLIReference(t, got)
+	if client.imageStreamWatchCount == 0 {
+		t.Fatal("expected extractAndTagCLIImage to wait for CLI spec visibility")
+	}
+	if len(client.CreatedPods) != 1 || client.CreatedPods[0].Name != targetCLI {
+		t.Fatalf("expected CLI extractor pod %q to be created, got %#v", targetCLI, client.CreatedPods)
+	}
+}
+
+func assertTestCLIReference(t *testing.T, ref *api.ImageStreamTagReference) {
+	t.Helper()
+	if ref == nil {
+		t.Fatal("expected a CLI image reference, got nil")
+	}
+	if ref.Name != "quay.io/test/cli" || ref.Tag != "latest" {
+		t.Fatalf("unexpected CLI image reference: %#v", ref)
+	}
+}
+
+type releaseImportGuardClient struct {
+	*testhelperkube.FakePodClient
+	namespace             string
+	streamName            string
+	imageStreamWatchCount int
+}
+
+func (c *releaseImportGuardClient) Create(ctx context.Context, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.CreateOption) error {
+	if pod, ok := obj.(*corev1.Pod); ok && len(pod.Spec.Containers) > 0 {
+		pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+			Name: pod.Spec.Containers[0].Name,
+			State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+				Message: testCLIImage,
+			}},
+		}}
+	}
+	return c.FakePodExecutor.Create(ctx, obj, opts...)
+}
+
+func (c *releaseImportGuardClient) Update(ctx context.Context, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.UpdateOption) error {
+	if streamTag, ok := obj.(*imagev1.ImageStreamTag); ok && streamTag.ResourceVersion == "" {
+		existing := &imagev1.ImageStreamTag{}
+		if err := c.FakePodExecutor.LoggingClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(streamTag), existing); err != nil {
+			return err
+		}
+		streamTag.ResourceVersion = existing.ResourceVersion
+	}
+	return c.FakePodExecutor.LoggingClient.Update(ctx, obj, opts...)
+}
+
+func (c *releaseImportGuardClient) Watch(ctx context.Context, list ctrlruntimeclient.ObjectList, opts ...ctrlruntimeclient.ListOption) (watch.Interface, error) {
+	if _, ok := list.(*corev1.PodList); ok {
+		return c.FakePodExecutor.Watch(ctx, list, opts...)
+	}
+	if _, ok := list.(*imagev1.ImageStreamList); !ok {
+		return c.FakePodExecutor.LoggingClient.Watch(ctx, list, opts...)
+	}
+
+	c.imageStreamWatchCount++
+	stream := &imagev1.ImageStream{}
+	key := ctrlruntimeclient.ObjectKey{Namespace: c.namespace, Name: c.streamName}
+	if err := c.FakePodExecutor.LoggingClient.Get(ctx, key, stream); err != nil {
+		return nil, err
+	}
+	stream.Spec.Tags = []imagev1.TagReference{{
+		Name: "cli",
+		From: &corev1.ObjectReference{Kind: "DockerImage", Name: testCLIImage},
+	}}
+	stream.Status.Tags = []imagev1.NamedTagEventList{{
+		Tag: "cli",
+		Items: []imagev1.TagEvent{{
+			DockerImageReference: "quay.io/test/cli@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		}},
+	}}
+	if err := c.FakePodExecutor.LoggingClient.Update(ctx, stream); err != nil {
+		return nil, err
+	}
+	events := make(chan watch.Event, 1)
+	events <- watch.Event{Type: watch.Modified, Object: stream.DeepCopy()}
+	return watch.NewProxyWatcher(events), nil
+}
+
+func newReleaseImportGuardClient(t *testing.T, namespace, streamName string, objects ...runtime.Object) *releaseImportGuardClient {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core API to scheme: %v", err)
+	}
+	if err := imagev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add image API to scheme: %v", err)
+	}
+	loggingClient := loggingclient.New(fakectrlruntimeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(objects...).
+		WithIndex(&corev1.Pod{}, "metadata.name", func(obj ctrlruntimeclient.Object) []string { return []string{obj.GetName()} }).
+		Build(), nil)
+	return &releaseImportGuardClient{
+		FakePodClient: &testhelperkube.FakePodClient{
+			FakePodExecutor: &testhelperkube.FakePodExecutor{
+				LoggingClient: loggingClient,
+				AutoSchedule:  true,
+			},
+			PendingTimeout: time.Minute,
+		},
+		namespace:  namespace,
+		streamName: streamName,
+	}
+}
+
+func newImageStreamFakeClient(t *testing.T, objects ...runtime.Object) ctrlruntimeclient.WithWatch {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := imagev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add image API to scheme: %v", err)
+	}
+	return fakectrlruntimeclient.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
+}

--- a/pkg/steps/release/import_release_test.go
+++ b/pkg/steps/release/import_release_test.go
@@ -2,7 +2,6 @@ package release
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -21,40 +20,6 @@ import (
 )
 
 const testCLIImage = "quay.io/test/cli:latest"
-
-func TestWaitForCLIImageTagInSpec(t *testing.T) {
-	const (
-		namespace  = "test-namespace"
-		streamName = "stable-initial"
-	)
-
-	t.Run("waits for CLI tag to become visible", func(t *testing.T) {
-		client := newReleaseImportGuardClient(t, namespace, streamName, &imagev1.ImageStream{
-			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: streamName},
-		})
-
-		if err := waitForCLIImageTagInSpec(context.Background(), client, namespace, streamName, time.Second); err != nil {
-			t.Fatalf("wait for CLI tag in spec: %v", err)
-		}
-		if client.imageStreamWatchCount == 0 {
-			t.Fatal("expected an ImageStream watch before the CLI tag became visible")
-		}
-	})
-
-	t.Run("returns a bounded timeout when CLI tag remains absent", func(t *testing.T) {
-		client := newImageStreamFakeClient(t, &imagev1.ImageStream{
-			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: streamName},
-		})
-
-		err := waitForCLIImageTagInSpec(context.Background(), client, namespace, streamName, 100*time.Millisecond)
-		if err == nil {
-			t.Fatal("expected timeout while CLI tag remains absent")
-		}
-		if !strings.Contains(err.Error(), "timed out waiting for the condition") {
-			t.Fatalf("expected bounded wait timeout, got: %v", err)
-		}
-	})
-}
 
 func TestResolveCLIImageFromStreamWaitsForSpecVisibility(t *testing.T) {
 	const (
@@ -82,8 +47,8 @@ func TestResolveCLIImageFromStreamWaitsForSpecVisibility(t *testing.T) {
 		t.Fatalf("resolve CLI image from stream: %v", err)
 	}
 	assertTestCLIReference(t, got)
-	if client.imageStreamWatchCount == 0 {
-		t.Fatal("expected resolveCLIImageFromStream to wait for CLI spec visibility")
+	if client.imageStreamWatchCount != 1 {
+		t.Fatalf("expected the shared import wait to use one ImageStream watch, got %d", client.imageStreamWatchCount)
 	}
 }
 
@@ -108,8 +73,8 @@ func TestExtractAndTagCLIImageWaitsForSpecVisibility(t *testing.T) {
 		t.Fatalf("extract and tag CLI image: %v", err)
 	}
 	assertTestCLIReference(t, got)
-	if client.imageStreamWatchCount == 0 {
-		t.Fatal("expected extractAndTagCLIImage to wait for CLI spec visibility")
+	if client.imageStreamWatchCount != 1 {
+		t.Fatalf("expected the shared import wait to use one ImageStream watch, got %d", client.imageStreamWatchCount)
 	}
 	if len(client.CreatedPods) != 1 || client.CreatedPods[0].Name != targetCLI {
 		t.Fatalf("expected CLI extractor pod %q to be created, got %#v", targetCLI, client.CreatedPods)
@@ -174,21 +139,21 @@ func (c *releaseImportGuardClient) Watch(ctx context.Context, list ctrlruntimecl
 		Name: "cli",
 		From: &corev1.ObjectReference{Kind: "DockerImage", Name: testCLIImage},
 	}}
-	// Reveal import status only after a separate watch has exposed the spec tag.
-	// Without the production spec-visibility guard, the import wait sees only
-	// this first spec-only event and the direct regression tests time out.
-	if c.imageStreamWatchCount > 1 {
-		stream.Status.Tags = []imagev1.NamedTagEventList{{
-			Tag: "cli",
-			Items: []imagev1.TagEvent{{
-				DockerImageReference: "quay.io/test/cli@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-			}},
-		}}
-	}
+	specOnly := stream.DeepCopy()
+	stream.Status.Tags = []imagev1.NamedTagEventList{{
+		Tag: "cli",
+		Items: []imagev1.TagEvent{{
+			DockerImageReference: "quay.io/test/cli@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		}},
+	}}
 	if err := c.FakePodExecutor.LoggingClient.Update(ctx, stream); err != nil {
 		return nil, err
 	}
-	events := make(chan watch.Event, 1)
+	// The first event exposes the spec tag; the second exposes import status.
+	// Without the spec-aware shared evaluator, the initial empty list fails
+	// before this watch can be established.
+	events := make(chan watch.Event, 2)
+	events <- watch.Event{Type: watch.Modified, Object: specOnly}
 	events <- watch.Event{Type: watch.Modified, Object: stream.DeepCopy()}
 	return watch.NewProxyWatcher(events), nil
 }
@@ -218,13 +183,4 @@ func newReleaseImportGuardClient(t *testing.T, namespace, streamName string, obj
 		namespace:  namespace,
 		streamName: streamName,
 	}
-}
-
-func newImageStreamFakeClient(t *testing.T, objects ...runtime.Object) ctrlruntimeclient.WithWatch {
-	t.Helper()
-	scheme := runtime.NewScheme()
-	if err := imagev1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add image API to scheme: %v", err)
-	}
-	return fakectrlruntimeclient.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
 }

--- a/pkg/steps/utils/image.go
+++ b/pkg/steps/utils/image.go
@@ -253,17 +253,13 @@ func WaitForImportingISTag(ctx context.Context, client ctrlruntimeclient.WithWat
 	for _, optionFn := range optionFns {
 		optionFn(&options)
 	}
-	return waitForImportingISTag(ctx, client, ns, name, into, tags, options.waitForSpecTags, timeout, metricsAgent)
-}
-
-func waitForImportingISTag(ctx context.Context, client ctrlruntimeclient.WithWatch, ns, name string, into *imagev1.ImageStream, tags sets.Set[string], waitForSpecTags bool, timeout time.Duration, metricsAgent *metrics.MetricsAgent) error {
 	startTime := time.Now()
 
 	obj := into
 	if obj == nil {
 		obj = &imagev1.ImageStream{}
 	}
-	err := kubernetes.WaitForConditionOnObject(ctx, client, ctrlruntimeclient.ObjectKey{Namespace: ns, Name: name}, &imagev1.ImageStreamList{}, obj, getEvaluator(ctx, client, ns, name, tags, waitForSpecTags, metricsAgent), timeout)
+	err := kubernetes.WaitForConditionOnObject(ctx, client, ctrlruntimeclient.ObjectKey{Namespace: ns, Name: name}, &imagev1.ImageStreamList{}, obj, getEvaluator(ctx, client, ns, name, tags, options.waitForSpecTags, metricsAgent), timeout)
 
 	completionTime := time.Now()
 	duration := completionTime.Sub(startTime)

--- a/pkg/steps/utils/image.go
+++ b/pkg/steps/utils/image.go
@@ -180,7 +180,7 @@ func FindStatusTag(is *imagev1.ImageStream, tag string) (*coreapi.ObjectReferenc
 
 const DefaultImageImportTimeout = 45 * time.Minute
 
-func getEvaluator(ctx context.Context, client ctrlruntimeclient.Client, ns, name string, tags sets.Set[string], metricsAgent *metrics.MetricsAgent) func(obj runtime.Object) (bool, error) {
+func getEvaluator(ctx context.Context, client ctrlruntimeclient.Client, ns, name string, tags sets.Set[string], waitForSpecTags bool, metricsAgent *metrics.MetricsAgent) func(obj runtime.Object) (bool, error) {
 	return func(obj runtime.Object) (bool, error) {
 		switch stream := obj.(type) {
 		case *imagev1.ImageStream:
@@ -219,6 +219,10 @@ func getEvaluator(ctx context.Context, client ctrlruntimeclient.Client, ns, name
 			if diff := tags.Difference(checkedTags); diff.Len() > 0 {
 				l := diff.UnsortedList()
 				sort.Strings(l)
+				if waitForSpecTags {
+					logrus.Debugf("Waiting for tag definition(s) [%s] on image stream %s/%s ...", strings.Join(l, ","), stream.Namespace, stream.Name)
+					return false, nil
+				}
 				return false, fmt.Errorf("failed to import tag(s) [%s] on image stream %s/%s because of missing definition in the spec", strings.Join(l, ","), stream.Namespace, stream.Name)
 			}
 			return true, nil
@@ -230,13 +234,24 @@ func getEvaluator(ctx context.Context, client ctrlruntimeclient.Client, ns, name
 
 // WaitForImportingISTag waits for the tags on the image stream are imported
 func WaitForImportingISTag(ctx context.Context, client ctrlruntimeclient.WithWatch, ns, name string, into *imagev1.ImageStream, tags sets.Set[string], timeout time.Duration, metricsAgent *metrics.MetricsAgent) error {
+	return waitForImportingISTag(ctx, client, ns, name, into, tags, false, timeout, metricsAgent)
+}
+
+// WaitForImportingISTagWithSpecVisibility waits for requested tags to appear in
+// the image stream spec before checking their import status. The supplied
+// timeout bounds both spec visibility and import completion.
+func WaitForImportingISTagWithSpecVisibility(ctx context.Context, client ctrlruntimeclient.WithWatch, ns, name string, into *imagev1.ImageStream, tags sets.Set[string], timeout time.Duration, metricsAgent *metrics.MetricsAgent) error {
+	return waitForImportingISTag(ctx, client, ns, name, into, tags, true, timeout, metricsAgent)
+}
+
+func waitForImportingISTag(ctx context.Context, client ctrlruntimeclient.WithWatch, ns, name string, into *imagev1.ImageStream, tags sets.Set[string], waitForSpecTags bool, timeout time.Duration, metricsAgent *metrics.MetricsAgent) error {
 	startTime := time.Now()
 
 	obj := into
 	if obj == nil {
 		obj = &imagev1.ImageStream{}
 	}
-	err := kubernetes.WaitForConditionOnObject(ctx, client, ctrlruntimeclient.ObjectKey{Namespace: ns, Name: name}, &imagev1.ImageStreamList{}, obj, getEvaluator(ctx, client, ns, name, tags, metricsAgent), timeout)
+	err := kubernetes.WaitForConditionOnObject(ctx, client, ctrlruntimeclient.ObjectKey{Namespace: ns, Name: name}, &imagev1.ImageStreamList{}, obj, getEvaluator(ctx, client, ns, name, tags, waitForSpecTags, metricsAgent), timeout)
 
 	completionTime := time.Now()
 	duration := completionTime.Sub(startTime)

--- a/pkg/steps/utils/image.go
+++ b/pkg/steps/utils/image.go
@@ -232,16 +232,28 @@ func getEvaluator(ctx context.Context, client ctrlruntimeclient.Client, ns, name
 	}
 }
 
-// WaitForImportingISTag waits for the tags on the image stream are imported
-func WaitForImportingISTag(ctx context.Context, client ctrlruntimeclient.WithWatch, ns, name string, into *imagev1.ImageStream, tags sets.Set[string], timeout time.Duration, metricsAgent *metrics.MetricsAgent) error {
-	return waitForImportingISTag(ctx, client, ns, name, into, tags, false, timeout, metricsAgent)
+type importWaitOptions struct {
+	waitForSpecTags bool
 }
 
-// WaitForImportingISTagWithSpecVisibility waits for requested tags to appear in
-// the image stream spec before checking their import status. The supplied
-// timeout bounds both spec visibility and import completion.
-func WaitForImportingISTagWithSpecVisibility(ctx context.Context, client ctrlruntimeclient.WithWatch, ns, name string, into *imagev1.ImageStream, tags sets.Set[string], timeout time.Duration, metricsAgent *metrics.MetricsAgent) error {
-	return waitForImportingISTag(ctx, client, ns, name, into, tags, true, timeout, metricsAgent)
+// ImportWaitOption configures an image stream tag import wait.
+type ImportWaitOption func(*importWaitOptions)
+
+// WaitForSpecTags keeps watching when requested tags are not yet visible in
+// the image stream spec. The import timeout also bounds spec visibility.
+func WaitForSpecTags() ImportWaitOption {
+	return func(options *importWaitOptions) {
+		options.waitForSpecTags = true
+	}
+}
+
+// WaitForImportingISTag waits for the tags on the image stream are imported.
+func WaitForImportingISTag(ctx context.Context, client ctrlruntimeclient.WithWatch, ns, name string, into *imagev1.ImageStream, tags sets.Set[string], timeout time.Duration, metricsAgent *metrics.MetricsAgent, optionFns ...ImportWaitOption) error {
+	options := importWaitOptions{}
+	for _, optionFn := range optionFns {
+		optionFn(&options)
+	}
+	return waitForImportingISTag(ctx, client, ns, name, into, tags, options.waitForSpecTags, timeout, metricsAgent)
 }
 
 func waitForImportingISTag(ctx context.Context, client ctrlruntimeclient.WithWatch, ns, name string, into *imagev1.ImageStream, tags sets.Set[string], waitForSpecTags bool, timeout time.Duration, metricsAgent *metrics.MetricsAgent) error {

--- a/pkg/steps/utils/image_test.go
+++ b/pkg/steps/utils/image_test.go
@@ -664,7 +664,7 @@ func TestGetEvaluator(t *testing.T) {
 	}
 }
 
-func TestWaitForImportingISTagWithSpecVisibilityTimesOut(t *testing.T) {
+func TestWaitForImportingISTagSpecTimeout(t *testing.T) {
 	const (
 		namespace  = "test-namespace"
 		streamName = "stable"
@@ -673,7 +673,7 @@ func TestWaitForImportingISTagWithSpecVisibilityTimesOut(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: streamName},
 	}).Build()
 
-	err := WaitForImportingISTagWithSpecVisibility(context.Background(), client, namespace, streamName, nil, sets.New("cli"), 100*time.Millisecond, nil)
+	err := WaitForImportingISTag(context.Background(), client, namespace, streamName, nil, sets.New("cli"), 100*time.Millisecond, nil, WaitForSpecTags())
 	if err == nil {
 		t.Fatal("expected timeout while the requested tag remains absent from the spec")
 	}

--- a/pkg/steps/utils/image_test.go
+++ b/pkg/steps/utils/image_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -323,13 +324,14 @@ func (client *imageStreamImportStatusSettingClient) Create(ctx context.Context, 
 
 func TestGetEvaluator(t *testing.T) {
 	var testCases = []struct {
-		name          string
-		client        ctrlruntimeclient.Client
-		obj           *imagev1.ImageStream
-		tags          sets.Set[string]
-		expected      bool
-		expectedErr   error
-		expectedCount int
+		name            string
+		client          ctrlruntimeclient.Client
+		obj             *imagev1.ImageStream
+		tags            sets.Set[string]
+		waitForSpecTags bool
+		expected        bool
+		expectedErr     error
+		expectedCount   int
 	}{
 		{
 			name:   "happy path",
@@ -617,10 +619,33 @@ func TestGetEvaluator(t *testing.T) {
 			expected:    false,
 			expectedErr: fmt.Errorf("failed to import tag(s) [m-tag1,m-tag2] on image stream imported/is because of missing definition in the spec"),
 		},
+		{
+			name:   "wait for requested tag not yet visible in spec",
+			client: bcc(fakectrlruntimeclient.NewClientBuilder().Build()),
+			obj: &imagev1.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "is",
+					Namespace: "imported",
+				},
+				Spec: imagev1.ImageStreamSpec{
+					Tags: []imagev1.TagReference{{Name: "tag1"}},
+				},
+				Status: imagev1.ImageStreamStatus{
+					PublicDockerImageRepository: "registry",
+					Tags: []imagev1.NamedTagEventList{{
+						Tag:   "tag1",
+						Items: []imagev1.TagEvent{{Image: "some"}},
+					}},
+				},
+			},
+			tags:            sets.New[string]("tag1", "cli"),
+			waitForSpecTags: true,
+			expected:        false,
+		},
 	}
 
 	for _, testCase := range testCases {
-		e := getEvaluator(context.Background(), testCase.client, testCase.obj.Namespace, testCase.obj.Name, testCase.tags, nil)
+		e := getEvaluator(context.Background(), testCase.client, testCase.obj.Namespace, testCase.obj.Name, testCase.tags, testCase.waitForSpecTags, nil)
 		actual, actualErr := e(testCase.obj)
 		if diff := cmp.Diff(testCase.expectedErr, actualErr, testhelper.EquateErrorMessage); diff != "" {
 			t.Errorf("%s: actualErr does not match expectedErr, diff: %s", testCase.name, diff)
@@ -636,6 +661,24 @@ func TestGetEvaluator(t *testing.T) {
 				t.Errorf("%s: actual does not match expected, diff: %s", testCase.name, diff)
 			}
 		}
+	}
+}
+
+func TestWaitForImportingISTagWithSpecVisibilityTimesOut(t *testing.T) {
+	const (
+		namespace  = "test-namespace"
+		streamName = "stable"
+	)
+	client := fakectrlruntimeclient.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(&imagev1.ImageStream{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: streamName},
+	}).Build()
+
+	err := WaitForImportingISTagWithSpecVisibility(context.Background(), client, namespace, streamName, nil, sets.New("cli"), 100*time.Millisecond, nil)
+	if err == nil {
+		t.Fatal("expected timeout while the requested tag remains absent from the spec")
+	}
+	if !strings.Contains(err.Error(), "timed out waiting for the condition") {
+		t.Fatalf("expected bounded wait timeout, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## What changed

- extend the shared ImageStream import evaluator with opt-in waiting for requested tags to appear in `spec.tags`
- use that mode in both release CLI resolution paths
- keep the existing ten-minute bound and preserve immediate missing-tag errors for callers that do not opt in
- add direct regression coverage for the evaluator, both call sites, and the timeout path

## Why

An ImageStreamTag update can complete before the parent ImageStream observation contains `spec.tags[cli]`. The shared import evaluator treated that temporary absence as terminal, so release jobs could fail before cluster installation.

The retained OpenShift 5.0 CI corpus contains 37 exact failures with this `[cli]` signature. Seven occurred from July 26 through July 30 across Azure and GCP jobs, stable and stable-initial streams, nightly and CI payloads, and three ci-operator versions. In the confirmed target run, the CLI extractor succeeded and the final ImageStream contained a populated CLI spec and status entry, but the initial release graph had already failed.

## Impact

CLI resolution now keeps watching through temporary spec visibility lag. Persistent missing tags and incomplete imports still fail within the existing ten-minute timeout. Other import-wait callers retain their current immediate missing-definition behavior.

## Validation

- `go test -p 1 ./pkg/steps/utils -run '^(TestGetEvaluator|TestWaitForImportingISTagSpecTimeout)$' -count=1 -v`
- `go test -p 1 ./pkg/steps/release -run '^(TestResolveCLIImageFromStreamWaitsForSpecVisibility|TestExtractAndTagCLIImageWaitsForSpecVisibility)$' -count=1 -v`
- `go test -p 1 ./pkg/steps/utils ./pkg/steps/release -count=1`
- `gofmt`
- `git diff --check`

The call-site tests model spec visibility and import status as separate events on one watch. Removing the `WaitForSpecTags` option fails on the original `missing definition in the spec` path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

The release CLI now optionally waits for requested tags to appear in an ImageStream’s `spec.tags` before it evaluates import status.

Both release image-resolution paths use this wait mode. Existing callers still fail immediately when a requested tag is missing. The existing ten-minute timeout remains in effect for missing tags and incomplete imports.

This prevents failures caused by temporary ImageStream observation lag in CI release workflows.

## Testing

- Added regression tests for both release CLI resolution paths.
- Added timeout coverage for persistently missing spec tags.
- Ran targeted and package tests.
- Ran `gofmt` and `git diff --check`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->