### PR TITLE
NO-JIRA: report unfinished aggregated jobs correctly

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
@@ -167,8 +167,8 @@ func (o *JobRunAggregatorAnalyzerOptions) Run(ctx context.Context) error {
 		if len(o.explicitGCSPrefix) > 0 {
 			jobRunGCSBucketRoot = filepath.Join(o.explicitGCSPrefix, jobRunName)
 		}
-		aggregationConfiguration.FinishedJobs = append(
-			aggregationConfiguration.FinishedJobs,
+		aggregationConfiguration.UnfinishedJobs = append(
+			aggregationConfiguration.UnfinishedJobs,
 			JobRunInfo{
 				JobName:      o.jobName,
 				JobRunID:     jobRunName,

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_test.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_test.go
@@ -6,11 +6,13 @@ import (
 	"encoding/xml"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
+	"gopkg.in/yaml.v2"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakeclock "k8s.io/utils/clock/testing"
@@ -68,9 +70,11 @@ func TestAnalyzer(t *testing.T) {
 	}
 
 	tests := []struct {
-		name              string
-		jobRunInfos       []jobrunaggregatorapi.JobRunInfo
-		expectErrContains string
+		name                   string
+		jobRunInfos            []jobrunaggregatorapi.JobRunInfo
+		expectErrContains      string
+		expectedFinishedJobs   int
+		expectedUnfinishedJobs int
 	}{
 		{
 			name: "no jobs finished",
@@ -106,7 +110,15 @@ func TestAnalyzer(t *testing.T) {
 					},
 				},
 			}),
-			expectErrContains: "",
+			expectErrContains:    "",
+			expectedFinishedJobs: 10,
+		},
+		{
+			name:                   "tolerated unfinished jobs are reported as unfinished",
+			jobRunInfos:            buildJobRunInfosWithFinishedCount(mockCtrl, payloadStartTime, historicalDisruption, 7),
+			expectErrContains:      "Some tests failed aggregation",
+			expectedFinishedJobs:   7,
+			expectedUnfinishedJobs: 3,
 		},
 		{
 			name: "too much disruption",
@@ -152,7 +164,8 @@ func TestAnalyzer(t *testing.T) {
 					},
 				},
 			}),
-			expectErrContains: "",
+			expectErrContains:    "",
+			expectedFinishedJobs: 10,
 		},
 	}
 	for _, tc := range tests {
@@ -215,12 +228,25 @@ func TestAnalyzer(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+
+			if tc.expectedFinishedJobs > 0 || tc.expectedUnfinishedJobs > 0 {
+				aggregationConfigData, readErr := os.ReadFile(filepath.Join(workDir, testJobName, testPayloadtag, "aggregation-config.yaml"))
+				assert.NoError(t, readErr)
+				aggregationConfig := &AggregationConfiguration{}
+				assert.NoError(t, yaml.Unmarshal(aggregationConfigData, aggregationConfig))
+				assert.Len(t, aggregationConfig.FinishedJobs, tc.expectedFinishedJobs)
+				assert.Len(t, aggregationConfig.UnfinishedJobs, tc.expectedUnfinishedJobs)
+			}
 		})
 	}
 
 }
 
 func buildJobRunInfos(mockCtrl *gomock.Controller, payloadStartTime time.Time, disruption jobrunaggregatorlib.BackendDisruptionList) []jobrunaggregatorapi.JobRunInfo {
+	return buildJobRunInfosWithFinishedCount(mockCtrl, payloadStartTime, disruption, 10)
+}
+
+func buildJobRunInfosWithFinishedCount(mockCtrl *gomock.Controller, payloadStartTime time.Time, disruption jobrunaggregatorlib.BackendDisruptionList, finishedCount int) []jobrunaggregatorapi.JobRunInfo {
 	backendDisruptionJSON, _ := json.Marshal(disruption)
 	openshiftFiles := map[string]string{
 		"0": string(backendDisruptionJSON),
@@ -229,18 +255,11 @@ func buildJobRunInfos(mockCtrl *gomock.Controller, payloadStartTime time.Time, d
 <testsuite tests="1" failures="0" time="1983" name="BackendDisruption">
 </testsuite>
 </testsuites>`
-	return []jobrunaggregatorapi.JobRunInfo{
-		buildFakeJobRunInfo(mockCtrl, "1001", payloadStartTime, true, junitXML, openshiftFiles),
-		buildFakeJobRunInfo(mockCtrl, "1002", payloadStartTime, true, junitXML, openshiftFiles),
-		buildFakeJobRunInfo(mockCtrl, "1003", payloadStartTime, true, junitXML, openshiftFiles),
-		buildFakeJobRunInfo(mockCtrl, "1004", payloadStartTime, true, junitXML, openshiftFiles),
-		buildFakeJobRunInfo(mockCtrl, "1005", payloadStartTime, true, junitXML, openshiftFiles),
-		buildFakeJobRunInfo(mockCtrl, "1006", payloadStartTime, true, junitXML, openshiftFiles),
-		buildFakeJobRunInfo(mockCtrl, "1007", payloadStartTime, true, junitXML, openshiftFiles),
-		buildFakeJobRunInfo(mockCtrl, "1008", payloadStartTime, true, junitXML, openshiftFiles),
-		buildFakeJobRunInfo(mockCtrl, "1009", payloadStartTime, true, junitXML, openshiftFiles),
-		buildFakeJobRunInfo(mockCtrl, "1010", payloadStartTime, true, junitXML, openshiftFiles),
+	jobRunInfos := make([]jobrunaggregatorapi.JobRunInfo, 0, 10)
+	for i := 1; i <= 10; i++ {
+		jobRunInfos = append(jobRunInfos, buildFakeJobRunInfo(mockCtrl, fmt.Sprintf("10%02d", i), payloadStartTime, i <= finishedCount, junitXML, openshiftFiles))
 	}
+	return jobRunInfos
 }
 
 func buildFakeJobRunInfo(mockCtrl *gomock.Controller,


### PR DESCRIPTION
A tolerated unfinished Prow job is currently appended to `AggregationConfiguration.FinishedJobs`, even though the result type has a dedicated `UnfinishedJobs` field. This makes `aggregation-config.yaml` report an unknown/incomplete child as finished precisely when downstream analysis needs an accurate child manifest.

This changes the assignment to `UnfinishedJobs` and adds regression coverage for the supported 7-finished/3-unfinished case, while preserving the existing terminal aggregate verdict for missing data.

Study context: an exact reconciliation of 570 OpenShift 5.0 aggregate parents found 95 parents with shared missing-data cascades. This PR intentionally does not change gating or claim green-job rescue; it corrects the machine-readable attribution boundary needed for follow-up missing-data collapse work.

Validation:
- `GOMAXPROCS=2 go test -p=2 ./pkg/jobrunaggregator/jobrunaggregatoranalyzer`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Record tolerated unfinished Prow jobs in `AggregationConfiguration.UnfinishedJobs` instead of `FinishedJobs`.
- Preserve the terminal aggregate verdict when job data is missing.
- Add regression coverage for seven finished and three unfinished jobs.
- Do not change gating or green-job rescue behavior.

## Validation

- Targeted Go tests
- `git diff --check`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->