### PR TITLE
Konflux: Expose the `ephemeralclusters` metric

### DIFF
--- a/cmd/dptp-controller-manager/main.go
+++ b/cmd/dptp-controller-manager/main.go
@@ -117,10 +117,12 @@ type serviceAccountSecretRefresherOptions struct {
 }
 
 type ephemeralClusterProvisionerOptions struct {
-	pollingRaw        string
-	polling           time.Duration
-	cliISTagRef       string
-	privilegedTenants flagutil.Strings
+	pollingRaw         string
+	polling            time.Duration
+	cliISTagRef        string
+	privilegedTenants  flagutil.Strings
+	metricsIntervalRaw string
+	metricsInterval    time.Duration
 }
 
 func newOpts() (*options, error) {
@@ -152,6 +154,7 @@ func newOpts() (*options, error) {
 	fs.StringVar(&opts.ephemeralClusterProvisinerOptions.pollingRaw, "ephemeralClusterProvisionerOptions.polling", "1m", "Set how often the reconciler checks for the ephemeral cluster before it gets provisioned.")
 	fs.StringVar(&opts.ephemeralClusterProvisinerOptions.cliISTagRef, "ephemeralClusterProvisionerOptions.cliISTagRef", "ocp/4.21:cli", "Set the cli image into the ci-operator base images in the form of `<namespace>/<name>:<tag>`. Defaults to `ocp/4.21:cli`.")
 	fs.Var(&opts.ephemeralClusterProvisinerOptions.privilegedTenants, "ephemeralClusterProvisionerOptions.privilegedTenants", "Konflux tenants that are allowed to use any cluster profile. Can be passed multiple times.")
+	fs.StringVar(&opts.ephemeralClusterProvisinerOptions.metricsIntervalRaw, "ephemeralClusterProvisionerOptions.metricsInterval", "1m", "Set how often the reconciler synchronizes metrics.")
 	fs.BoolVar(&opts.dryRun, "dry-run", true, "Whether to run the controller-manager with dry-run")
 	fs.StringVar(&opts.releaseRepoGitSyncPath, "release-repo-git-sync-path", "", "Path to release repository dir")
 	if err := fs.Parse(os.Args[1:]); err != nil {
@@ -235,6 +238,14 @@ func newOpts() (*options, error) {
 			errs = append(errs, fmt.Errorf("--ephemeralClusterProvisionerOptions.polling is invalid: %w", err))
 		} else {
 			opts.ephemeralClusterProvisinerOptions.polling = polling
+		}
+	}
+
+	if opts.ephemeralClusterProvisinerOptions.metricsIntervalRaw != "" {
+		if metricsInterval, err := time.ParseDuration(opts.ephemeralClusterProvisinerOptions.metricsIntervalRaw); err != nil {
+			errs = append(errs, fmt.Errorf("--ephemeralClusterProvisionerOptions.metricsInterval is invalid: %w", err))
+		} else {
+			opts.ephemeralClusterProvisinerOptions.metricsInterval = metricsInterval
 		}
 	}
 
@@ -555,7 +566,8 @@ func main() {
 		if err := ephemeralcluster.AddToManager(log, mgr, allManagers, configAgent, registryAgent,
 			ephemeralcluster.WithPolling(opts.ephemeralClusterProvisinerOptions.polling),
 			ephemeralcluster.WithCLIISTagRef(opts.ephemeralClusterProvisinerOptions.cliISTagRef),
-			ephemeralcluster.WithPrivilegedTenants(opts.ephemeralClusterProvisinerOptions.privilegedTenants.Strings())); err != nil {
+			ephemeralcluster.WithPrivilegedTenants(opts.ephemeralClusterProvisinerOptions.privilegedTenants.Strings()),
+			ephemeralcluster.WithMetricsInterval(opts.ephemeralClusterProvisinerOptions.metricsInterval)); err != nil {
 			logrus.WithError(err).Fatalf("Failed to construct the %s controller", ephemeralcluster.ControllerName)
 		}
 	}

--- a/pkg/controller/ephemeralcluster/metrics.go
+++ b/pkg/controller/ephemeralcluster/metrics.go
@@ -1,0 +1,120 @@
+package ephemeralcluster
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	ephemeralclusterv1 "github.com/openshift/ci-tools/pkg/api/ephemeralcluster/v1"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	hostedManagementClusterEnvVar   = "HOSTED_MANAGEMENT_CLUSTER"
+	hypershiftHostedClusterWorkflow = "hypershift-hostedcluster-workflow"
+)
+
+func ecTotalGaugeVec() *prometheus.GaugeVec {
+	return prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ephemeralclusters",
+		Help: "The number of ephemeralclusters the controller created",
+	}, []string{"konflux_cluster", "konflux_tenant", "cluster_profile", "workflow"})
+}
+
+type metricsGatherer struct {
+	logger       *logrus.Entry
+	client       ctrlruntimeclient.Client
+	ecTotalGauge *prometheus.GaugeVec
+	ecNS         string
+	interval     time.Duration
+}
+
+func addMetricsToManager(logger *logrus.Entry, mgr manager.Manager, ecNS string, interval time.Duration) error {
+	ecTotalGauge := ecTotalGaugeVec()
+
+	if err := metrics.Registry.Register(ecTotalGauge); err != nil {
+		return fmt.Errorf("failed to register ephemeralclusters metric: %w", err)
+	}
+
+	metricsGatherer := newMetricsGatherer(logger.WithField("controller", "ephemeral_cluster_metrics"),
+		mgr.GetClient(), ecTotalGauge, ecNS, interval)
+	if err := mgr.Add(metricsGatherer); err != nil {
+		return fmt.Errorf("add metrics to manager: %w", err)
+	}
+
+	return nil
+}
+
+func (mg *metricsGatherer) Start(ctx context.Context) error {
+	ticker := time.NewTicker(mg.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			ecList := ephemeralclusterv1.EphemeralClusterList{}
+			if err := mg.client.List(ctx, &ecList, ctrlruntimeclient.InNamespace(mg.ecNS)); err != nil {
+				mg.logger.WithError(err).Error("failed to list ephemeralclusters for metrics")
+				continue
+			}
+
+			mg.collect(&ecList)
+		}
+	}
+}
+
+func (mg *metricsGatherer) collect(ecList *ephemeralclusterv1.EphemeralClusterList) {
+	ecTotal := make(map[struct {
+		konfluxCluster string
+		konfluxTenant  string
+		clusterProfile string
+		workflow       string
+	}]uint)
+
+	for i := range ecList.Items {
+		ec := &ecList.Items[i]
+
+		k := struct {
+			konfluxCluster string
+			konfluxTenant  string
+			clusterProfile string
+			workflow       string
+		}{
+			konfluxCluster: ec.KonfluxCluster(),
+			konfluxTenant:  ec.KonfluxTenant(),
+			clusterProfile: ec.Spec.CIOperator.Test.ClusterProfile,
+			workflow:       ec.Spec.CIOperator.Test.Workflow,
+		}
+
+		// This combination of workflow and env var is used mainly by Konflux users.
+		if hostedMgmt, ok := ec.Spec.CIOperator.Test.Env[hostedManagementClusterEnvVar]; ok && k.workflow == hypershiftHostedClusterWorkflow {
+			k.workflow = k.workflow + "_" + hostedMgmt
+		}
+
+		ecTotal[k]++
+	}
+
+	mg.ecTotalGauge.Reset()
+	for k, v := range ecTotal {
+		mg.ecTotalGauge.WithLabelValues(k.konfluxCluster, k.konfluxTenant, k.clusterProfile, k.workflow).Set(float64(v))
+	}
+}
+
+func (mg *metricsGatherer) NeedLeaderElection() bool { return true }
+
+func newMetricsGatherer(logger *logrus.Entry, client ctrlruntimeclient.Client, ecTotalGauge *prometheus.GaugeVec,
+	ecNS string, interval time.Duration) *metricsGatherer {
+	return &metricsGatherer{
+		logger:       logger,
+		client:       client,
+		ecTotalGauge: ecTotalGauge,
+		ecNS:         ecNS,
+		interval:     interval,
+	}
+}

--- a/pkg/controller/ephemeralcluster/metrics.go
+++ b/pkg/controller/ephemeralcluster/metrics.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"time"
 
-	ephemeralclusterv1 "github.com/openshift/ci-tools/pkg/api/ephemeralcluster/v1"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	ephemeralclusterv1 "github.com/openshift/ci-tools/pkg/api/ephemeralcluster/v1"
 )
 
 const (

--- a/pkg/controller/ephemeralcluster/metrics_test.go
+++ b/pkg/controller/ephemeralcluster/metrics_test.go
@@ -13,16 +13,18 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	ephemeralclusterv1 "github.com/openshift/ci-tools/pkg/api/ephemeralcluster/v1"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/sirupsen/logrus"
+
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
+
+	ephemeralclusterv1 "github.com/openshift/ci-tools/pkg/api/ephemeralcluster/v1"
 )
 
 type metric struct {

--- a/pkg/controller/ephemeralcluster/metrics_test.go
+++ b/pkg/controller/ephemeralcluster/metrics_test.go
@@ -1,0 +1,187 @@
+package ephemeralcluster
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+	ephemeralclusterv1 "github.com/openshift/ci-tools/pkg/api/ephemeralcluster/v1"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
+)
+
+type metric struct {
+	Labels []string
+	Value  float64
+}
+
+func ec(cluster, tenant, clusterProfile, workflow, hostedMgmtClusterEnv string) *ephemeralclusterv1.EphemeralCluster {
+	ec := ephemeralclusterv1.EphemeralCluster{
+		ObjectMeta: v1.ObjectMeta{
+			Annotations: map[string]string{
+				ephemeralclusterv1.KonfluxClusterAnnotation: cluster,
+				ephemeralclusterv1.KonfluxTenantAnnotation:  tenant,
+			},
+			Namespace: EphemeralClusterNamespace,
+			Name:      uuid.NewString(),
+		},
+		Spec: ephemeralclusterv1.EphemeralClusterSpec{
+			CIOperator: ephemeralclusterv1.CIOperatorSpec{
+				Test: ephemeralclusterv1.TestSpec{
+					ClusterProfile: clusterProfile,
+					Workflow:       workflow,
+				},
+			},
+		},
+	}
+
+	if hostedMgmtClusterEnv != "" {
+		ec.Spec.CIOperator.Test.Env = map[string]string{
+			hostedManagementClusterEnvVar: hostedMgmtClusterEnv,
+		}
+	}
+
+	return &ec
+}
+
+func collectGauge(v *prometheus.MetricVec) (result []metric, err error) {
+	metricCh := make(chan prometheus.Metric)
+	wg := sync.WaitGroup{}
+
+	wg.Go(func() {
+		for m := range metricCh {
+			dtoMetric := dto.Metric{}
+			if writeErr := m.Write(&dtoMetric); writeErr != nil {
+				err = fmt.Errorf("write gauge: %w", writeErr)
+				return
+			}
+
+			m := metric{Value: *dtoMetric.Gauge.Value}
+			for _, l := range dtoMetric.Label {
+				m.Labels = append(m.Labels, *l.Value)
+			}
+
+			result = append(result, m)
+		}
+	})
+
+	v.Collect(metricCh)
+	close(metricCh)
+	wg.Wait()
+
+	return
+}
+
+func TestStart(t *testing.T) {
+	t.Parallel()
+
+	const gatherInterval = time.Second
+	cmpMetricOpts := []cmp.Option{
+		cmpopts.SortSlices(func(a, b metric) bool {
+			aLabels := strings.Join(a.Labels, "")
+			bLabels := strings.Join(b.Labels, "")
+			return strings.Compare(aLabels, bLabels) < 0
+		}),
+		cmp.Comparer(func(a, b metric) bool {
+			sort.Strings(a.Labels)
+			sort.Strings(b.Labels)
+			aLabels := strings.Join(a.Labels, "")
+			bLabels := strings.Join(b.Labels, "")
+			return strings.Compare(aLabels, bLabels) == 0 && a.Value == b.Value
+		}),
+	}
+
+	scheme := runtime.NewScheme()
+	sb := runtime.NewSchemeBuilder(ephemeralclusterv1.AddToScheme, prowv1.AddToScheme, corev1.AddToScheme)
+	if err := sb.AddToScheme(scheme); err != nil {
+		t.Fatalf("build scheme: %s", err.Error())
+	}
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(func() { cancel() })
+
+		client := fake.NewClientBuilder().WithScheme(scheme).Build()
+		ecTotalGauge := ecTotalGaugeVec()
+
+		mg := newMetricsGatherer(logrus.NewEntry(logrus.StandardLogger()), client, ecTotalGauge,
+			EphemeralClusterNamespace, gatherInterval)
+		go func() {
+			if err := mg.Start(ctx); err != nil {
+				t.Errorf("Failed to start metrics gatherer: %s", err.Error())
+			}
+		}()
+
+		for i, round := range []struct {
+			ecs            []*ephemeralclusterv1.EphemeralCluster
+			wantMetricVals []metric
+		}{
+			{
+				ecs: []*ephemeralclusterv1.EphemeralCluster{
+					ec("stone-prd-rh01", "tp-ci-tenant", "aws", "e2e-aws-workflow", ""),
+					ec("stone-prd-rh01", "tp-ci-tenant", "aws", "e2e-aws-workflow", ""),
+					ec("stone-stg-rh01", "tp-ci-tenant-2", "aws-2", "e2e-aws-workflow", ""),
+				},
+				wantMetricVals: []metric{{
+					Labels: []string{"stone-prd-rh01", "tp-ci-tenant", "aws", "e2e-aws-workflow"},
+					Value:  2,
+				}, {
+					Labels: []string{"stone-stg-rh01", "tp-ci-tenant-2", "aws-2", "e2e-aws-workflow"},
+					Value:  1,
+				}},
+			},
+			{
+				ecs: []*ephemeralclusterv1.EphemeralCluster{
+					ec("stone-stg-rh01", "tp-ci-tenant-2", "aws-2", "e2e-aws-workflow", ""),
+					ec("stone-prd-rh01", "amisstea-tenant", "aws-konflux-prod", "hypershift-hostedcluster-workflow", "hosted-mgmt2"),
+				},
+				wantMetricVals: []metric{{
+					Labels: []string{"stone-stg-rh01", "tp-ci-tenant-2", "aws-2", "e2e-aws-workflow"},
+					Value:  1,
+				}, {
+					Labels: []string{"stone-prd-rh01", "amisstea-tenant", "aws-konflux-prod", "hypershift-hostedcluster-workflow_hosted-mgmt2"},
+					Value:  1,
+				}},
+			},
+			{},
+		} {
+			if err := client.DeleteAllOf(ctx, &ephemeralclusterv1.EphemeralCluster{},
+				ctrlruntimeclient.InNamespace(EphemeralClusterNamespace)); err != nil {
+				t.Fatalf("delete all ephemeral clusters: %s", err.Error())
+			}
+
+			for _, ec := range round.ecs {
+				if err := client.Create(ctx, ec); err != nil {
+					t.Fatalf("create ephemeral cluster: %s", err.Error())
+				}
+			}
+
+			time.Sleep(gatherInterval)
+			synctest.Wait()
+
+			gotMetrics, err := collectGauge(ecTotalGauge.MetricVec)
+			if err != nil {
+				t.Fatalf("collect gauge: %s", err.Error())
+			}
+
+			if diff := cmp.Diff(round.wantMetricVals, gotMetrics, cmpMetricOpts...); diff != "" {
+				t.Errorf("Round %d - Unexpected metric: %s\n", i, diff)
+			}
+		}
+	})
+}

--- a/pkg/controller/ephemeralcluster/reconciler.go
+++ b/pkg/controller/ephemeralcluster/reconciler.go
@@ -72,11 +72,6 @@ var (
 		},
 	}
 
-	defaultReconcilerOpts = reconcilerOptions{
-		polling:           3 * time.Second,
-		privilegedTenants: sets.New[string](),
-	}
-
 	isTagRegexp = regexp.MustCompile(`(?P<Namespace>.+)/(?P<Name>.+)\:(?P<Tag>.+)`)
 )
 
@@ -110,6 +105,7 @@ type reconcilerOptions struct {
 	polling           time.Duration
 	cliISTagRef       string
 	privilegedTenants sets.Set[string]
+	metricsInterval   time.Duration
 }
 
 type ReconcilerOption func(*reconcilerOptions)
@@ -131,6 +127,13 @@ func WithCLIISTagRef(isTagRef string) ReconcilerOption {
 func WithPrivilegedTenants(tenants []string) ReconcilerOption {
 	return func(o *reconcilerOptions) {
 		o.privilegedTenants.Insert(tenants...)
+	}
+}
+
+// WithMetricsInterval determines how often the controller reconciles metrics.
+func WithMetricsInterval(interval time.Duration) ReconcilerOption {
+	return func(o *reconcilerOptions) {
+		o.metricsInterval = interval
 	}
 }
 
@@ -181,11 +184,17 @@ func AddToManager(log *logrus.Entry, mgr manager.Manager, allManagers map[string
 		buildClients[clusterName] = clusterManager.GetClient()
 	}
 
-	for _, opt := range opts {
-		opt(&defaultReconcilerOpts)
+	reconcilerOpts := reconcilerOptions{
+		polling:           time.Minute,
+		privilegedTenants: sets.New[string](),
+		metricsInterval:   time.Minute,
 	}
 
-	cliISTagRef, err := parseCLIISTagRef(defaultReconcilerOpts.cliISTagRef)
+	for _, opt := range opts {
+		opt(&reconcilerOpts)
+	}
+
+	cliISTagRef, err := parseCLIISTagRef(reconcilerOpts.cliISTagRef)
 	if err != nil {
 		return err
 	}
@@ -199,9 +208,9 @@ func AddToManager(log *logrus.Entry, mgr manager.Manager, allManagers map[string
 		scheme:                 mgr.GetScheme(),
 		newProwJob:             pjutil.NewProwJob,
 		now:                    time.Now,
-		polling:                func() time.Duration { return defaultReconcilerOpts.polling },
+		polling:                func() time.Duration { return reconcilerOpts.polling },
 		cliISTagRef:            cliISTagRef,
-		privilegedTenants:      defaultReconcilerOpts.privilegedTenants,
+		privilegedTenants:      reconcilerOpts.privilegedTenants,
 	}
 
 	if err := ctrlbldr.ControllerManagedBy(mgr).
@@ -216,7 +225,11 @@ func AddToManager(log *logrus.Entry, mgr manager.Manager, allManagers map[string
 	}
 
 	if err := addPJReconcilerToManager(log, mgr, buildClients); err != nil {
-		return fmt.Errorf("build prowjob controller: %w", err)
+		return fmt.Errorf("add prowjob controller: %w", err)
+	}
+
+	if err := addMetricsToManager(log, mgr, EphemeralClusterNamespace, reconcilerOpts.metricsInterval); err != nil {
+		return fmt.Errorf("add metrics controller: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Add the `metricsGatherer` reconciler that exposes the following metric:
```
ephemeralclusters{konflux_cluster, konflux_tenant, cluster_profile, workflow}
```

That is a Prometheus Gauge that keeps track of `EphemeralCluster`s that exist on the cluster.

Labels are self explanatory but there is one caveat: for any `EphemeralCluster`s that use the `hypershift-hostedcluster-workflow` workflow and set the `HOSTED_MANAGEMENT_CLUSTER` env variable, the `workflow` label becomes `hypershift-hostedcluster-workflow_${HOSTED_MANAGEMENT_CLUSTER}`.

This special case is justified by the fact that Konflux users are expected to use `hypershift-hostedcluster-workflow` in combination with `HOSTED_MANAGEMENT_CLUSTER`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds Prometheus metrics for existing `EphemeralCluster` resources managed by the DPTP controller.

The `ephemeralclusters{tenant, cluster_profile, workflow}` gauge helps CI operators monitor cluster usage. Hosted HyperShift workflows include the management cluster in the `workflow` label.

The metrics gatherer runs at a configurable interval with a one-minute default. It supports cancellation and leader election. Tests cover aggregation, hosted workflow labels, resource updates, empty states, and client errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->