### PR TITLE
ci-operator: change --enable-secrets-store-csi-driver default to true

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -466,7 +466,7 @@ func bindOptions(flag *flag.FlagSet) *options {
 	flag.BoolVar(&opt.givePrAuthorAccessToNamespace, "give-pr-author-access-to-namespace", true, "Give view access to the temporarily created namespace to the PR author.")
 	flag.StringVar(&opt.impersonateUser, "as", "", "Username to impersonate")
 	flag.BoolVar(&opt.restrictNetworkAccess, "restrict-network-access", false, "Restrict network access to 10.0.0.0/8 (RedHat intranet).")
-	flag.BoolVar(&opt.enableSecretsStoreCSIDriver, "enable-secrets-store-csi-driver", false, "Use Secrets Store CSI driver for accessing multi-stage credentials.")
+	flag.BoolVar(&opt.enableSecretsStoreCSIDriver, "enable-secrets-store-csi-driver", true, "Use Secrets Store CSI driver for accessing multi-stage credentials.")
 
 	// Google Secret Manager flags
 	flag.StringVar(&opt.gsmConfigPath, "gsm-config", "", "Path to the gsm secrets config file.")
@@ -536,10 +536,6 @@ func (o *options) Complete() error {
 	}
 	if o.unresolvedConfigPath != "" && o.resolverAddress == "" {
 		return errors.New("cannot request resolved config with --unresolved-config unless providing --resolver-address")
-	}
-
-	if o.enableSecretsStoreCSIDriver && o.gsmConfigPath == "" {
-		return fmt.Errorf("--gsm-config is required when --enable-secrets-store-csi-driver is enabled")
 	}
 
 	injectTest, err := o.getInjectTest()
@@ -705,7 +701,7 @@ func (o *options) Complete() error {
 	handleTargetAdditionalSuffix(o)
 	setDisablePodScalerFromTarget(o)
 
-	if o.enableSecretsStoreCSIDriver {
+	if o.gsmConfigPath != "" {
 		if err := api.LoadGSMConfigFromFile(o.gsmConfigPath, &o.gsmConfig); err != nil {
 			return err
 		}
@@ -1012,7 +1008,7 @@ func (o *options) Run() (errs []error) {
 	}
 
 	var gsmConfig *csi_secrets.GSMConfiguration
-	if o.enableSecretsStoreCSIDriver {
+	if o.gsmConfigPath != "" {
 		var opts []option.ClientOption
 		if o.gsmCredentialsFile != "" {
 			opts = append(opts, option.WithCredentialsFile(o.gsmCredentialsFile))

--- a/pkg/steps/multi_stage/multi_stage.go
+++ b/pkg/steps/multi_stage/multi_stage.go
@@ -291,15 +291,15 @@ func (s *multiStageTestStep) run(ctx context.Context) error {
 		}
 	}
 	if s.enableSecretsStoreCSIDriver {
-		if s.gsm == nil || s.gsm.Client == nil {
-			return fmt.Errorf("GSM client was not initialized - credentials file may be missing")
-		}
 		if len(k8sSecretCredentials) > 0 {
 			if err := s.createCredentials(ctx, k8sSecretCredentials); err != nil {
 				return fmt.Errorf("failed to create K8s Secret credentials: %w", err)
 			}
 		}
 		if len(gsmCredentials) > 0 {
+			if s.gsm == nil || s.gsm.Client == nil {
+				return fmt.Errorf("gsm client was not initialized - ensure --gsm-config and --gsm-credentials-file are provided")
+			}
 			if err := s.createSPCs(ctx, gsmCredentials); err != nil {
 				return fmt.Errorf("failed to create SecretProviderClass objects: %w", err)
 			}

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -457,7 +457,7 @@ func (s *podStep) resolveAndCreateGSMSecrets(ctx context.Context) error {
 	}
 
 	if s.config.GSMConfig == nil || s.config.GSMConfig.Client == nil {
-		return fmt.Errorf("GSM client was not initialized - credentials file may be missing")
+		return fmt.Errorf("gsm client was not initialized - ensure --gsm-config and --gsm-credentials-file are provided")
 	}
 
 	resolved, err := csi_secrets.ResolveCredentialReferences(

--- a/pkg/steps/pod_test.go
+++ b/pkg/steps/pod_test.go
@@ -436,7 +436,7 @@ func TestResolveAndCreateGSMSecrets(t *testing.T) {
 			},
 			enableCSI:     true,
 			gsmConfig:     nil,
-			expectedError: "GSM client was not initialized - credentials file may be missing",
+			expectedError: "gsm client was not initialized - ensure --gsm-config and --gsm-credentials-file are provided",
 		},
 		{
 			name: "default mount paths when not specified",


### PR DESCRIPTION
## Summary
- Change `--enable-secrets-store-csi-driver` default from `false` to `true` in `cmd/ci-operator/main.go`.
- Remove the startup validation that required `--gsm-config` when CSI is enabled. Instead, gate GSM config loading and client initialization on `--gsm-config` being provided — jobs without credentials skip GSM setup entirely.
- Improve error message in `pkg/steps/pod.go` when a container test has GSM credentials but no GSM config.

## Context
Part of the Vault-to-GSM migration cleanup. Depends on:
1. Migration complete (all credentials use GSM format)
2. Prowgen PR merged (https://github.com/openshift/ci-tools/pull/5351)

After this PR, the `prowgen: enable_secrets_store_csi_driver: true` field can be removed from all ci-operator configs.

/hold 
until the above dependencies are met.

https://redhat.atlassian.net/browse/DPTP-5322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- `ci-operator` now enables the Secrets Store CSI driver by default.
- CI jobs without GSM credentials skip GSM configuration and client setup.
- GSM initialization errors now identify both required flags: `--gsm-config` and `--gsm-credentials-file`.
- Merge after the Vault-to-GSM migration and related `prowgen` changes are complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->