### PR TITLE
checkconfig: validate GSM credential reference names

### DIFF
--- a/pkg/gsm-validation/mount_filename.go
+++ b/pkg/gsm-validation/mount_filename.go
@@ -3,6 +3,7 @@ package gsmvalidation
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 )
 
@@ -31,10 +32,8 @@ func validateDecodedMountFileName(encoded, decoded string) error {
 	if strings.HasPrefix(decoded, "/") {
 		return fmt.Errorf("mount file name %q decodes to %q which is an absolute path", encoded, decoded)
 	}
-	for _, segment := range strings.Split(decoded, "/") {
-		if segment == ".." {
-			return fmt.Errorf("mount file name %q decodes to %q which contains a path traversal segment", encoded, decoded)
-		}
+	if slices.Contains(strings.Split(decoded, "/"), "..") {
+		return fmt.Errorf("mount file name %q decodes to %q which contains a path traversal segment", encoded, decoded)
 	}
 	if invalidCharacters := mountFileNameCharRegexp.FindAllString(decoded, -1); len(invalidCharacters) > 0 {
 		return fmt.Errorf(

--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	gsmvalidation "github.com/openshift/ci-tools/pkg/gsm-validation"
 	"github.com/openshift/ci-tools/pkg/privateorg"
 	"github.com/openshift/ci-tools/pkg/util"
 )
@@ -280,6 +281,24 @@ func (v *Validator) validateTestStepConfiguration(
 					validationErrors = append(validationErrors, fmt.Errorf("%s.secrets[%d]: `field` requires `collection` and `group` to be set", fieldRootN, i))
 				} else {
 					validationErrors = append(validationErrors, fmt.Errorf("%s.secrets[%d]: must specify `bundle` or `collection`+`group`", fieldRootN, i))
+				}
+				if secret.IsGSMReference() && !secret.IsBundleReference() {
+					if !gsmvalidation.ValidateCollectionName(secret.Collection) {
+						validationErrors = append(validationErrors, fmt.Errorf("%s.secrets[%d].collection: %q is not a valid collection name", fieldRootN, i, secret.Collection))
+					}
+					if !gsmvalidation.ValidateGroupName(secret.Group) {
+						validationErrors = append(validationErrors, fmt.Errorf("%s.secrets[%d].group: %q is not a valid group name", fieldRootN, i, secret.Group))
+					}
+					if secret.Field != "" {
+						if err := gsmvalidation.ValidateMountFileName(secret.Field); err != nil {
+							validationErrors = append(validationErrors, fmt.Errorf("%s.secrets[%d].field: %w", fieldRootN, i, err))
+						}
+					}
+					if secret.As != "" {
+						if err := gsmvalidation.ValidateMountFileName(secret.As); err != nil {
+							validationErrors = append(validationErrors, fmt.Errorf("%s.secrets[%d].as: %w", fieldRootN, i, err))
+						}
+					}
 				}
 			} else {
 				// K8s object names must be valid DNS 1123 subdomains.
@@ -869,19 +888,28 @@ func validateCredentials(fieldRoot string, credentials []api.CredentialReference
 				if credential.Collection != "" || credential.Group != "" || credential.Field != "" {
 					errs = append(errs, fmt.Errorf("%s.credentials[%d]: `bundle` cannot be used with `collection`, `group`, or `field`", fieldRoot, i))
 				}
-			} else if credential.IsAutoDiscovery() {
+			} else if credential.IsAutoDiscovery() || credential.IsExplicitField() {
 				if credential.Bundle != "" {
 					errs = append(errs, fmt.Errorf("%s.credentials[%d]: `bundle` cannot be used with `collection`, `group`, or `field`", fieldRoot, i))
 				}
 				if credential.Namespace != "" {
 					errs = append(errs, fmt.Errorf("%s.credentials[%d]: `namespace` cannot be used with `collection`, `group`, or `field`", fieldRoot, i))
 				}
-			} else if credential.IsExplicitField() {
-				if credential.Bundle != "" {
-					errs = append(errs, fmt.Errorf("%s.credentials[%d]: `bundle` cannot be used with `collection`, `group`, or `field`", fieldRoot, i))
+				if !gsmvalidation.ValidateCollectionName(credential.Collection) {
+					errs = append(errs, fmt.Errorf("%s.credentials[%d].collection: %q is not a valid collection name", fieldRoot, i, credential.Collection))
 				}
-				if credential.Namespace != "" {
-					errs = append(errs, fmt.Errorf("%s.credentials[%d]: `namespace` cannot be used with `collection`, `group`, or `field`", fieldRoot, i))
+				if !gsmvalidation.ValidateGroupName(credential.Group) {
+					errs = append(errs, fmt.Errorf("%s.credentials[%d].group: %q is not a valid group name", fieldRoot, i, credential.Group))
+				}
+				if credential.Field != "" {
+					if err := gsmvalidation.ValidateMountFileName(credential.Field); err != nil {
+						errs = append(errs, fmt.Errorf("%s.credentials[%d].field: %w", fieldRoot, i, err))
+					}
+				}
+				if credential.As != "" {
+					if err := gsmvalidation.ValidateMountFileName(credential.As); err != nil {
+						errs = append(errs, fmt.Errorf("%s.credentials[%d].as: %w", fieldRoot, i, err))
+					}
 				}
 			} else {
 				errs = append(errs, fmt.Errorf("%s.credentials[%d]: must specify `bundle`, `collection`+`group`, or `collection`+`group`+`field`", fieldRoot, i))

--- a/pkg/validation/test_test.go
+++ b/pkg/validation/test_test.go
@@ -606,6 +606,61 @@ func TestValidateTests(t *testing.T) {
 			},
 		},
 		{
+			id: "GSM secret with invalid group name means error",
+			tests: []api.TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
+					Secrets: []*api.Secret{
+						{Collection: "col", Group: "_leading-underscore", MountPath: "/path"},
+					},
+				},
+			},
+			expectedError: errors.New(`tests[0].secrets[0].group: "_leading-underscore" is not a valid group name`),
+		},
+		{
+			id: "GSM secret with path traversal in field means error",
+			tests: []api.TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
+					Secrets: []*api.Secret{
+						{Collection: "col", Group: "grp", Field: "--dot----dot--", MountPath: "/path"},
+					},
+				},
+			},
+			expectedError: errors.New(`tests[0].secrets[0].field: mount file name "--dot----dot--" decodes to ".." which contains a path traversal segment`),
+		},
+		{
+			id: "GSM secret with invalid as means error",
+			tests: []api.TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
+					Secrets: []*api.Secret{
+						{Collection: "col", Group: "grp", Field: "fld", As: "--dot----dot--", MountPath: "/path"},
+					},
+				},
+			},
+			expectedError: errors.New(`tests[0].secrets[0].as: mount file name "--dot----dot--" decodes to ".." which contains a path traversal segment`),
+		},
+		{
+			id: "GSM secret with group/subgroup is valid",
+			tests: []api.TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
+					Secrets: []*api.Secret{
+						{Collection: "col", Group: "grp/subgrp", MountPath: "/path"},
+					},
+				},
+			},
+		},
+		{
 			id:       "non-literal test is invalid in fully-resolved configuration",
 			resolved: true,
 			tests: []api.TestStepConfiguration{
@@ -1851,13 +1906,75 @@ func TestValidateCredentials(t *testing.T) {
 				{Collection: "coll", Group: "grp", Field: "fld", MountPath: "/tmp/gsm"},
 			},
 		},
+		{
+			name: "auto-discovery with invalid collection name means error",
+			input: []api.CredentialReference{
+				{Collection: "INVALID_UPPER", Group: "grp", MountPath: "/foo"},
+			},
+			output: []error{
+				errors.New(`root.credentials[0].collection: "INVALID_UPPER" is not a valid collection name`),
+			},
+		},
+		{
+			name: "auto-discovery with invalid group name means error",
+			input: []api.CredentialReference{
+				{Collection: "coll", Group: "_leading-underscore", MountPath: "/foo"},
+			},
+			output: []error{
+				errors.New(`root.credentials[0].group: "_leading-underscore" is not a valid group name`),
+			},
+		},
+		{
+			name: "explicit field with invalid collection and group means multiple errors",
+			input: []api.CredentialReference{
+				{Collection: "BAD!", Group: "__bad", Field: "fld", MountPath: "/foo"},
+			},
+			output: []error{
+				errors.New(`root.credentials[0].collection: "BAD!" is not a valid collection name`),
+				errors.New(`root.credentials[0].group: "__bad" is not a valid group name`),
+			},
+		},
+		{
+			name: "explicit field with path traversal in field means error",
+			input: []api.CredentialReference{
+				{Collection: "coll", Group: "grp", Field: "--dot----dot--", MountPath: "/foo"},
+			},
+			output: []error{
+				errors.New(`root.credentials[0].field: mount file name "--dot----dot--" decodes to ".." which contains a path traversal segment`),
+			},
+		},
+		{
+			name: "explicit field with invalid as means error",
+			input: []api.CredentialReference{
+				{Collection: "coll", Group: "grp", Field: "fld", As: "--dot----dot--", MountPath: "/foo"},
+			},
+			output: []error{
+				errors.New(`root.credentials[0].as: mount file name "--dot----dot--" decodes to ".." which contains a path traversal segment`),
+			},
+		},
+		{
+			name: "explicit field with valid names is valid",
+			input: []api.CredentialReference{
+				{Collection: "test-platform-infra", Group: "my-group", Field: "my-field", MountPath: "/foo"},
+			},
+		},
+		{
+			name: "explicit field with valid as is valid",
+			input: []api.CredentialReference{
+				{Collection: "test-platform-infra", Group: "my-group", Field: "my-field", As: "renamed", MountPath: "/foo"},
+			},
+		},
+		{
+			name: "auto-discovery with group/subgroup is valid",
+			input: []api.CredentialReference{
+				{Collection: "coll", Group: "group/subgroup", MountPath: "/foo"},
+			},
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			if actual, expected := validateCredentials("root", testCase.input), testCase.output; !reflect.DeepEqual(actual, expected) {
-				t.Errorf("%s: got incorrect errors (-want,+got): %s", testCase.name, cmp.Diff(actual, expected, cmp.Comparer(func(x, y error) bool {
-					return x.Error() == y.Error()
-				})))
+			if diff := cmp.Diff(testCase.output, validateCredentials("root", testCase.input), testhelper.EquateErrorMessage); diff != "" {
+				t.Errorf("%s: got incorrect errors (-want,+got): %s", testCase.name, diff)
 			}
 		})
 	}


### PR DESCRIPTION
Adds GSM naming validation to `ci-operator-checkconfig` for both multi-stage step credentials and container test `secrets:`. Calls existing `ValidateCollectionName`, `ValidateGroupName`, and `ValidateMountFileName` from `pkg/gsm-validation`.

Catches invalid collection/group names and unsafe field/as values (path traversal, forbidden characters) at PR time (runs as `pull-ci-openshift-release-main-ci-operator-config`) rather than at runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- `ci-operator-checkconfig` now validates GSM collection, group, `field`, and `as` names for multi-stage credentials and container test `secrets:`.
- Pull request checks now catch invalid names and unsafe values, including path traversal and forbidden characters, before runtime.
- Credential auto-discovery and explicit-field validation now use the same checks.
- Added coverage for invalid, unsafe, and valid GSM references, including multiple validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->