### PR TITLE
Konflux: Add more metrics

### DIFF
--- a/pkg/controller/ephemeralcluster/metrics.go
+++ b/pkg/controller/ephemeralcluster/metrics.go
@@ -16,40 +16,60 @@ import (
 )
 
 const (
+	metricsNamespace = "ephemeralcluster"
+
 	hostedManagementClusterEnvVar   = "HOSTED_MANAGEMENT_CLUSTER"
 	hypershiftHostedClusterWorkflow = "hypershift-hostedcluster-workflow"
 )
 
-func ecCountGaugeVec() *prometheus.GaugeVec {
+func newCountGaugeVec() *prometheus.GaugeVec {
 	return prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "ephemeralcluster",
+		Namespace: metricsNamespace,
 		Name:      "count",
-		Help:      "The number of ephemeralclusters the controller created",
+		Help:      "The number of ephemeralclusters that currently exist",
 	}, []string{"konflux_cluster", "konflux_tenant", "cluster_profile", "workflow", "phase"})
 }
 
-type metricsGatherer struct {
-	logger       *logrus.Entry
-	client       ctrlruntimeclient.Client
-	ecCountGauge *prometheus.GaugeVec
-	ecNS         string
-	interval     time.Duration
+var (
+	provisioningDurationBuckets = []float64{300, 600, 900, 1800, 3600, 5400, 7200, 9000, 10800}
+)
+
+func newProvisioningDurationHistogramVec() *prometheus.HistogramVec {
+	return prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: metricsNamespace,
+		Name:      "provisioning_duration_seconds",
+		Help:      "Measure how long the provisioning procedure takes",
+		Buckets:   provisioningDurationBuckets,
+	}, []string{"workflow"})
 }
 
-func addMetricsToManager(logger *logrus.Entry, mgr manager.Manager, ecNS string, interval time.Duration) error {
-	ecCountGauge := ecCountGaugeVec()
+type metricsGatherer struct {
+	logger                           *logrus.Entry
+	client                           ctrlruntimeclient.Client
+	countGauge                       *prometheus.GaugeVec
+	provisioningDurationHistogramVec *prometheus.HistogramVec
+	ecNS                             string
+	interval                         time.Duration
+}
 
-	if err := metrics.Registry.Register(ecCountGauge); err != nil {
-		return fmt.Errorf("failed to register ephemeralclusters metric: %w", err)
+func addMetricsToManager(logger *logrus.Entry, mgr manager.Manager, ecNS string, interval time.Duration) (*metricsGatherer, error) {
+	countGauge := newCountGaugeVec()
+	if err := metrics.Registry.Register(countGauge); err != nil {
+		return nil, fmt.Errorf("failed to register count gauge: %w", err)
+	}
+
+	provisioningDurationHistogram := newProvisioningDurationHistogramVec()
+	if err := metrics.Registry.Register(provisioningDurationHistogram); err != nil {
+		return nil, fmt.Errorf("failed to register provisioning duration histogram: %w", err)
 	}
 
 	metricsGatherer := newMetricsGatherer(logger.WithField("controller", "ephemeral_cluster_metrics"),
-		mgr.GetClient(), ecCountGauge, ecNS, interval)
+		mgr.GetClient(), countGauge, provisioningDurationHistogram, ecNS, interval)
 	if err := mgr.Add(metricsGatherer); err != nil {
-		return fmt.Errorf("add metrics to manager: %w", err)
+		return nil, fmt.Errorf("add metrics to manager: %w", err)
 	}
 
-	return nil
+	return metricsGatherer, nil
 }
 
 func (mg *metricsGatherer) Start(ctx context.Context) error {
@@ -67,13 +87,13 @@ func (mg *metricsGatherer) Start(ctx context.Context) error {
 				continue
 			}
 
-			mg.collect(&ecList)
+			mg.collectCount(&ecList)
 		}
 	}
 }
 
-func (mg *metricsGatherer) collect(ecList *ephemeralclusterv1.EphemeralClusterList) {
-	ecCount := make(map[struct {
+func (mg *metricsGatherer) collectCount(ecList *ephemeralclusterv1.EphemeralClusterList) {
+	count := make(map[struct {
 		konfluxCluster string
 		konfluxTenant  string
 		clusterProfile string
@@ -103,26 +123,49 @@ func (mg *metricsGatherer) collect(ecList *ephemeralclusterv1.EphemeralClusterLi
 			k.workflow = k.workflow + "_" + hostedMgmt
 		}
 
-		ecCount[k]++
+		count[k]++
 	}
 
-	mg.ecCountGauge.Reset()
-	for k, v := range ecCount {
-		mg.ecCountGauge.
+	mg.countGauge.Reset()
+	for k, v := range count {
+		mg.countGauge.
 			WithLabelValues(k.konfluxCluster, k.konfluxTenant, k.clusterProfile, k.workflow, k.phase).
 			Set(float64(v))
 	}
 }
 
+func (mg *metricsGatherer) collectProvisioningDuration(ec *ephemeralclusterv1.EphemeralCluster, status *ephemeralclusterv1.EphemeralClusterStatus) bool {
+	find := func(t ephemeralclusterv1.EphemeralClusterConditionType) (time.Time, bool) {
+		for i := range status.Conditions {
+			if c := &status.Conditions[i]; c.Type == t && c.Status == ephemeralclusterv1.ConditionTrue {
+				return c.LastTransitionTime.Time, true
+			}
+		}
+		return time.Time{}, false
+	}
+
+	if end, ok := find(ephemeralclusterv1.ClusterReady); ok {
+		start := ec.CreationTimestamp.Time
+		duration := end.Sub(start).Seconds()
+		workflow := ec.Spec.CIOperator.Test.Workflow
+		mg.provisioningDurationHistogramVec.WithLabelValues(workflow).Observe(duration)
+		return true
+	}
+
+	return false
+}
+
 func (mg *metricsGatherer) NeedLeaderElection() bool { return true }
 
-func newMetricsGatherer(logger *logrus.Entry, client ctrlruntimeclient.Client, ecCountGauge *prometheus.GaugeVec,
+func newMetricsGatherer(logger *logrus.Entry, client ctrlruntimeclient.Client,
+	countGauge *prometheus.GaugeVec, provisioningDurationHistogramVec *prometheus.HistogramVec,
 	ecNS string, interval time.Duration) *metricsGatherer {
 	return &metricsGatherer{
-		logger:       logger,
-		client:       client,
-		ecCountGauge: ecCountGauge,
-		ecNS:         ecNS,
-		interval:     interval,
+		logger:                           logger,
+		client:                           client,
+		countGauge:                       countGauge,
+		provisioningDurationHistogramVec: provisioningDurationHistogramVec,
+		ecNS:                             ecNS,
+		interval:                         interval,
 	}
 }

--- a/pkg/controller/ephemeralcluster/metrics.go
+++ b/pkg/controller/ephemeralcluster/metrics.go
@@ -20,30 +20,31 @@ const (
 	hypershiftHostedClusterWorkflow = "hypershift-hostedcluster-workflow"
 )
 
-func ecTotalGaugeVec() *prometheus.GaugeVec {
+func ecCountGaugeVec() *prometheus.GaugeVec {
 	return prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "ephemeralclusters",
-		Help: "The number of ephemeralclusters the controller created",
-	}, []string{"konflux_cluster", "konflux_tenant", "cluster_profile", "workflow"})
+		Namespace: "ephemeralcluster",
+		Name:      "count",
+		Help:      "The number of ephemeralclusters the controller created",
+	}, []string{"konflux_cluster", "konflux_tenant", "cluster_profile", "workflow", "phase"})
 }
 
 type metricsGatherer struct {
 	logger       *logrus.Entry
 	client       ctrlruntimeclient.Client
-	ecTotalGauge *prometheus.GaugeVec
+	ecCountGauge *prometheus.GaugeVec
 	ecNS         string
 	interval     time.Duration
 }
 
 func addMetricsToManager(logger *logrus.Entry, mgr manager.Manager, ecNS string, interval time.Duration) error {
-	ecTotalGauge := ecTotalGaugeVec()
+	ecCountGauge := ecCountGaugeVec()
 
-	if err := metrics.Registry.Register(ecTotalGauge); err != nil {
+	if err := metrics.Registry.Register(ecCountGauge); err != nil {
 		return fmt.Errorf("failed to register ephemeralclusters metric: %w", err)
 	}
 
 	metricsGatherer := newMetricsGatherer(logger.WithField("controller", "ephemeral_cluster_metrics"),
-		mgr.GetClient(), ecTotalGauge, ecNS, interval)
+		mgr.GetClient(), ecCountGauge, ecNS, interval)
 	if err := mgr.Add(metricsGatherer); err != nil {
 		return fmt.Errorf("add metrics to manager: %w", err)
 	}
@@ -72,11 +73,12 @@ func (mg *metricsGatherer) Start(ctx context.Context) error {
 }
 
 func (mg *metricsGatherer) collect(ecList *ephemeralclusterv1.EphemeralClusterList) {
-	ecTotal := make(map[struct {
+	ecCount := make(map[struct {
 		konfluxCluster string
 		konfluxTenant  string
 		clusterProfile string
 		workflow       string
+		phase          string
 	}]uint)
 
 	for i := range ecList.Items {
@@ -87,11 +89,13 @@ func (mg *metricsGatherer) collect(ecList *ephemeralclusterv1.EphemeralClusterLi
 			konfluxTenant  string
 			clusterProfile string
 			workflow       string
+			phase          string
 		}{
 			konfluxCluster: ec.KonfluxCluster(),
 			konfluxTenant:  ec.KonfluxTenant(),
 			clusterProfile: ec.Spec.CIOperator.Test.ClusterProfile,
 			workflow:       ec.Spec.CIOperator.Test.Workflow,
+			phase:          string(ec.Status.Phase),
 		}
 
 		// This combination of workflow and env var is used mainly by Konflux users.
@@ -99,23 +103,25 @@ func (mg *metricsGatherer) collect(ecList *ephemeralclusterv1.EphemeralClusterLi
 			k.workflow = k.workflow + "_" + hostedMgmt
 		}
 
-		ecTotal[k]++
+		ecCount[k]++
 	}
 
-	mg.ecTotalGauge.Reset()
-	for k, v := range ecTotal {
-		mg.ecTotalGauge.WithLabelValues(k.konfluxCluster, k.konfluxTenant, k.clusterProfile, k.workflow).Set(float64(v))
+	mg.ecCountGauge.Reset()
+	for k, v := range ecCount {
+		mg.ecCountGauge.
+			WithLabelValues(k.konfluxCluster, k.konfluxTenant, k.clusterProfile, k.workflow, k.phase).
+			Set(float64(v))
 	}
 }
 
 func (mg *metricsGatherer) NeedLeaderElection() bool { return true }
 
-func newMetricsGatherer(logger *logrus.Entry, client ctrlruntimeclient.Client, ecTotalGauge *prometheus.GaugeVec,
+func newMetricsGatherer(logger *logrus.Entry, client ctrlruntimeclient.Client, ecCountGauge *prometheus.GaugeVec,
 	ecNS string, interval time.Duration) *metricsGatherer {
 	return &metricsGatherer{
 		logger:       logger,
 		client:       client,
-		ecTotalGauge: ecTotalGauge,
+		ecCountGauge: ecCountGauge,
 		ecNS:         ecNS,
 		interval:     interval,
 	}

--- a/pkg/controller/ephemeralcluster/metrics.go
+++ b/pkg/controller/ephemeralcluster/metrics.go
@@ -43,13 +43,27 @@ func newProvisioningDurationHistogramVec() *prometheus.HistogramVec {
 	}, []string{"workflow"})
 }
 
+var (
+	deprovisioningDurationBuckets = []float64{300, 600, 900, 1800, 3600, 5400, 7200, 9000, 10800}
+)
+
+func newDeprovisioningDurationHistogramVec() *prometheus.HistogramVec {
+	return prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: metricsNamespace,
+		Name:      "deprovisioning_duration_seconds",
+		Help:      "Measure how long the deprovisioning procedure takes",
+		Buckets:   deprovisioningDurationBuckets,
+	}, []string{"workflow"})
+}
+
 type metricsGatherer struct {
-	logger                           *logrus.Entry
-	client                           ctrlruntimeclient.Client
-	countGauge                       *prometheus.GaugeVec
-	provisioningDurationHistogramVec *prometheus.HistogramVec
-	ecNS                             string
-	interval                         time.Duration
+	logger                             *logrus.Entry
+	client                             ctrlruntimeclient.Client
+	countGauge                         *prometheus.GaugeVec
+	provisioningDurationHistogramVec   *prometheus.HistogramVec
+	deprovisioningDurationHistogramVec *prometheus.HistogramVec
+	ecNS                               string
+	interval                           time.Duration
 }
 
 func addMetricsToManager(logger *logrus.Entry, mgr manager.Manager, ecNS string, interval time.Duration) (*metricsGatherer, error) {
@@ -63,8 +77,13 @@ func addMetricsToManager(logger *logrus.Entry, mgr manager.Manager, ecNS string,
 		return nil, fmt.Errorf("failed to register provisioning duration histogram: %w", err)
 	}
 
+	deprovisioningDurationHistogram := newDeprovisioningDurationHistogramVec()
+	if err := metrics.Registry.Register(deprovisioningDurationHistogram); err != nil {
+		return nil, fmt.Errorf("failed to register deprovisioning duration histogram: %w", err)
+	}
+
 	metricsGatherer := newMetricsGatherer(logger.WithField("controller", "ephemeral_cluster_metrics"),
-		mgr.GetClient(), countGauge, provisioningDurationHistogram, ecNS, interval)
+		mgr.GetClient(), countGauge, provisioningDurationHistogram, deprovisioningDurationHistogram, ecNS, interval)
 	if err := mgr.Add(metricsGatherer); err != nil {
 		return nil, fmt.Errorf("add metrics to manager: %w", err)
 	}
@@ -155,17 +174,40 @@ func (mg *metricsGatherer) collectProvisioningDuration(ec *ephemeralclusterv1.Ep
 	return false
 }
 
+func (mg *metricsGatherer) collectDeprovisioningDuration(ec *ephemeralclusterv1.EphemeralCluster, oldStatus, observedStatus *ephemeralclusterv1.EphemeralClusterStatus) bool {
+	find := func(status *ephemeralclusterv1.EphemeralClusterStatus, t ephemeralclusterv1.EphemeralClusterConditionType) (time.Time, bool) {
+		for i := range status.Conditions {
+			if c := &status.Conditions[i]; c.Type == t && c.Status == ephemeralclusterv1.ConditionTrue {
+				return c.LastTransitionTime.Time, true
+			}
+		}
+		return time.Time{}, false
+	}
+
+	start, startOk := find(oldStatus, ephemeralclusterv1.TestCompleted)
+	end, endOk := find(observedStatus, ephemeralclusterv1.ProwJobCompleted)
+	if startOk && endOk {
+		duration := end.Sub(start).Seconds()
+		workflow := ec.Spec.CIOperator.Test.Workflow
+		mg.deprovisioningDurationHistogramVec.WithLabelValues(workflow).Observe(duration)
+		return true
+	}
+
+	return false
+}
+
 func (mg *metricsGatherer) NeedLeaderElection() bool { return true }
 
 func newMetricsGatherer(logger *logrus.Entry, client ctrlruntimeclient.Client,
-	countGauge *prometheus.GaugeVec, provisioningDurationHistogramVec *prometheus.HistogramVec,
+	countGauge *prometheus.GaugeVec, provisioningDurationHistogramVec, deprovisioningDurationHistogramVec *prometheus.HistogramVec,
 	ecNS string, interval time.Duration) *metricsGatherer {
 	return &metricsGatherer{
-		logger:                           logger,
-		client:                           client,
-		countGauge:                       countGauge,
-		provisioningDurationHistogramVec: provisioningDurationHistogramVec,
-		ecNS:                             ecNS,
-		interval:                         interval,
+		logger:                             logger,
+		client:                             client,
+		countGauge:                         countGauge,
+		provisioningDurationHistogramVec:   provisioningDurationHistogramVec,
+		deprovisioningDurationHistogramVec: deprovisioningDurationHistogramVec,
+		ecNS:                               ecNS,
+		interval:                           interval,
 	}
 }

--- a/pkg/controller/ephemeralcluster/metrics.go
+++ b/pkg/controller/ephemeralcluster/metrics.go
@@ -22,6 +22,14 @@ const (
 	hypershiftHostedClusterWorkflow = "hypershift-hostedcluster-workflow"
 )
 
+func workflowLabel(ec *ephemeralclusterv1.EphemeralCluster) string {
+	workflow := ec.Spec.CIOperator.Test.Workflow
+	if hostedMgmt, ok := ec.Spec.CIOperator.Test.Env[hostedManagementClusterEnvVar]; ok && workflow == hypershiftHostedClusterWorkflow {
+		workflow = workflow + "_" + hostedMgmt
+	}
+	return workflow
+}
+
 func newCountGaugeVec() *prometheus.GaugeVec {
 	return prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: metricsNamespace,
@@ -133,13 +141,8 @@ func (mg *metricsGatherer) collectCount(ecList *ephemeralclusterv1.EphemeralClus
 			konfluxCluster: ec.KonfluxCluster(),
 			konfluxTenant:  ec.KonfluxTenant(),
 			clusterProfile: ec.Spec.CIOperator.Test.ClusterProfile,
-			workflow:       ec.Spec.CIOperator.Test.Workflow,
+			workflow:       workflowLabel(ec),
 			phase:          string(ec.Status.Phase),
-		}
-
-		// This combination of workflow and env var is used mainly by Konflux users.
-		if hostedMgmt, ok := ec.Spec.CIOperator.Test.Env[hostedManagementClusterEnvVar]; ok && k.workflow == hypershiftHostedClusterWorkflow {
-			k.workflow = k.workflow + "_" + hostedMgmt
 		}
 
 		count[k]++
@@ -166,8 +169,7 @@ func (mg *metricsGatherer) collectProvisioningDuration(ec *ephemeralclusterv1.Ep
 	if end, ok := find(ephemeralclusterv1.ClusterReady); ok {
 		start := ec.CreationTimestamp.Time
 		duration := end.Sub(start).Seconds()
-		workflow := ec.Spec.CIOperator.Test.Workflow
-		mg.provisioningDurationHistogramVec.WithLabelValues(workflow).Observe(duration)
+		mg.provisioningDurationHistogramVec.WithLabelValues(workflowLabel(ec)).Observe(duration)
 		return true
 	}
 
@@ -184,12 +186,17 @@ func (mg *metricsGatherer) collectDeprovisioningDuration(ec *ephemeralclusterv1.
 		return time.Time{}, false
 	}
 
+	// Normally TestCompleted is in oldStatus from a prior reconcile. After a controller
+	// restart both TestCompleted and ProwJobCompleted may be set in the same cycle,
+	// so fall back to observedStatus to avoid losing the data point.
 	start, startOk := find(oldStatus, ephemeralclusterv1.TestCompleted)
+	if !startOk {
+		start, startOk = find(observedStatus, ephemeralclusterv1.TestCompleted)
+	}
 	end, endOk := find(observedStatus, ephemeralclusterv1.ProwJobCompleted)
 	if startOk && endOk {
 		duration := end.Sub(start).Seconds()
-		workflow := ec.Spec.CIOperator.Test.Workflow
-		mg.deprovisioningDurationHistogramVec.WithLabelValues(workflow).Observe(duration)
+		mg.deprovisioningDurationHistogramVec.WithLabelValues(workflowLabel(ec)).Observe(duration)
 		return true
 	}
 

--- a/pkg/controller/ephemeralcluster/metrics_test.go
+++ b/pkg/controller/ephemeralcluster/metrics_test.go
@@ -32,7 +32,7 @@ type metric struct {
 	Value  float64
 }
 
-func ec(cluster, tenant, clusterProfile, workflow, hostedMgmtClusterEnv string) *ephemeralclusterv1.EphemeralCluster {
+func ec(cluster, tenant, clusterProfile, workflow, hostedMgmtClusterEnv string, phase ephemeralclusterv1.EphemeralClusterPhase) *ephemeralclusterv1.EphemeralCluster {
 	ec := ephemeralclusterv1.EphemeralCluster{
 		ObjectMeta: v1.ObjectMeta{
 			Annotations: map[string]string{
@@ -49,6 +49,9 @@ func ec(cluster, tenant, clusterProfile, workflow, hostedMgmtClusterEnv string) 
 					Workflow:       workflow,
 				},
 			},
+		},
+		Status: ephemeralclusterv1.EphemeralClusterStatus{
+			Phase: phase,
 		},
 	}
 
@@ -119,7 +122,7 @@ func TestStart(t *testing.T) {
 		t.Cleanup(func() { cancel() })
 
 		client := fake.NewClientBuilder().WithScheme(scheme).Build()
-		ecTotalGauge := ecTotalGaugeVec()
+		ecTotalGauge := ecCountGaugeVec()
 
 		mg := newMetricsGatherer(logrus.NewEntry(logrus.StandardLogger()), client, ecTotalGauge,
 			EphemeralClusterNamespace, gatherInterval)
@@ -135,28 +138,28 @@ func TestStart(t *testing.T) {
 		}{
 			{
 				ecs: []*ephemeralclusterv1.EphemeralCluster{
-					ec("stone-prd-rh01", "tp-ci-tenant", "aws", "e2e-aws-workflow", ""),
-					ec("stone-prd-rh01", "tp-ci-tenant", "aws", "e2e-aws-workflow", ""),
-					ec("stone-stg-rh01", "tp-ci-tenant-2", "aws-2", "e2e-aws-workflow", ""),
+					ec("stone-prd-rh01", "tp-ci-tenant", "aws", "e2e-aws-workflow", "", ephemeralclusterv1.EphemeralClusterProvisioning),
+					ec("stone-prd-rh01", "tp-ci-tenant", "aws", "e2e-aws-workflow", "", ephemeralclusterv1.EphemeralClusterProvisioning),
+					ec("stone-stg-rh01", "tp-ci-tenant-2", "aws-2", "e2e-aws-workflow", "", ephemeralclusterv1.EphemeralClusterFailed),
 				},
 				wantMetricVals: []metric{{
-					Labels: []string{"stone-prd-rh01", "tp-ci-tenant", "aws", "e2e-aws-workflow"},
+					Labels: []string{"stone-prd-rh01", "tp-ci-tenant", "aws", "e2e-aws-workflow", "Provisioning"},
 					Value:  2,
 				}, {
-					Labels: []string{"stone-stg-rh01", "tp-ci-tenant-2", "aws-2", "e2e-aws-workflow"},
+					Labels: []string{"stone-stg-rh01", "tp-ci-tenant-2", "aws-2", "e2e-aws-workflow", "Failed"},
 					Value:  1,
 				}},
 			},
 			{
 				ecs: []*ephemeralclusterv1.EphemeralCluster{
-					ec("stone-stg-rh01", "tp-ci-tenant-2", "aws-2", "e2e-aws-workflow", ""),
-					ec("stone-prd-rh01", "amisstea-tenant", "aws-konflux-prod", "hypershift-hostedcluster-workflow", "hosted-mgmt2"),
+					ec("stone-stg-rh01", "tp-ci-tenant-2", "aws-2", "e2e-aws-workflow", "", ephemeralclusterv1.EphemeralClusterFailed),
+					ec("stone-prd-rh01", "amisstea-tenant", "aws-konflux-prod", "hypershift-hostedcluster-workflow", "hosted-mgmt2", ephemeralclusterv1.EphemeralClusterDeprovisioning),
 				},
 				wantMetricVals: []metric{{
-					Labels: []string{"stone-stg-rh01", "tp-ci-tenant-2", "aws-2", "e2e-aws-workflow"},
+					Labels: []string{"stone-stg-rh01", "tp-ci-tenant-2", "aws-2", "e2e-aws-workflow", "Failed"},
 					Value:  1,
 				}, {
-					Labels: []string{"stone-prd-rh01", "amisstea-tenant", "aws-konflux-prod", "hypershift-hostedcluster-workflow_hosted-mgmt2"},
+					Labels: []string{"stone-prd-rh01", "amisstea-tenant", "aws-konflux-prod", "hypershift-hostedcluster-workflow_hosted-mgmt2", "Deprovisioning"},
 					Value:  1,
 				}},
 			},

--- a/pkg/controller/ephemeralcluster/metrics_test.go
+++ b/pkg/controller/ephemeralcluster/metrics_test.go
@@ -62,8 +62,10 @@ func TestStart(t *testing.T) {
 		countGauge := newCountGaugeVec()
 		provisioningDurationHistogram := newProvisioningDurationHistogramVec()
 
+		deprovisioningDurationHistogram := newDeprovisioningDurationHistogramVec()
+
 		mg := newMetricsGatherer(logrus.NewEntry(logrus.StandardLogger()), client,
-			countGauge, provisioningDurationHistogram, EphemeralClusterNamespace, gatherInterval)
+			countGauge, provisioningDurationHistogram, deprovisioningDurationHistogram, EphemeralClusterNamespace, gatherInterval)
 		go func() {
 			if err := mg.Start(ctx); err != nil {
 				t.Errorf("Failed to start metrics gatherer: %s", err.Error())

--- a/pkg/controller/ephemeralcluster/metrics_test.go
+++ b/pkg/controller/ephemeralcluster/metrics_test.go
@@ -2,35 +2,19 @@ package ephemeralcluster
 
 import (
 	"context"
-	"fmt"
-	"sort"
-	"strings"
-	"sync"
 	"testing"
 	"testing/synctest"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
 	"github.com/sirupsen/logrus"
 
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 
 	ephemeralclusterv1 "github.com/openshift/ci-tools/pkg/api/ephemeralcluster/v1"
 )
-
-type metric struct {
-	Labels []string
-	Value  float64
-}
 
 func ec(cluster, tenant, clusterProfile, workflow, hostedMgmtClusterEnv string, phase ephemeralclusterv1.EphemeralClusterPhase) *ephemeralclusterv1.EphemeralCluster {
 	ec := ephemeralclusterv1.EphemeralCluster{
@@ -64,68 +48,22 @@ func ec(cluster, tenant, clusterProfile, workflow, hostedMgmtClusterEnv string, 
 	return &ec
 }
 
-func collectGauge(v *prometheus.MetricVec) (result []metric, err error) {
-	metricCh := make(chan prometheus.Metric)
-	wg := sync.WaitGroup{}
-
-	wg.Go(func() {
-		for m := range metricCh {
-			dtoMetric := dto.Metric{}
-			if writeErr := m.Write(&dtoMetric); writeErr != nil {
-				err = fmt.Errorf("write gauge: %w", writeErr)
-				return
-			}
-
-			m := metric{Value: *dtoMetric.Gauge.Value}
-			for _, l := range dtoMetric.Label {
-				m.Labels = append(m.Labels, *l.Value)
-			}
-
-			result = append(result, m)
-		}
-	})
-
-	v.Collect(metricCh)
-	close(metricCh)
-	wg.Wait()
-
-	return
-}
-
 func TestStart(t *testing.T) {
 	t.Parallel()
 
 	const gatherInterval = time.Second
-	cmpMetricOpts := []cmp.Option{
-		cmpopts.SortSlices(func(a, b metric) bool {
-			aLabels := strings.Join(a.Labels, "")
-			bLabels := strings.Join(b.Labels, "")
-			return strings.Compare(aLabels, bLabels) < 0
-		}),
-		cmp.Comparer(func(a, b metric) bool {
-			sort.Strings(a.Labels)
-			sort.Strings(b.Labels)
-			aLabels := strings.Join(a.Labels, "")
-			bLabels := strings.Join(b.Labels, "")
-			return strings.Compare(aLabels, bLabels) == 0 && a.Value == b.Value
-		}),
-	}
-
-	scheme := runtime.NewScheme()
-	sb := runtime.NewSchemeBuilder(ephemeralclusterv1.AddToScheme, prowv1.AddToScheme, corev1.AddToScheme)
-	if err := sb.AddToScheme(scheme); err != nil {
-		t.Fatalf("build scheme: %s", err.Error())
-	}
+	scheme := fakeScheme(t)
 
 	synctest.Test(t, func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(func() { cancel() })
 
 		client := fake.NewClientBuilder().WithScheme(scheme).Build()
-		ecTotalGauge := ecCountGaugeVec()
+		countGauge := newCountGaugeVec()
+		provisioningDurationHistogram := newProvisioningDurationHistogramVec()
 
-		mg := newMetricsGatherer(logrus.NewEntry(logrus.StandardLogger()), client, ecTotalGauge,
-			EphemeralClusterNamespace, gatherInterval)
+		mg := newMetricsGatherer(logrus.NewEntry(logrus.StandardLogger()), client,
+			countGauge, provisioningDurationHistogram, EphemeralClusterNamespace, gatherInterval)
 		go func() {
 			if err := mg.Start(ctx); err != nil {
 				t.Errorf("Failed to start metrics gatherer: %s", err.Error())
@@ -143,11 +81,15 @@ func TestStart(t *testing.T) {
 					ec("stone-stg-rh01", "tp-ci-tenant-2", "aws-2", "e2e-aws-workflow", "", ephemeralclusterv1.EphemeralClusterFailed),
 				},
 				wantMetricVals: []metric{{
-					Labels: []string{"stone-prd-rh01", "tp-ci-tenant", "aws", "e2e-aws-workflow", "Provisioning"},
-					Value:  2,
+					Gauge: &gauge{
+						Labels: []string{"stone-prd-rh01", "tp-ci-tenant", "aws", "e2e-aws-workflow", "Provisioning"},
+						Value:  2,
+					},
 				}, {
-					Labels: []string{"stone-stg-rh01", "tp-ci-tenant-2", "aws-2", "e2e-aws-workflow", "Failed"},
-					Value:  1,
+					Gauge: &gauge{
+						Labels: []string{"stone-stg-rh01", "tp-ci-tenant-2", "aws-2", "e2e-aws-workflow", "Failed"},
+						Value:  1,
+					},
 				}},
 			},
 			{
@@ -156,11 +98,15 @@ func TestStart(t *testing.T) {
 					ec("stone-prd-rh01", "amisstea-tenant", "aws-konflux-prod", "hypershift-hostedcluster-workflow", "hosted-mgmt2", ephemeralclusterv1.EphemeralClusterDeprovisioning),
 				},
 				wantMetricVals: []metric{{
-					Labels: []string{"stone-stg-rh01", "tp-ci-tenant-2", "aws-2", "e2e-aws-workflow", "Failed"},
-					Value:  1,
+					Gauge: &gauge{
+						Labels: []string{"stone-stg-rh01", "tp-ci-tenant-2", "aws-2", "e2e-aws-workflow", "Failed"},
+						Value:  1,
+					},
 				}, {
-					Labels: []string{"stone-prd-rh01", "amisstea-tenant", "aws-konflux-prod", "hypershift-hostedcluster-workflow_hosted-mgmt2", "Deprovisioning"},
-					Value:  1,
+					Gauge: &gauge{
+						Labels: []string{"stone-prd-rh01", "amisstea-tenant", "aws-konflux-prod", "hypershift-hostedcluster-workflow_hosted-mgmt2", "Deprovisioning"},
+						Value:  1,
+					},
 				}},
 			},
 			{},
@@ -179,12 +125,12 @@ func TestStart(t *testing.T) {
 			time.Sleep(gatherInterval)
 			synctest.Wait()
 
-			gotMetrics, err := collectGauge(ecTotalGauge.MetricVec)
+			gotMetrics, err := collectGauge(countGauge.MetricVec)
 			if err != nil {
 				t.Fatalf("collect gauge: %s", err.Error())
 			}
 
-			if diff := cmp.Diff(round.wantMetricVals, gotMetrics, cmpMetricOpts...); diff != "" {
+			if diff := cmpMetrics(round.wantMetricVals, gotMetrics); diff != "" {
 				t.Errorf("Round %d - Unexpected metric: %s\n", i, diff)
 			}
 		}

--- a/pkg/controller/ephemeralcluster/reconciler.go
+++ b/pkg/controller/ephemeralcluster/reconciler.go
@@ -160,6 +160,8 @@ type reconciler struct {
 	cliISTagRef            api.ImageStreamTagReference
 	privilegedTenants      sets.Set[string]
 
+	collectProvisioningDurationMetricFunc func(ec *ephemeralclusterv1.EphemeralCluster, status *ephemeralclusterv1.EphemeralClusterStatus) bool
+
 	// Mock for testing
 	now     func() time.Time
 	polling func() time.Duration
@@ -199,18 +201,24 @@ func AddToManager(log *logrus.Entry, mgr manager.Manager, allManagers map[string
 		return err
 	}
 
+	metricsGatherer, err := addMetricsToManager(log, mgr, EphemeralClusterNamespace, reconcilerOpts.metricsInterval)
+	if err != nil {
+		return fmt.Errorf("add metrics controller: %w", err)
+	}
+
 	r := reconciler{
-		logger:                 log.WithField("controller", ControllerName),
-		masterClient:           mgr.GetClient(),
-		buildClients:           buildClients,
-		prowConfigAgent:        prowConfigAgent,
-		clusterProfileResolver: clusterProfileResolverAdapter(registryAgent),
-		scheme:                 mgr.GetScheme(),
-		newProwJob:             pjutil.NewProwJob,
-		now:                    time.Now,
-		polling:                func() time.Duration { return reconcilerOpts.polling },
-		cliISTagRef:            cliISTagRef,
-		privilegedTenants:      reconcilerOpts.privilegedTenants,
+		logger:                                log.WithField("controller", ControllerName),
+		masterClient:                          mgr.GetClient(),
+		buildClients:                          buildClients,
+		prowConfigAgent:                       prowConfigAgent,
+		clusterProfileResolver:                clusterProfileResolverAdapter(registryAgent),
+		scheme:                                mgr.GetScheme(),
+		newProwJob:                            pjutil.NewProwJob,
+		cliISTagRef:                           cliISTagRef,
+		privilegedTenants:                     reconcilerOpts.privilegedTenants,
+		collectProvisioningDurationMetricFunc: metricsGatherer.collectProvisioningDuration,
+		now:                                   time.Now,
+		polling:                               func() time.Duration { return reconcilerOpts.polling },
 	}
 
 	if err := ctrlbldr.ControllerManagedBy(mgr).
@@ -226,10 +234,6 @@ func AddToManager(log *logrus.Entry, mgr manager.Manager, allManagers map[string
 
 	if err := addPJReconcilerToManager(log, mgr, buildClients); err != nil {
 		return fmt.Errorf("add prowjob controller: %w", err)
-	}
-
-	if err := addMetricsToManager(log, mgr, EphemeralClusterNamespace, reconcilerOpts.metricsInterval); err != nil {
-		return fmt.Errorf("add metrics controller: %w", err)
 	}
 
 	return nil
@@ -309,6 +313,8 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	if err := r.updateEphemeralClusterStatus(ctx, ec, &observedStatus); err != nil {
 		return reconcile.Result{}, err
 	}
+
+	r.collectProvisioningDurationMetric(ec, &oldStatus, &observedStatus)
 
 	return reconcile.Result{RequeueAfter: requeueAfter}, nil
 }
@@ -1010,6 +1016,14 @@ func (r *reconciler) notifyTestComplete(ctx context.Context, log *logrus.Entry, 
 	}
 
 	return nil
+}
+
+func (r *reconciler) collectProvisioningDurationMetric(ec *ephemeralclusterv1.EphemeralCluster, oldStatus, observedStatus *ephemeralclusterv1.EphemeralClusterStatus) {
+	if oldStatus.Phase != ephemeralclusterv1.EphemeralClusterReady && observedStatus.Phase == ephemeralclusterv1.EphemeralClusterReady {
+		if !r.collectProvisioningDurationMetricFunc(ec, observedStatus) {
+			r.logger.Warn("Failed to collect the provisioning duration metric")
+		}
+	}
 }
 
 func findCIOperatorTestNS(ctx context.Context, buildClient ctrlruntimeclient.Client, pj *prowv1.ProwJob) (string, error) {

--- a/pkg/controller/ephemeralcluster/reconciler.go
+++ b/pkg/controller/ephemeralcluster/reconciler.go
@@ -160,7 +160,8 @@ type reconciler struct {
 	cliISTagRef            api.ImageStreamTagReference
 	privilegedTenants      sets.Set[string]
 
-	collectProvisioningDurationMetricFunc func(ec *ephemeralclusterv1.EphemeralCluster, status *ephemeralclusterv1.EphemeralClusterStatus) bool
+	collectProvisioningDurationMetricFunc   func(ec *ephemeralclusterv1.EphemeralCluster, status *ephemeralclusterv1.EphemeralClusterStatus) bool
+	collectDeprovisioningDurationMetricFunc func(ec *ephemeralclusterv1.EphemeralCluster, oldStatus, observedStatus *ephemeralclusterv1.EphemeralClusterStatus) bool
 
 	// Mock for testing
 	now     func() time.Time
@@ -207,18 +208,19 @@ func AddToManager(log *logrus.Entry, mgr manager.Manager, allManagers map[string
 	}
 
 	r := reconciler{
-		logger:                                log.WithField("controller", ControllerName),
-		masterClient:                          mgr.GetClient(),
-		buildClients:                          buildClients,
-		prowConfigAgent:                       prowConfigAgent,
-		clusterProfileResolver:                clusterProfileResolverAdapter(registryAgent),
-		scheme:                                mgr.GetScheme(),
-		newProwJob:                            pjutil.NewProwJob,
-		cliISTagRef:                           cliISTagRef,
-		privilegedTenants:                     reconcilerOpts.privilegedTenants,
-		collectProvisioningDurationMetricFunc: metricsGatherer.collectProvisioningDuration,
-		now:                                   time.Now,
-		polling:                               func() time.Duration { return reconcilerOpts.polling },
+		logger:                                  log.WithField("controller", ControllerName),
+		masterClient:                            mgr.GetClient(),
+		buildClients:                            buildClients,
+		prowConfigAgent:                         prowConfigAgent,
+		clusterProfileResolver:                  clusterProfileResolverAdapter(registryAgent),
+		scheme:                                  mgr.GetScheme(),
+		newProwJob:                              pjutil.NewProwJob,
+		cliISTagRef:                             cliISTagRef,
+		privilegedTenants:                       reconcilerOpts.privilegedTenants,
+		collectProvisioningDurationMetricFunc:   metricsGatherer.collectProvisioningDuration,
+		collectDeprovisioningDurationMetricFunc: metricsGatherer.collectDeprovisioningDuration,
+		now:                                     time.Now,
+		polling:                                 func() time.Duration { return reconcilerOpts.polling },
 	}
 
 	if err := ctrlbldr.ControllerManagedBy(mgr).
@@ -304,7 +306,11 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		if removeFinalizer(ec) {
 			log.Info("ProwJob in a definitive state, finalizer removed")
 			ec.Status = observedStatus
-			return reconcile.Result{}, r.updateEphemeralClusterWithStatus(ctx, ec)
+			if updateErr := r.updateEphemeralClusterWithStatus(ctx, ec); updateErr != nil {
+				return reconcile.Result{}, updateErr
+			}
+			r.collectDeprovisioningDurationMetric(ec, &oldStatus, &observedStatus)
+			return reconcile.Result{}, nil
 		}
 	} else {
 		requeueAfter = r.polling()
@@ -315,6 +321,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	r.collectProvisioningDurationMetric(ec, &oldStatus, &observedStatus)
+	r.collectDeprovisioningDurationMetric(ec, &oldStatus, &observedStatus)
 
 	return reconcile.Result{RequeueAfter: requeueAfter}, nil
 }
@@ -925,9 +932,19 @@ func (r *reconciler) reconcileDeleteEphemeralCluster(ctx context.Context, log *l
 	if isFinalState := r.reportProwJobFinalState(&pj, observedStatus); isFinalState {
 		if removeFinalizer(ec) {
 			log.Info("ProwJob in a definitive state, removing the finalizer")
-			return reconcile.Result{}, r.updateEphemeralCluster(ctx, ec)
+			if updateErr := r.updateEphemeralCluster(ctx, ec); updateErr != nil {
+				return reconcile.Result{}, updateErr
+			}
+			r.collectDeprovisioningDurationMetric(ec, &oldStatus, observedStatus)
+			return reconcile.Result{}, nil
 		}
-		return reconcile.Result{}, r.updateEphemeralClusterStatus(ctx, ec, observedStatus)
+
+		if updateErr := r.updateEphemeralClusterStatus(ctx, ec, observedStatus); updateErr != nil {
+			return reconcile.Result{}, updateErr
+		}
+
+		r.collectDeprovisioningDurationMetric(ec, &oldStatus, observedStatus)
+		return reconcile.Result{}, nil
 	}
 
 	if err := r.notifyTestComplete(ctx, log, &oldStatus, observedStatus, &pj); err != nil {
@@ -1022,6 +1039,14 @@ func (r *reconciler) collectProvisioningDurationMetric(ec *ephemeralclusterv1.Ep
 	if oldStatus.Phase != ephemeralclusterv1.EphemeralClusterReady && observedStatus.Phase == ephemeralclusterv1.EphemeralClusterReady {
 		if !r.collectProvisioningDurationMetricFunc(ec, observedStatus) {
 			r.logger.Warn("Failed to collect the provisioning duration metric")
+		}
+	}
+}
+
+func (r *reconciler) collectDeprovisioningDurationMetric(ec *ephemeralclusterv1.EphemeralCluster, oldStatus, observedStatus *ephemeralclusterv1.EphemeralClusterStatus) {
+	if oldStatus.Phase != ephemeralclusterv1.EphemeralClusterDeprovisioned && observedStatus.Phase == ephemeralclusterv1.EphemeralClusterDeprovisioned {
+		if !r.collectDeprovisioningDurationMetricFunc(ec, oldStatus, observedStatus) {
+			r.logger.Warn("Failed to collect the deprovisioning duration metric")
 		}
 	}
 }

--- a/pkg/controller/ephemeralcluster/reconciler.go
+++ b/pkg/controller/ephemeralcluster/reconciler.go
@@ -309,6 +309,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			if updateErr := r.updateEphemeralClusterWithStatus(ctx, ec); updateErr != nil {
 				return reconcile.Result{}, updateErr
 			}
+			r.collectProvisioningDurationMetric(ec, &oldStatus, &observedStatus)
 			r.collectDeprovisioningDurationMetric(ec, &oldStatus, &observedStatus)
 			return reconcile.Result{}, nil
 		}
@@ -1036,7 +1037,16 @@ func (r *reconciler) notifyTestComplete(ctx context.Context, log *logrus.Entry, 
 }
 
 func (r *reconciler) collectProvisioningDurationMetric(ec *ephemeralclusterv1.EphemeralCluster, oldStatus, observedStatus *ephemeralclusterv1.EphemeralClusterStatus) {
-	if oldStatus.Phase != ephemeralclusterv1.EphemeralClusterReady && observedStatus.Phase == ephemeralclusterv1.EphemeralClusterReady {
+	hasClusterReady := func(status *ephemeralclusterv1.EphemeralClusterStatus) bool {
+		for i := range status.Conditions {
+			if c := &status.Conditions[i]; c.Type == ephemeralclusterv1.ClusterReady && c.Status == ephemeralclusterv1.ConditionTrue {
+				return true
+			}
+		}
+		return false
+	}
+
+	if !hasClusterReady(oldStatus) && hasClusterReady(observedStatus) {
 		if !r.collectProvisioningDurationMetricFunc(ec, observedStatus) {
 			r.logger.Warn("Failed to collect the provisioning duration metric")
 		}

--- a/pkg/controller/ephemeralcluster/reconciler_test.go
+++ b/pkg/controller/ephemeralcluster/reconciler_test.go
@@ -606,16 +606,17 @@ func TestReconcile(t *testing.T) {
 	const pollingTime = 5
 
 	for _, tc := range []struct {
-		name                              string
-		ec                                *ephemeralclusterv1.EphemeralCluster
-		objs                              []ctrlclient.Object
-		buildClients                      func() map[string]*ctrlruntimetest.FakeClient
-		now                               *time.Time
-		wantEC                            *ephemeralclusterv1.EphemeralCluster
-		wantSecret                        *corev1.Secret
-		wantRes                           reconcile.Result
-		wantProvisioningDurationHistogram []metric
-		wantErr                           error
+		name                                string
+		ec                                  *ephemeralclusterv1.EphemeralCluster
+		objs                                []ctrlclient.Object
+		buildClients                        func() map[string]*ctrlruntimetest.FakeClient
+		now                                 *time.Time
+		wantEC                              *ephemeralclusterv1.EphemeralCluster
+		wantSecret                          *corev1.Secret
+		wantRes                             reconcile.Result
+		wantProvisioningDurationHistogram   []metric
+		wantDeprovisioningDurationHistogram []metric
+		wantErr                             error
 	}{
 		{
 			name: "Kubeconfig ready",
@@ -1491,6 +1492,111 @@ func TestReconcile(t *testing.T) {
 			wantRes: reconcile.Result{RequeueAfter: pollingTime},
 		},
 		{
+			name: "ProwJob succeeded after deprovisioning, collect deprovisioning metric",
+			ec: &ephemeralclusterv1.EphemeralCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "foo",
+					Namespace:         "bar",
+					CreationTimestamp: metav1.NewTime(parseTime(t, "2025-04-02 12:00:00")),
+					UID:               types.UID("test-ec-uid"),
+					Finalizers:        []string{DependentProwJobFinalizer},
+				},
+				Spec: ephemeralclusterv1.EphemeralClusterSpec{
+					TearDownCluster: true,
+					CIOperator: ephemeralclusterv1.CIOperatorSpec{
+						Test: ephemeralclusterv1.TestSpec{Workflow: "e2e-aws"},
+					},
+				},
+				Status: ephemeralclusterv1.EphemeralClusterStatus{
+					ProwJobID: "pj-123",
+					Phase:     ephemeralclusterv1.EphemeralClusterDeprovisioning,
+					Conditions: []ephemeralclusterv1.EphemeralClusterCondition{{
+						Type:               ephemeralclusterv1.TestCompleted,
+						Status:             ephemeralclusterv1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(parseTime(t, "2025-04-02 12:30:00")),
+					}},
+				},
+			},
+			objs: []ctrlclient.Object{
+				&prowv1.ProwJob{
+					ObjectMeta: metav1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
+					Spec:       prowv1.ProwJobSpec{Cluster: "build01"},
+					Status:     prowv1.ProwJobStatus{State: prowv1.SuccessState},
+				},
+			},
+			buildClients: func() map[string]*ctrlruntimetest.FakeClient {
+				objs := []ctrlclient.Object{
+					&corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{steps.LabelJobID: "pj-123"},
+							Name:   "ci-op-1234",
+						},
+					},
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Name: EphemeralClusterTestName, Namespace: "ci-op-1234"},
+						Data:       map[string][]byte{"kubeconfig": []byte("kubeconfig")},
+					},
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      api.EphemeralClusterTestDoneSignalSecretName,
+							Namespace: "ci-op-1234",
+						},
+					},
+				}
+				c := fake.NewClientBuilder().WithObjects(objs...).WithScheme(scheme).Build()
+				return map[string]*ctrlruntimetest.FakeClient{
+					"build01": ctrlruntimetest.NewFakeClient(c, scheme, ctrlruntimetest.WithInitObjects(objs...)),
+				}
+			},
+			now: ptr.To(parseTime(t, "2025-04-02 12:45:00")),
+			wantEC: &ephemeralclusterv1.EphemeralCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "foo",
+					Namespace:         "bar",
+					CreationTimestamp: metav1.NewTime(parseTime(t, "2025-04-02 12:00:00")),
+				},
+				Spec: ephemeralclusterv1.EphemeralClusterSpec{
+					TearDownCluster: true,
+					CIOperator: ephemeralclusterv1.CIOperatorSpec{
+						Test: ephemeralclusterv1.TestSpec{Workflow: "e2e-aws"},
+					},
+				},
+				Status: ephemeralclusterv1.EphemeralClusterStatus{
+					Phase:     ephemeralclusterv1.EphemeralClusterDeprovisioned,
+					ProwJobID: "pj-123",
+					SecretRef: "foo-credentials",
+					Conditions: []ephemeralclusterv1.EphemeralClusterCondition{{
+						Type:               ephemeralclusterv1.ProwJobCreating,
+						Status:             ephemeralclusterv1.ConditionFalse,
+						Reason:             ProwJobCreatingDoneReason,
+						LastTransitionTime: metav1.NewTime(parseTime(t, "2025-04-02 12:45:00")),
+					}, {
+						Type:               ephemeralclusterv1.ClusterReady,
+						Status:             ephemeralclusterv1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(parseTime(t, "2025-04-02 12:45:00")),
+					}, {
+						Type:               ephemeralclusterv1.TestCompleted,
+						Status:             ephemeralclusterv1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(parseTime(t, "2025-04-02 12:45:00")),
+					}, {
+						Type:               ephemeralclusterv1.ProwJobCompleted,
+						Status:             ephemeralclusterv1.ConditionTrue,
+						Reason:             ephemeralclusterv1.ProwJobCompletedReason,
+						Message:            "prowjob state: success",
+						LastTransitionTime: metav1.NewTime(parseTime(t, "2025-04-02 12:45:00")),
+					}},
+				},
+			},
+			wantRes: reconcile.Result{},
+			wantDeprovisioningDurationHistogram: []metric{{
+				Histogram: &histogram{
+					Labels:      []string{"e2e-aws"},
+					SampleCount: 1,
+					Buckets:     histogramBuckets(deprovisioningDurationBuckets, 0, 0, 1),
+				},
+			}},
+		},
+		{
 			name: "Hive cluster not ready yet, errs out when fetching a secret",
 			ec: &ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1595,8 +1701,9 @@ func TestReconcile(t *testing.T) {
 			}
 
 			provisioningDurationHistogramVec := newProvisioningDurationHistogramVec()
+			deprovisioningDurationHistogramVec := newDeprovisioningDurationHistogramVec()
 			metricsGatherer := newMetricsGatherer(logrus.NewEntry(logrus.StandardLogger()),
-				nil, nil, provisioningDurationHistogramVec, "", 0)
+				nil, nil, provisioningDurationHistogramVec, deprovisioningDurationHistogramVec, "", 0)
 
 			subTestFakeNow := fakeNow
 			if tc.now != nil {
@@ -1614,7 +1721,8 @@ func TestReconcile(t *testing.T) {
 				prowConfigAgent: prowConfigAgent(&prowconfig.Config{
 					ProwConfig: prowconfig.ProwConfig{ProwJobNamespace: prowJobNamespace},
 				}),
-				collectProvisioningDurationMetricFunc: metricsGatherer.collectProvisioningDuration,
+				collectProvisioningDurationMetricFunc:   metricsGatherer.collectProvisioningDuration,
+				collectDeprovisioningDurationMetricFunc: metricsGatherer.collectDeprovisioningDuration,
 			}
 
 			gotRes, gotErr := r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.ec.Name, Namespace: tc.ec.Namespace}})
@@ -1679,6 +1787,15 @@ func TestReconcile(t *testing.T) {
 			if diff := cmpMetrics(tc.wantProvisioningDurationHistogram, gotProvisioningDurationMetrics); diff != "" {
 				t.Errorf("Provisioning duration metric differ: %s\n", diff)
 			}
+
+			gotDeprovisioningDurationMetrics, err := collectHistogram(deprovisioningDurationHistogramVec.MetricVec)
+			if err != nil {
+				t.Fatalf("collect deprovisioning duration histogram: %s", err)
+			}
+
+			if diff := cmpMetrics(tc.wantDeprovisioningDurationHistogram, gotDeprovisioningDurationMetrics); diff != "" {
+				t.Errorf("Deprovisioning duration metric differ: %s\n", diff)
+			}
 		})
 	}
 }
@@ -1689,15 +1806,16 @@ func TestReconcileDeleteEphemeralCluster(t *testing.T) {
 	const pollingTime = 5
 
 	for _, tc := range []struct {
-		name         string
-		ec           *ephemeralclusterv1.EphemeralCluster
-		pj           *prowv1.ProwJob
-		buildClients func() map[string]*ctrlruntimetest.FakeClient
-		wantEC       *ephemeralclusterv1.EphemeralCluster
-		wantPJ       *prowv1.ProwJob
-		wantSecret   *corev1.Secret
-		wantRes      reconcile.Result
-		wantErr      error
+		name                                string
+		ec                                  *ephemeralclusterv1.EphemeralCluster
+		pj                                  *prowv1.ProwJob
+		buildClients                        func() map[string]*ctrlruntimetest.FakeClient
+		wantEC                              *ephemeralclusterv1.EphemeralCluster
+		wantPJ                              *prowv1.ProwJob
+		wantSecret                          *corev1.Secret
+		wantRes                             reconcile.Result
+		wantDeprovisioningDurationHistogram []metric
+		wantErr                             error
 	}{
 		{
 			name: "Start deprovision procedure",
@@ -1856,6 +1974,49 @@ func TestReconcileDeleteEphemeralCluster(t *testing.T) {
 			},
 			wantRes: reconcile.Result{},
 		},
+		{
+			name: "ProwJob succeeded after deprovisioning, collect deprovisioning metric",
+			ec: &ephemeralclusterv1.EphemeralCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "foo",
+					Namespace:         "bar",
+					DeletionTimestamp: ptr.To(metav1.NewTime(fakeNow)),
+					Finalizers:        []string{DependentProwJobFinalizer},
+				},
+				Spec: ephemeralclusterv1.EphemeralClusterSpec{
+					CIOperator: ephemeralclusterv1.CIOperatorSpec{
+						Test: ephemeralclusterv1.TestSpec{Workflow: "e2e-aws"},
+					},
+				},
+				Status: ephemeralclusterv1.EphemeralClusterStatus{
+					ProwJobID: "pj-123",
+					Phase:     ephemeralclusterv1.EphemeralClusterDeprovisioning,
+					Conditions: []ephemeralclusterv1.EphemeralClusterCondition{{
+						Type:               ephemeralclusterv1.TestCompleted,
+						Status:             ephemeralclusterv1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(parseTime(t, "2025-04-02 12:00:00")),
+					}},
+				},
+			},
+			pj: &prowv1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
+				Spec:       prowv1.ProwJobSpec{Cluster: "build01"},
+				Status:     prowv1.ProwJobStatus{State: prowv1.SuccessState},
+			},
+			wantPJ: &prowv1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
+				Spec:       prowv1.ProwJobSpec{Cluster: "build01"},
+				Status:     prowv1.ProwJobStatus{State: prowv1.SuccessState},
+			},
+			wantRes: reconcile.Result{},
+			wantDeprovisioningDurationHistogram: []metric{{
+				Histogram: &histogram{
+					Labels:      []string{"e2e-aws"},
+					SampleCount: 1,
+					Buckets:     histogramBuckets(deprovisioningDurationBuckets, 0, 0, 1),
+				},
+			}},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -1879,6 +2040,10 @@ func TestReconcileDeleteEphemeralCluster(t *testing.T) {
 				}
 			}
 
+			deprovisioningDurationHistogramVec := newDeprovisioningDurationHistogramVec()
+			metricsGatherer := newMetricsGatherer(logrus.NewEntry(logrus.StandardLogger()),
+				nil, nil, nil, deprovisioningDurationHistogramVec, "", 0)
+
 			r := reconciler{
 				logger:       logrus.NewEntry(logrus.StandardLogger()),
 				masterClient: client,
@@ -1888,6 +2053,7 @@ func TestReconcileDeleteEphemeralCluster(t *testing.T) {
 				prowConfigAgent: prowConfigAgent(&prowconfig.Config{
 					ProwConfig: prowconfig.ProwConfig{ProwJobNamespace: prowJobNamespace},
 				}),
+				collectDeprovisioningDurationMetricFunc: metricsGatherer.collectDeprovisioningDuration,
 			}
 
 			gotRes, gotErr := r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.ec.Name, Namespace: tc.ec.Namespace}})
@@ -1953,6 +2119,15 @@ func TestReconcileDeleteEphemeralCluster(t *testing.T) {
 				if diff := cmp.Diff(tc.wantSecret.Data, gotSecret.Data); diff != "" {
 					t.Errorf("unexpected credentials secret data: %s", diff)
 				}
+			}
+
+			gotDeprovisioningDurationMetrics, err := collectHistogram(deprovisioningDurationHistogramVec.MetricVec)
+			if err != nil {
+				t.Fatalf("collect deprovisioning duration histogram: %s", err)
+			}
+
+			if diff := cmpMetrics(tc.wantDeprovisioningDurationHistogram, gotDeprovisioningDurationMetrics); diff != "" {
+				t.Errorf("Deprovisioning duration metric differ: %s\n", diff)
 			}
 		})
 	}

--- a/pkg/controller/ephemeralcluster/reconciler_test.go
+++ b/pkg/controller/ephemeralcluster/reconciler_test.go
@@ -983,9 +983,10 @@ func TestReconcile(t *testing.T) {
 			name: "Succeeded ProwJob maps to ProwJobCompleted condition",
 			ec: &ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo",
-					Namespace: "bar",
-					UID:       types.UID("test-ec-uid"),
+					Name:              "foo",
+					Namespace:         "bar",
+					CreationTimestamp: metav1.NewTime(parseTime(t, "2025-04-02 11:52:12")),
+					UID:               types.UID("test-ec-uid"),
 				},
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
 					ProwJobID: "pj-123",
@@ -1018,8 +1019,9 @@ func TestReconcile(t *testing.T) {
 			},
 			wantEC: &ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo",
-					Namespace: "bar",
+					Name:              "foo",
+					Namespace:         "bar",
+					CreationTimestamp: metav1.NewTime(parseTime(t, "2025-04-02 11:52:12")),
 				},
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
 					Phase:     ephemeralclusterv1.EphemeralClusterDeprovisioned,
@@ -1044,6 +1046,13 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			wantRes: reconcile.Result{},
+			wantProvisioningDurationHistogram: []metric{{
+				Histogram: &histogram{
+					Labels:      []string{""},
+					SampleCount: 1,
+					Buckets:     histogramBuckets(provisioningDurationBuckets, 0, 0, 0, 1),
+				},
+			}},
 		},
 		{
 			name: "ProwJob not found remove the finalizer",
@@ -1129,9 +1138,10 @@ func TestReconcile(t *testing.T) {
 			name: "Test completed, create secret",
 			ec: &ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo",
-					Namespace: "bar",
-					UID:       types.UID("test-ec-uid"),
+					Name:              "foo",
+					Namespace:         "bar",
+					CreationTimestamp: metav1.NewTime(parseTime(t, "2025-04-02 11:57:12")),
+					UID:               types.UID("test-ec-uid"),
 				},
 				Spec: ephemeralclusterv1.EphemeralClusterSpec{TearDownCluster: true},
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
@@ -1164,9 +1174,10 @@ func TestReconcile(t *testing.T) {
 			},
 			wantEC: &ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            "foo",
-					Namespace:       "bar",
-					ResourceVersion: "1000",
+					Name:              "foo",
+					Namespace:         "bar",
+					CreationTimestamp: metav1.NewTime(parseTime(t, "2025-04-02 11:57:12")),
+					ResourceVersion:   "1000",
 				},
 				Spec: ephemeralclusterv1.EphemeralClusterSpec{TearDownCluster: true},
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
@@ -1190,6 +1201,13 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			wantRes: reconcile.Result{RequeueAfter: pollingTime},
+			wantProvisioningDurationHistogram: []metric{{
+				Histogram: &histogram{
+					Labels:      []string{""},
+					SampleCount: 1,
+					Buckets:     histogramBuckets(provisioningDurationBuckets, 0, 0, 1),
+				},
+			}},
 		},
 		{
 			name: "Test completed, ci-operator NS not found",
@@ -1588,6 +1606,13 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			wantRes: reconcile.Result{},
+			wantProvisioningDurationHistogram: []metric{{
+				Histogram: &histogram{
+					Labels:      []string{"e2e-aws"},
+					SampleCount: 1,
+					Buckets:     histogramBuckets(provisioningDurationBuckets, 0, 0, 0, 0, 1),
+				},
+			}},
 			wantDeprovisioningDurationHistogram: []metric{{
 				Histogram: &histogram{
 					Labels:      []string{"e2e-aws"},

--- a/pkg/controller/ephemeralcluster/reconciler_test.go
+++ b/pkg/controller/ephemeralcluster/reconciler_test.go
@@ -13,7 +13,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
@@ -66,20 +65,7 @@ func prowConfigAgent(c *prowconfig.Config) *prowconfig.Agent {
 }
 
 func fakeNow(t *testing.T) time.Time {
-	fakeNow, err := time.Parse("2006-01-02 15:04:05", "2025-04-02 12:12:12")
-	if err != nil {
-		t.Fatalf("parse fake now: %s", err)
-	}
-	return fakeNow
-}
-
-func fakeScheme(t *testing.T) *runtime.Scheme {
-	scheme := runtime.NewScheme()
-	sb := runtime.NewSchemeBuilder(ephemeralclusterv1.AddToScheme, prowv1.AddToScheme, corev1.AddToScheme)
-	if err := sb.AddToScheme(scheme); err != nil {
-		t.Fatal("build scheme")
-	}
-	return scheme
+	return parseTime(t, "2025-04-02 12:12:12")
 }
 
 func cmpError(t *testing.T, want, got error) {
@@ -620,22 +606,30 @@ func TestReconcile(t *testing.T) {
 	const pollingTime = 5
 
 	for _, tc := range []struct {
-		name         string
-		ec           *ephemeralclusterv1.EphemeralCluster
-		objs         []ctrlclient.Object
-		buildClients func() map[string]*ctrlruntimetest.FakeClient
-		wantEC       *ephemeralclusterv1.EphemeralCluster
-		wantSecret   *corev1.Secret
-		wantRes      reconcile.Result
-		wantErr      error
+		name                              string
+		ec                                *ephemeralclusterv1.EphemeralCluster
+		objs                              []ctrlclient.Object
+		buildClients                      func() map[string]*ctrlruntimetest.FakeClient
+		now                               *time.Time
+		wantEC                            *ephemeralclusterv1.EphemeralCluster
+		wantSecret                        *corev1.Secret
+		wantRes                           reconcile.Result
+		wantProvisioningDurationHistogram []metric
+		wantErr                           error
 	}{
 		{
 			name: "Kubeconfig ready",
 			ec: &ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo",
-					Namespace: "bar",
-					UID:       types.UID("test-ec-uid"),
+					Name:              "foo",
+					Namespace:         "bar",
+					CreationTimestamp: metav1.NewTime(parseTime(t, "2025-04-02 12:12:12")),
+					UID:               types.UID("test-ec-uid"),
+				},
+				Spec: ephemeralclusterv1.EphemeralClusterSpec{
+					CIOperator: ephemeralclusterv1.CIOperatorSpec{
+						Test: ephemeralclusterv1.TestSpec{Workflow: "e2e-aws"},
+					},
 				},
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
 					ProwJobID: "pj-123",
@@ -676,11 +670,18 @@ func TestReconcile(t *testing.T) {
 					"kubeAdminPassword": {},
 				},
 			},
+			now: ptr.To(parseTime(t, "2025-04-02 12:14:12")),
 			wantEC: &ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            "foo",
-					Namespace:       "bar",
-					ResourceVersion: "1000",
+					Name:              "foo",
+					Namespace:         "bar",
+					CreationTimestamp: metav1.NewTime(parseTime(t, "2025-04-02 12:12:12")),
+					ResourceVersion:   "1000",
+				},
+				Spec: ephemeralclusterv1.EphemeralClusterSpec{
+					CIOperator: ephemeralclusterv1.CIOperatorSpec{
+						Test: ephemeralclusterv1.TestSpec{Workflow: "e2e-aws"},
+					},
 				},
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
 					Phase:      ephemeralclusterv1.EphemeralClusterReady,
@@ -691,15 +692,22 @@ func TestReconcile(t *testing.T) {
 						Type:               ephemeralclusterv1.ProwJobCreating,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ProwJobCreatingDoneReason,
-						LastTransitionTime: metav1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(parseTime(t, "2025-04-02 12:14:12")),
 					}, {
 						Type:               ephemeralclusterv1.ClusterReady,
 						Status:             ephemeralclusterv1.ConditionTrue,
-						LastTransitionTime: metav1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(parseTime(t, "2025-04-02 12:14:12")),
 					}},
 				},
 			},
 			wantRes: reconcile.Result{RequeueAfter: pollingTime},
+			wantProvisioningDurationHistogram: []metric{{
+				Histogram: &histogram{
+					Labels:      []string{"e2e-aws"},
+					SampleCount: 1,
+					Buckets:     histogramBuckets(provisioningDurationBuckets, 1),
+				},
+			}},
 		},
 		{
 			name: "ci-operator NS doesn't exist yet",
@@ -1313,9 +1321,10 @@ func TestReconcile(t *testing.T) {
 			name: "Hive cluster provisioned, report secrets",
 			ec: &ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo",
-					Namespace: "bar",
-					UID:       types.UID("test-ec-uid"),
+					Name:              "foo",
+					Namespace:         "bar",
+					CreationTimestamp: metav1.NewTime(parseTime(t, "2025-04-02 12:12:12")),
+					UID:               types.UID("test-ec-uid"),
 				},
 				Spec: ephemeralclusterv1.EphemeralClusterSpec{
 					CIOperator: ephemeralclusterv1.CIOperatorSpec{
@@ -1366,11 +1375,13 @@ func TestReconcile(t *testing.T) {
 					"kubeAdminPassword": []byte("admin-passwd"),
 				},
 			},
+			now: ptr.To(parseTime(t, "2025-04-02 13:11:12")),
 			wantEC: &ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            "foo",
-					Namespace:       "bar",
-					ResourceVersion: "1000",
+					Name:              "foo",
+					Namespace:         "bar",
+					CreationTimestamp: metav1.NewTime(parseTime(t, "2025-04-02 12:12:12")),
+					ResourceVersion:   "1000",
 				},
 				Spec: ephemeralclusterv1.EphemeralClusterSpec{
 					CIOperator: ephemeralclusterv1.CIOperatorSpec{
@@ -1387,15 +1398,22 @@ func TestReconcile(t *testing.T) {
 						Type:               ephemeralclusterv1.ProwJobCreating,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ProwJobCreatingDoneReason,
-						LastTransitionTime: metav1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(parseTime(t, "2025-04-02 13:11:12")),
 					}, {
 						Type:               ephemeralclusterv1.ClusterReady,
 						Status:             ephemeralclusterv1.ConditionTrue,
-						LastTransitionTime: metav1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(parseTime(t, "2025-04-02 13:11:12")),
 					}},
 				},
 			},
 			wantRes: reconcile.Result{RequeueAfter: pollingTime},
+			wantProvisioningDurationHistogram: []metric{{
+				Histogram: &histogram{
+					Labels:      []string{""},
+					SampleCount: 1,
+					Buckets:     histogramBuckets(provisioningDurationBuckets, 0, 0, 0, 0, 1),
+				},
+			}},
 		},
 		{
 			name: "Hive cluster not ready yet, kubeconfig missing",
@@ -1576,17 +1594,27 @@ func TestReconcile(t *testing.T) {
 				}
 			}
 
+			provisioningDurationHistogramVec := newProvisioningDurationHistogramVec()
+			metricsGatherer := newMetricsGatherer(logrus.NewEntry(logrus.StandardLogger()),
+				nil, nil, provisioningDurationHistogramVec, "", 0)
+
+			subTestFakeNow := fakeNow
+			if tc.now != nil {
+				subTestFakeNow = *tc.now
+			}
+
 			r := reconciler{
 				logger:       logrus.NewEntry(logrus.StandardLogger()),
 				masterClient: client,
 				buildClients: clients,
 				scheme:       scheme,
-				now:          func() time.Time { return fakeNow },
+				now:          func() time.Time { return subTestFakeNow },
 				polling:      func() time.Duration { return pollingTime },
-				newProwJob:   newProwJobFaker("foobar", fakeNow),
+				newProwJob:   newProwJobFaker("foobar", subTestFakeNow),
 				prowConfigAgent: prowConfigAgent(&prowconfig.Config{
 					ProwConfig: prowconfig.ProwConfig{ProwJobNamespace: prowJobNamespace},
 				}),
+				collectProvisioningDurationMetricFunc: metricsGatherer.collectProvisioningDuration,
 			}
 
 			gotRes, gotErr := r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.ec.Name, Namespace: tc.ec.Namespace}})
@@ -1641,6 +1669,15 @@ func TestReconcile(t *testing.T) {
 				if len(allObjs) > 0 {
 					testhelper.CompareWithFixture(t, allObjs, testhelper.WithPrefix(cluster+"-"))
 				}
+			}
+
+			gotProvisioningDurationMetrics, err := collectHistogram(provisioningDurationHistogramVec.MetricVec)
+			if err != nil {
+				t.Fatalf("collect provision duration histogram: %s", err)
+			}
+
+			if diff := cmpMetrics(tc.wantProvisioningDurationHistogram, gotProvisioningDurationMetrics); diff != "" {
+				t.Errorf("Provisioning duration metric differ: %s\n", diff)
 			}
 		})
 	}

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_build01_TestReconcile_ProwJob_succeeded_after_deprovisioning__collect_deprovisioning_metric.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_build01_TestReconcile_ProwJob_succeeded_after_deprovisioning__collect_deprovisioning_metric.yaml
@@ -1,0 +1,26 @@
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    creationTimestamp: null
+    labels:
+      ci.openshift.io/jobid: pj-123
+    name: ci-op-1234
+    resourceVersion: "999"
+  spec: {}
+  status: {}
+- apiVersion: v1
+  data:
+    kubeconfig: a3ViZWNvbmZpZw==
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    name: cluster-provisioning
+    namespace: ci-op-1234
+    resourceVersion: "999"
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    name: test-done-signal
+    namespace: ci-op-1234
+    resourceVersion: "999"

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestReconcile_ProwJob_succeeded_after_deprovisioning__collect_deprovisioning_metric.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestReconcile_ProwJob_succeeded_after_deprovisioning__collect_deprovisioning_metric.yaml
@@ -1,0 +1,12 @@
+items:
+- metadata:
+    creationTimestamp: null
+    name: pj-123
+    namespace: ci
+    resourceVersion: "999"
+  spec:
+    cluster: build01
+  status:
+    startTime: null
+    state: success
+metadata: {}

--- a/pkg/controller/ephemeralcluster/testutil_test.go
+++ b/pkg/controller/ephemeralcluster/testutil_test.go
@@ -1,0 +1,166 @@
+package ephemeralcluster
+
+import (
+	"fmt"
+	"math"
+	"slices"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	ephemeralclusterv1 "github.com/openshift/ci-tools/pkg/api/ephemeralcluster/v1"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
+)
+
+type metric struct {
+	Gauge     *gauge
+	Histogram *histogram
+}
+
+type gauge struct {
+	Labels []string
+	Value  float64
+}
+
+type histogram struct {
+	Labels      []string
+	SampleCount uint64
+	Buckets     []bucket
+}
+
+type bucket struct {
+	UpperBound float64
+	Count      uint64
+}
+
+func sortMetricsFunc(a, b metric) int {
+	metricLabels := func(m metric) []string {
+		if m.Gauge != nil {
+			sort.Strings(m.Gauge.Labels)
+			return m.Gauge.Labels
+		}
+		if m.Histogram != nil {
+			sort.Strings(m.Histogram.Labels)
+			return m.Histogram.Labels
+		}
+		return nil
+	}
+	as := strings.Join(metricLabels(a), "")
+	bs := strings.Join(metricLabels(b), "")
+	return strings.Compare(as, bs)
+}
+
+type metricTransformer func(in *dto.Metric) metric
+
+func gaugeTransformer(in *dto.Metric) metric {
+	out := metric{Gauge: &gauge{Value: *in.Gauge.Value}}
+
+	for _, l := range in.Label {
+		out.Gauge.Labels = append(out.Gauge.Labels, *l.Value)
+	}
+
+	return out
+}
+
+func histogramTransformer(in *dto.Metric) metric {
+	out := metric{
+		Histogram: &histogram{
+			SampleCount: in.Histogram.GetSampleCount(),
+			Buckets:     make([]bucket, len(in.Histogram.Bucket)),
+		},
+	}
+
+	var prevCumulativeCount uint64
+	for i, b := range in.Histogram.Bucket {
+		out.Histogram.Buckets[i] = bucket{
+			UpperBound: b.GetUpperBound(),
+			Count:      b.GetCumulativeCount() - prevCumulativeCount,
+		}
+		prevCumulativeCount = b.GetCumulativeCount()
+	}
+
+	out.Histogram.Buckets = append(out.Histogram.Buckets, bucket{
+		UpperBound: math.Inf(1),
+		Count:      in.Histogram.GetSampleCount() - prevCumulativeCount,
+	})
+
+	for _, l := range in.Label {
+		out.Histogram.Labels = append(out.Histogram.Labels, *l.Value)
+	}
+
+	return out
+}
+
+func histogramBuckets(upperBounds []float64, counts ...uint64) []bucket {
+	upperBounds = append(upperBounds, math.Inf(1))
+	res := make([]bucket, len(upperBounds))
+	for i, b := range upperBounds {
+		res[i] = bucket{
+			UpperBound: b,
+		}
+		if i < len(counts) {
+			res[i].Count = counts[i]
+		}
+	}
+	return res
+}
+
+func collect(v *prometheus.MetricVec, transform metricTransformer) (result []metric, err error) {
+	metricCh := make(chan prometheus.Metric)
+
+	wg := sync.WaitGroup{}
+	wg.Go(func() {
+		for m := range metricCh {
+			dtoMetric := dto.Metric{}
+			if writeErr := m.Write(&dtoMetric); writeErr != nil {
+				err = fmt.Errorf("write gauge: %w", writeErr)
+				return
+			}
+			result = append(result, transform(&dtoMetric))
+		}
+	})
+
+	v.Collect(metricCh)
+	close(metricCh)
+	wg.Wait()
+
+	return
+}
+
+func collectGauge(v *prometheus.MetricVec) (result []metric, err error) {
+	return collect(v, gaugeTransformer)
+}
+
+func collectHistogram(v *prometheus.MetricVec) (result []metric, err error) {
+	return collect(v, histogramTransformer)
+}
+
+func cmpMetrics(a, b []metric) string {
+	slices.SortFunc(a, sortMetricsFunc)
+	slices.SortFunc(b, sortMetricsFunc)
+	return cmp.Diff(a, b)
+}
+
+func parseTime(t *testing.T, timeStr string) time.Time {
+	parsed, err := time.Parse("2006-01-02 15:04:05", timeStr)
+	if err != nil {
+		t.Fatalf("parse fake now: %s", err)
+	}
+	return parsed
+}
+
+func fakeScheme(t *testing.T) *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	sb := runtime.NewSchemeBuilder(ephemeralclusterv1.AddToScheme, prowv1.AddToScheme, corev1.AddToScheme)
+	if err := sb.AddToScheme(scheme); err != nil {
+		t.Fatal("build scheme")
+	}
+	return scheme
+}

--- a/pkg/controller/ephemeralcluster/testutil_test.go
+++ b/pkg/controller/ephemeralcluster/testutil_test.go
@@ -16,6 +16,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	aggerrs "k8s.io/apimachinery/pkg/util/errors"
 	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 )
 
@@ -112,16 +113,18 @@ func histogramBuckets(upperBounds []float64, counts ...uint64) []bucket {
 	return res
 }
 
-func collect(v *prometheus.MetricVec, transform metricTransformer) (result []metric, err error) {
+func collect(v *prometheus.MetricVec, transform metricTransformer) ([]metric, error) {
 	metricCh := make(chan prometheus.Metric)
+	errs := make([]error, 0)
+	var result []metric
 
 	wg := sync.WaitGroup{}
 	wg.Go(func() {
 		for m := range metricCh {
 			dtoMetric := dto.Metric{}
 			if writeErr := m.Write(&dtoMetric); writeErr != nil {
-				err = fmt.Errorf("write gauge: %w", writeErr)
-				return
+				errs = append(errs, fmt.Errorf("write gauge: %w", writeErr))
+				continue
 			}
 			result = append(result, transform(&dtoMetric))
 		}
@@ -131,7 +134,7 @@ func collect(v *prometheus.MetricVec, transform metricTransformer) (result []met
 	close(metricCh)
 	wg.Wait()
 
-	return
+	return result, aggerrs.NewAggregate(errs)
 }
 
 func collectGauge(v *prometheus.MetricVec) (result []metric, err error) {

--- a/pkg/controller/ephemeralcluster/testutil_test.go
+++ b/pkg/controller/ephemeralcluster/testutil_test.go
@@ -40,7 +40,7 @@ type bucket struct {
 	Count      uint64
 }
 
-func sortMetricsFunc(a, b metric) int {
+func sortMetrics(a, b metric) int {
 	metricLabels := func(m metric) []string {
 		if m.Gauge != nil {
 			sort.Strings(m.Gauge.Labels)
@@ -143,8 +143,8 @@ func collectHistogram(v *prometheus.MetricVec) (result []metric, err error) {
 }
 
 func cmpMetrics(a, b []metric) string {
-	slices.SortFunc(a, sortMetricsFunc)
-	slices.SortFunc(b, sortMetricsFunc)
+	slices.SortFunc(a, sortMetrics)
+	slices.SortFunc(b, sortMetrics)
 	return cmp.Diff(a, b)
 }
 

--- a/pkg/controller/ephemeralcluster/testutil_test.go
+++ b/pkg/controller/ephemeralcluster/testutil_test.go
@@ -11,13 +11,15 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	ephemeralclusterv1 "github.com/openshift/ci-tools/pkg/api/ephemeralcluster/v1"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	aggerrs "k8s.io/apimachinery/pkg/util/errors"
 	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
+
+	ephemeralclusterv1 "github.com/openshift/ci-tools/pkg/api/ephemeralcluster/v1"
 )
 
 type metric struct {


### PR DESCRIPTION
Add the following metrics:
```
ephemeralcluster_count{konflux_cluster, konflux_namespace, cluster_profile, workflow, phase}
ephemeralcluster_provisioning_duration_seconds{workflow}
ephemeralcluster_deprovisioning_duration_seconds{workflow}
```

`ephemeralcluster_count` replace `ephemeralclusters` as the new name is much clearer and more consistent with Prometheus metric naming conventions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

The ephemeral cluster controller now exposes Prometheus metrics for Konflux cluster operations:

- `ephemeralcluster_count` tracks clusters by profile, workflow, phase, namespace, and management cluster.
- Provisioning and deprovisioning histograms track operation duration by workflow.
- Deprovisioning metrics support restart and Prow job completion edge cases.

The reconciler records these metrics when clusters become ready or complete deprovisioning. Tests cover provisioning, failure, deprovisioning, hosted management clusters, and successful Prow job completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->