### PR TITLE
DPTP-5132: prowgen: add support for skip_if_only_changed and run_if_changed on operator.bundles[]

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1538,6 +1538,14 @@ type Bundle struct {
 	Optional bool `json:"optional,omitempty"`
 	// Capabilities is the list of strings that define additional capabilities needed by the bundle build job
 	Capabilities []string `json:"capabilities,omitempty"`
+	// RunIfChanged is a regex that will cause the auto-generated bundle
+	// presubmit to only run if a file matching the regex is changed.
+	// This field works only for named bundles, i.e., "as" is not empty.
+	RunIfChanged string `json:"run_if_changed,omitempty"`
+	// SkipIfOnlyChanged is a regex that will cause the auto-generated bundle
+	// presubmit to be skipped if all changed files match the regex.
+	// This field works only for named bundles, i.e., "as" is not empty.
+	SkipIfOnlyChanged string `json:"skip_if_only_changed,omitempty"`
 }
 
 // IndexGeneratorStepConfiguration describes a step that creates an index database and

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -201,6 +201,8 @@ func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *cio
 			presubmits[orgrepo] = append(presubmits[orgrepo], *generatePresubmitForTest(jobBaseGen, testName, info, func(options *generatePresubmitOptions) {
 				options.optional = bundle.Optional
 				options.Capabilities = bundle.Capabilities
+				options.runIfChanged = bundle.RunIfChanged
+				options.skipIfOnlyChanged = bundle.SkipIfOnlyChanged
 			}))
 		}
 		if containsUnnamedBundle {

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -651,6 +651,62 @@ func TestGenerateJobs(t *testing.T) {
 				Branch: "branch",
 			},
 		}, {
+			id:   "operator section creates ci-bundle-my-bundle presubmit job with skip_if_only_changed",
+			keep: true,
+			config: &ciop.ReleaseBuildConfiguration{
+				Tests: []ciop.TestStepConfiguration{},
+				Operator: &ciop.OperatorStepConfiguration{
+					Bundles: []ciop.Bundle{{
+						As:                "my-bundle",
+						DockerfilePath:    "bundle.Dockerfile",
+						ContextDir:        "manifests",
+						SkipBuildingIndex: true,
+						SkipIfOnlyChanged: `^(docs/|.*\.md$)`,
+					}},
+				},
+			},
+			repoInfo: &ciop.Metadata{
+				Org:    "organization",
+				Repo:   "repository",
+				Branch: "branch",
+			},
+		}, {
+			id: "operator bundle job with skip_if_only_changed propagated to presubmit",
+			config: &ciop.ReleaseBuildConfiguration{
+				Tests: []ciop.TestStepConfiguration{},
+				Operator: &ciop.OperatorStepConfiguration{
+					Bundles: []ciop.Bundle{{
+						As:                "my-bundle",
+						DockerfilePath:    "bundle.Dockerfile",
+						ContextDir:        "manifests",
+						SkipIfOnlyChanged: `^(docs/|.*\.md$)`,
+					}},
+				},
+			},
+			repoInfo: &ciop.Metadata{
+				Org:    "organization",
+				Repo:   "repository",
+				Branch: "branch",
+			},
+		}, {
+			id: "operator bundle job with run_if_changed propagated to presubmit",
+			config: &ciop.ReleaseBuildConfiguration{
+				Tests: []ciop.TestStepConfiguration{},
+				Operator: &ciop.OperatorStepConfiguration{
+					Bundles: []ciop.Bundle{{
+						As:             "my-bundle",
+						DockerfilePath: "bundle.Dockerfile",
+						ContextDir:     "manifests",
+						RunIfChanged:   `^(Dockerfile|src/)`,
+					}},
+				},
+			},
+			repoInfo: &ciop.Metadata{
+				Org:    "organization",
+				Repo:   "repository",
+				Branch: "branch",
+			},
+		}, {
 			id: "skip operator presubmits via ci-operator config",
 			config: &ciop.ReleaseBuildConfiguration{
 				Prowgen: &ciop.ProwgenOverrides{SkipOperatorPresubmits: true},

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_operator_bundle_job_with_run_if_changed_propagated_to_presubmit.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_operator_bundle_job_with_run_if_changed_propagated_to_presubmit.yaml
@@ -1,0 +1,7 @@
+presubmits:
+  organization/repository:
+  - always_run: false
+    labels:
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-organization-repository-branch-ci-index-my-bundle
+    run_if_changed: ^(Dockerfile|src/)

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_operator_bundle_job_with_skip_if_only_changed_propagated_to_presubmit.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_operator_bundle_job_with_skip_if_only_changed_propagated_to_presubmit.yaml
@@ -1,0 +1,7 @@
+presubmits:
+  organization/repository:
+  - always_run: false
+    labels:
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-organization-repository-branch-ci-index-my-bundle
+    skip_if_only_changed: ^(docs/|.*\.md$)

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_operator_section_creates_ci_bundle_my_bundle_presubmit_job_with_skip_if_only_changed.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_operator_section_creates_ci_bundle_my_bundle_presubmit_job_with_skip_if_only_changed.yaml
@@ -1,0 +1,56 @@
+presubmits:
+  organization/repository:
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^branch$
+    - ^branch-
+    context: ci/prow/ci-bundle-my-bundle
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-organization-repository-branch-ci-bundle-my-bundle
+    rerun_command: /test ci-bundle-my-bundle
+    skip_if_only_changed: ^(docs/|.*\.md$)
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=my-bundle
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )ci-bundle-my-bundle,?($|\s.*)

--- a/pkg/validation/config.go
+++ b/pkg/validation/config.go
@@ -303,22 +303,52 @@ func validateBuildRootImageStreamTag(ctx *configContext, buildRoot api.ImageStre
 	return validationErrors
 }
 
-func validateRunIfChangedExclusivity(runIfChanged, skipIfOnlyChanged, pipelineRunIfChanged, pipelineSkipIfOnlyChanged string) error {
+// runIfChangedField pairs a config field's YAML name with its configured value, so that
+// validateRunIfChangedExclusivity can report an error that only mentions fields that are
+// actually valid for the caller.
+type runIfChangedField struct {
+	name  string
+	value string
+}
+
+// joinFieldNamesWithAnd renders a slice of already-formatted field names as an
+// Oxford-comma-separated English list, e.g. "a, b, and c" or "a and b".
+func joinFieldNamesWithAnd(names []string) string {
+	switch len(names) {
+	case 0:
+		return ""
+	case 1:
+		return names[0]
+	case 2:
+		return names[0] + " and " + names[1]
+	default:
+		return strings.Join(names[:len(names)-1], ", ") + ", and " + names[len(names)-1]
+	}
+}
+
+func validateRunIfChangedExclusivity(fields ...runIfChangedField) error {
 	set := 0
-	for _, f := range []string{runIfChanged, skipIfOnlyChanged, pipelineRunIfChanged, pipelineSkipIfOnlyChanged} {
-		if f != "" {
+	names := make([]string, 0, len(fields))
+	for _, f := range fields {
+		names = append(names, fmt.Sprintf("`%s`", f.name))
+		if f.value != "" {
 			set++
 		}
 	}
 	if set > 1 {
-		return fmt.Errorf("`run_if_changed`, `skip_if_only_changed`, `pipeline_run_if_changed`, and `pipeline_skip_if_only_changed` are mutually exclusive")
+		return fmt.Errorf("%s are mutually exclusive", joinFieldNamesWithAnd(names))
 	}
 	return nil
 }
 
 func validateImageConfiguration(ctx *configContext, images api.ImageConfiguration) []error {
 	var validationErrors []error
-	if err := validateRunIfChangedExclusivity(images.RunIfChanged, images.SkipIfOnlyChanged, images.PipelineRunIfChanged, images.PipelineSkipIfOnlyChanged); err != nil {
+	if err := validateRunIfChangedExclusivity(
+		runIfChangedField{"run_if_changed", images.RunIfChanged},
+		runIfChangedField{"skip_if_only_changed", images.SkipIfOnlyChanged},
+		runIfChangedField{"pipeline_run_if_changed", images.PipelineRunIfChanged},
+		runIfChangedField{"pipeline_skip_if_only_changed", images.PipelineSkipIfOnlyChanged},
+	); err != nil {
 		validationErrors = append(validationErrors, ctx.errorf("%s", err))
 	}
 	validationErrors = append(validationErrors, ValidateImages(ctx, images.Items)...)
@@ -405,7 +435,10 @@ func validateOperator(ctx *configContext, input *api.OperatorStepConfiguration, 
 		if bundle.As == "" && bundle.SkipIfOnlyChanged != "" {
 			validationErrors = append(validationErrors, ctxN.AddField("skip_if_only_changed").errorf("skip_if_only_changed requires 'as' to be set"))
 		}
-		if err := validateRunIfChangedExclusivity(bundle.RunIfChanged, bundle.SkipIfOnlyChanged, "", ""); err != nil {
+		if err := validateRunIfChangedExclusivity(
+			runIfChangedField{"run_if_changed", bundle.RunIfChanged},
+			runIfChangedField{"skip_if_only_changed", bundle.SkipIfOnlyChanged},
+		); err != nil {
 			validationErrors = append(validationErrors, ctxN.errorf("%s", err))
 		}
 		if bundle.UpdateGraph != "" {

--- a/pkg/validation/config.go
+++ b/pkg/validation/config.go
@@ -399,6 +399,15 @@ func validateOperator(ctx *configContext, input *api.OperatorStepConfiguration, 
 		if bundle.As == "" && bundle.SkipBuildingIndex {
 			validationErrors = append(validationErrors, ctxN.AddField("skip_building_index").errorf("skip_building_index requires 'as' to be set"))
 		}
+		if bundle.As == "" && bundle.RunIfChanged != "" {
+			validationErrors = append(validationErrors, ctxN.AddField("run_if_changed").errorf("run_if_changed requires 'as' to be set"))
+		}
+		if bundle.As == "" && bundle.SkipIfOnlyChanged != "" {
+			validationErrors = append(validationErrors, ctxN.AddField("skip_if_only_changed").errorf("skip_if_only_changed requires 'as' to be set"))
+		}
+		if err := validateRunIfChangedExclusivity(bundle.RunIfChanged, bundle.SkipIfOnlyChanged, "", ""); err != nil {
+			validationErrors = append(validationErrors, ctxN.errorf("%s", err))
+		}
 		if bundle.UpdateGraph != "" {
 			if bundle.BaseIndex == "" {
 				validationErrors = append(validationErrors, ctxN.AddField("update_graph").errorf("update_graph requires base_index to be set"))

--- a/pkg/validation/config_test.go
+++ b/pkg/validation/config_test.go
@@ -800,6 +800,76 @@ func TestValidateOperator(t *testing.T) {
 				errors.New("operator.bundles[0].skip_building_index: skip_building_index requires 'as' to be set"),
 			},
 		},
+		{
+			name: "run_if_changed can be set on a named bundle",
+			input: &api.OperatorStepConfiguration{
+				Bundles: []api.Bundle{{
+					As:                "my-bundle",
+					DockerfilePath:    "./dockerfile",
+					ContextDir:        ".",
+					SkipBuildingIndex: true,
+					RunIfChanged:      "^(Dockerfile|src/)",
+				}},
+			},
+			withResolvesTo: goodStepLink,
+		},
+		{
+			name: "skip_if_only_changed can be set on a named bundle",
+			input: &api.OperatorStepConfiguration{
+				Bundles: []api.Bundle{{
+					As:                "my-bundle",
+					DockerfilePath:    "./dockerfile",
+					ContextDir:        ".",
+					SkipBuildingIndex: true,
+					SkipIfOnlyChanged: `^(docs/|.*\.md$)`,
+				}},
+			},
+			withResolvesTo: goodStepLink,
+		},
+		{
+			name: "run_if_changed cannot be set on an unnamed bundle",
+			input: &api.OperatorStepConfiguration{
+				Bundles: []api.Bundle{{
+					DockerfilePath: "./dockerfile",
+					ContextDir:     ".",
+					RunIfChanged:   "^(Dockerfile|src/)",
+				}},
+			},
+			withResolvesTo: goodStepLink,
+			output: []error{
+				errors.New("operator.bundles[0].run_if_changed: run_if_changed requires 'as' to be set"),
+			},
+		},
+		{
+			name: "skip_if_only_changed cannot be set on an unnamed bundle",
+			input: &api.OperatorStepConfiguration{
+				Bundles: []api.Bundle{{
+					DockerfilePath:    "./dockerfile",
+					ContextDir:        ".",
+					SkipIfOnlyChanged: `^(docs/|.*\.md$)`,
+				}},
+			},
+			withResolvesTo: goodStepLink,
+			output: []error{
+				errors.New("operator.bundles[0].skip_if_only_changed: skip_if_only_changed requires 'as' to be set"),
+			},
+		},
+		{
+			name: "run_if_changed and skip_if_only_changed are mutually exclusive",
+			input: &api.OperatorStepConfiguration{
+				Bundles: []api.Bundle{{
+					As:                "my-bundle",
+					DockerfilePath:    "./dockerfile",
+					ContextDir:        ".",
+					RunIfChanged:      "^(Dockerfile|src/)",
+					SkipIfOnlyChanged: `^(docs/|.*\.md$)`,
+				}},
+			},
+			withResolvesTo: goodStepLink,
+			output: []error{
+				errors.New("operator.bundles[0]: `run_if_changed`, `skip_if_only_changed`, `pipeline_run_if_changed`, and `pipeline_skip_if_only_changed` are mutually exclusive"),
+			},
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/pkg/validation/config_test.go
+++ b/pkg/validation/config_test.go
@@ -867,7 +867,7 @@ func TestValidateOperator(t *testing.T) {
 			},
 			withResolvesTo: goodStepLink,
 			output: []error{
-				errors.New("operator.bundles[0]: `run_if_changed`, `skip_if_only_changed`, `pipeline_run_if_changed`, and `pipeline_skip_if_only_changed` are mutually exclusive"),
+				errors.New("operator.bundles[0]: `run_if_changed` and `skip_if_only_changed` are mutually exclusive"),
 			},
 		},
 	}

--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -201,7 +201,12 @@ func (v *Validator) validateTestStepConfiguration(
 		if (test.Cron != nil || test.Interval != nil || test.MinimumInterval != nil) && !test.Presubmit && (test.RunIfChanged != "" || test.SkipIfOnlyChanged != "" || test.Optional) {
 			validationErrors = append(validationErrors, fmt.Errorf("%s: `cron`/`interval`/`minimum_interval` are mutually exclusive with `run_if_changed`/`skip_if_only_changed`/`optional`", fieldRootN))
 		}
-		if err := validateRunIfChangedExclusivity(test.RunIfChanged, test.SkipIfOnlyChanged, test.PipelineRunIfChanged, test.PipelineSkipIfOnlyChanged); err != nil {
+		if err := validateRunIfChangedExclusivity(
+			runIfChangedField{"run_if_changed", test.RunIfChanged},
+			runIfChangedField{"skip_if_only_changed", test.SkipIfOnlyChanged},
+			runIfChangedField{"pipeline_run_if_changed", test.PipelineRunIfChanged},
+			runIfChangedField{"pipeline_skip_if_only_changed", test.PipelineSkipIfOnlyChanged},
+		); err != nil {
 			validationErrors = append(validationErrors, fmt.Errorf("%s: %w", fieldRootN, err))
 		}
 

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -280,9 +280,17 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"          dockerfile_path: ' '\n" +
 	"          # Optional indicates that the job's status context, that is generated from the corresponding test, should not be required for merge.\n" +
 	"          optional: true\n" +
+	"          # RunIfChanged is a regex that will cause the auto-generated bundle\n" +
+	"          # presubmit to only run if a file matching the regex is changed.\n" +
+	"          # This field works only for named bundles, i.e., \"as\" is not empty.\n" +
+	"          run_if_changed: ' '\n" +
 	"          # Skip building the index image for this bundle. Default to false.\n" +
 	"          # This field works only for named bundles, i.e., \"as\" is not empty.\n" +
 	"          skip_building_index: true\n" +
+	"          # SkipIfOnlyChanged is a regex that will cause the auto-generated bundle\n" +
+	"          # presubmit to be skipped if all changed files match the regex.\n" +
+	"          # This field works only for named bundles, i.e., \"as\" is not empty.\n" +
+	"          skip_if_only_changed: ' '\n" +
 	"          # UpdateGraph defines the update mode to use when adding the bundle to the base index.\n" +
 	"          # Can be: semver (default), semver-skippatch, or replaces\n" +
 	"          update_graph: ' '\n" +


### PR DESCRIPTION
Bundle presubmits (ci-bundle-*/ci-index-*) always ran with
 always_run: true
with no way to skip them on documentation-only or metadata-only PRs, unlike images and tests[] which already support run_if_changed/ skip_if_only_changed.

For operators whose bundle build depends on
resolving a full image build (e.g. via operator.substitutions), this forces an expensive rebuild on every PR regardless of what changed.

This PR adds run_if_changed/skip_if_only_changed to the Bundle type and wire them into the bundle presubmit generation in prowgen, so named bundles can opt out of always_run
the same way tests[] entries do.
Validation requires 'as' to be set for either field (matching base_index/ skip_building_index) and rejects setting both at once.

Fixes https://github.com/openshift/ci-tools/issues/5357

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

`prowgen` now supports `run_if_changed` and `skip_if_only_changed` for `operator.bundles[]`.

CI operators can control when bundle presubmit jobs run. Jobs can skip documentation-only changes or run only when selected files change.

The settings propagate to generated Prow presubmits. Validation requires `as` for either field and rejects using both fields together. Tests and fixtures cover propagation and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->