### PR TITLE
fix(multi-pr-prow-plugin): comment on PR when job URL is not available

### DIFF
--- a/cmd/multi-pr-prow-plugin/server.go
+++ b/cmd/multi-pr-prow-plugin/server.go
@@ -228,6 +228,14 @@ func (s *server) handle(l *logrus.Entry, ic github.IssueCommentEvent) ([]*prowv1
 				err := s.reporter.reportNewProwJob(prowJob, jr, l)
 				if err != nil {
 					l.WithError(err).Error("could not report new prow job")
+					comment := fmt.Sprintf(
+						"@%s, `testwith`: job `%s` was triggered but the status URL was not available in time.\n"+
+							"You can find the job at: https://prow.ci.openshift.org/?job=%s",
+						user, prowJob.Spec.Job, prowJob.Spec.Job,
+					)
+					if err := s.ghc.CreateComment(org, repo, number, comment); err != nil {
+						l.WithError(err).Error("failed to create comment for missing URL")
+					}
 				}
 			}()
 


### PR DESCRIPTION
## Summary
- When the multi-pr-prow-plugin times out waiting for a ProwJob's status URL (60s), it now posts a comment on the PR with a Prow search link instead of failing silently
- Users can find their triggered job via the link even when the cluster is overloaded and URL population is delayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates `multi-pr-prow-plugin` so that, when a ProwJob status URL is still unavailable after 60 seconds, it comments on the pull request with a Prow search link. CI users can use the link to locate the triggered job during cluster overload or other delays. The plugin logs failures to create the comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->