### PR TITLE
Strip MULTISTAGE_PARAM_OVERRIDE_ prefix in applyEnvOverrides

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -842,7 +842,8 @@ func applyEnvOverrides(o *options) {
 		if len(parts) != 2 {
 			continue
 		}
-		key, value := parts[0], parts[1]
+		key := strings.TrimPrefix(parts[0], "MULTISTAGE_PARAM_OVERRIDE_")
+		value := parts[1]
 		for _, test := range o.configSpec.Tests {
 			if test.MultiStageTestConfigurationLiteral != nil {
 				if test.MultiStageTestConfigurationLiteral.Environment == nil {

--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -1351,15 +1351,15 @@ func TestApplyEnvOverrides(t *testing.T) {
 				"XXX_OVERRIDE_PARAM2":              "VAL3",
 			},
 			expectedParams: map[string]string{
-				"MULTISTAGE_PARAM_OVERRIDE_PARAM1": "VAL1",
-				"MULTISTAGE_PARAM_OVERRIDE_PARAM2": "VAL2",
+				"PARAM1": "VAL1",
+				"PARAM2": "VAL2",
 			},
 			testConfig: []api.TestStepConfiguration{
 				{
 					MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{
 						Environment: map[string]string{
-							"MULTISTAGE_PARAM_OVERRIDE_PARAM1": "VAL1",
-							"MULTISTAGE_PARAM_OVERRIDE_PARAM2": "VAL2",
+							"PARAM1": "VAL1",
+							"PARAM2": "VAL2",
 						},
 					},
 				},
@@ -1387,17 +1387,17 @@ func TestApplyEnvOverrides(t *testing.T) {
 				"MULTISTAGE_PARAM_OVERRIDE_PARAM3": "VAL2",
 			},
 			expectedParams: map[string]string{
-				"MULTISTAGE_PARAM_OVERRIDE_PARAM1": "VAL2",
-				"MULTISTAGE_PARAM_OVERRIDE_PARAM2": "VAL=2",
-				"MULTISTAGE_PARAM_OVERRIDE_PARAM3": "VAL2",
+				"PARAM1": "VAL2",
+				"PARAM2": "VAL=2",
+				"PARAM3": "VAL2",
 			},
 			testConfig: []api.TestStepConfiguration{
 				{
 					MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{
 						Environment: map[string]string{
-							"MULTISTAGE_PARAM_OVERRIDE_PARAM1": "VAL2",
-							"MULTISTAGE_PARAM_OVERRIDE_PARAM2": "VAL=2",
-							"MULTISTAGE_PARAM_OVERRIDE_PARAM3": "VAL2",
+							"PARAM1": "VAL2",
+							"PARAM2": "VAL=2",
+							"PARAM3": "VAL2",
 						},
 					},
 				},


### PR DESCRIPTION
## Problem

`applyEnvOverrides()` stores Gangway-injected env var overrides into `test.MultiStageTestConfigurationLiteral.Environment` with the full prefixed key name (e.g., `MULTISTAGE_PARAM_OVERRIDE_FBC_COMMIT_SHA`). When `generateParams()` in `pkg/steps/multi_stage/gen.go` later looks up step parameters by their declared name (`FBC_COMMIT_SHA`), the lookup misses because the stored key still has the prefix.

This makes all `MULTISTAGE_PARAM_OVERRIDE_*` env var overrides passed via Gangway `pod_spec_options.envs` silently ineffective: the env var reaches the ProwJob pod (visible in `prowjob.json`) but is never injected into step pods.

## Summary

Strip the `MULTISTAGE_PARAM_OVERRIDE_` prefix before storing, so the key matches what `generateParams()` expects. This is consistent with `overrideMultiStageParams()` which already stores bare parameter names via CLI flags.

## Changes

- `cmd/ci-operator/main.go`: use `strings.TrimPrefix` to strip the `MULTISTAGE_PARAM_OVERRIDE_` prefix from the env var name before storing it in `TestEnvironment`
- `cmd/ci-operator/main_test.go`: update test expectations to assert stripped parameter names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

`ci-operator` now removes the `MULTISTAGE_PARAM_OVERRIDE_` prefix when applying Gangway environment overrides.

This makes parameter keys such as `FBC_COMMIT_SHA` match `generateParams()` and ensures the values reach multi-stage step pods correctly.

Tests now verify the stripped parameter names and preserve values that contain `=`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->