### PR TITLE
pkg/defaults: promote to specified registry override

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -296,7 +296,8 @@ func fromConfig(ctx context.Context, cfg *Config) ([]api.Step, []api.Step, error
 
 		// Used primarily (only?) by the ci-chat-bot
 		if cfg.CIConfig.PromotionConfiguration.RegistryOverride != "" {
-			logrus.Info("No images to promote to quay.io if the registry is overridden")
+			logrus.Infof("Promoting to registry override %s instead of quay.io", registryDomain(cfg.CIConfig.PromotionConfiguration))
+			promotionSteps = append(promotionSteps, releasesteps.PromotionStep(api.PromotionStepName, cfg.CIConfig, requiredNames, cfg.SkippedImages, cfg.JobSpec, cfg.podClient, cfg.PushSecret, registryDomain(cfg.CIConfig.PromotionConfiguration), api.DefaultMirrorFunc, api.DefaultTargetNameFunc, cfg.NodeArchitectures, cliVersion))
 		} else {
 			promotionSteps = append(promotionSteps, releasesteps.PromotionStep(api.PromotionQuayStepName, cfg.CIConfig, requiredNames, cfg.SkippedImages, cfg.JobSpec, cfg.podClient, cfg.PushSecret, api.QuayOpenShiftCIRepo, api.QuayCombinedMirrorFunc, api.QuayTargetNameFunc, cfg.NodeArchitectures, cliVersion))
 		}


### PR DESCRIPTION
Promote images to the specified registry override if registry override is specified. This is required for ci-chat-bot to build releases from PRs correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
When a promotion registry override is configured, `pkg/defaults` adds a promotion step that uses the override registry. This enables `ci-chat-bot` to build releases from pull requests with images promoted to the correct registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->