### PR TITLE
pkg/steps: retry network-unreachable builds, capture failed build logs

### DIFF
--- a/pkg/steps/artifacts.go
+++ b/pkg/steps/artifacts.go
@@ -664,12 +664,12 @@ func gatherContainerLogsOutput(podClient kubernetes.PodClient, artifactDir, name
 	return utilerrors.NewAggregate(validationErrors)
 }
 
-// for gathering successful build logs to the artifacts, there is no way to augment the pod spec
+// for gathering build logs (successful or failed) to the artifacts, there is no way to augment the pod spec
 // created by the build controller to add the artifacts container; this method cherry picks elements
 // from downloadArtifacts and gatherContainerLogsOutput and munges them in conjunction with the build
 // api logging capabilities; also, without needing to inject an artifacts container, some of the complexities
 // around download/copy from the artifacts container's volume mount and multiple pods are avoided.
-func gatherSuccessfulBuildLog(buildClient BuildClient, namespace, buildName string) error {
+func gatherBuildLog(buildClient BuildClient, namespace, buildName string) error {
 	artifactDir, set := api.Artifacts()
 	if !set {
 		return nil

--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -590,7 +590,7 @@ func handleBuild(ctx context.Context, client BuildClient, podClient kubernetes.P
 			errs = append(errs, err)
 			return false, handleFailedBuild(ctx, client, ns, name, err)
 		}
-		if err := gatherSuccessfulBuildLog(client, ns, name); err != nil {
+		if err := gatherBuildLog(client, ns, name); err != nil {
 			// log error but do not fail successful build
 			logrus.WithError(err).Warnf("Failed gathering successful build %s logs into artifacts.", name)
 		}
@@ -659,7 +659,9 @@ func hintsAtInfraReason(logSnippet string) bool {
 		strings.Contains(logSnippet, "Could not resolve host: ") ||
 		strings.Contains(logSnippet, "net/http: TLS handshake timeout") ||
 		strings.Contains(logSnippet, "All mirrors were tried") ||
-		strings.Contains(logSnippet, "connection reset by peer")
+		strings.Contains(logSnippet, "connection reset by peer") ||
+		strings.Contains(logSnippet, "network is unreachable") ||
+		strings.Contains(logSnippet, "no route to host")
 }
 
 func waitForBuildOrTimeout(
@@ -746,6 +748,9 @@ func waitForBuild(
 			case buildapi.BuildPhaseFailed, buildapi.BuildPhaseCancelled, buildapi.BuildPhaseError:
 				logrus.Infof("Build %s failed, printing logs:", build.Name)
 				printBuildLogs(buildClient, build.Namespace, build.Name)
+				if err := gatherBuildLog(buildClient, build.Namespace, build.Name); err != nil {
+					logrus.WithError(err).Warnf("Failed gathering failed build %s logs into artifacts.", build.Name)
+				}
 				podClient.MetricsAgent().StorePodLifecycleMetrics(buildPodName, build.Namespace, corev1.PodFailed)
 				podClient.MetricsAgent().StoreMachinesSnapshot(build)
 				return true, util.AppendLogToError(fmt.Errorf("the build %s failed after %s with reason %s: %s", build.Name, buildDuration(build).Truncate(time.Second), build.Status.Reason, build.Status.Message), build.Status.LogSnippet)


### PR DESCRIPTION
## Summary
- `hintsAtInfraReason()` (`pkg/steps/source.go`) now matches `"network is unreachable"` and `"no route to host"`, so a transient ENETUNREACH-style dial failure during a build (e.g. a Go module/sumdb fetch mid-Dockerfile-build) is classified as an infra-side retryable failure instead of falling through to "classified as legitimate failure, will not be retried".
- Renamed the outcome-agnostic `gatherSuccessfulBuildLog` to `gatherBuildLog` (`pkg/steps/artifacts.go`) and call it from both the success path and the failure path (`waitForBuild`'s `BuildPhaseFailed`/`Cancelled`/`Error` case, alongside the existing `printBuildLogs` stdout dump), so failed builds get the same discrete `build-logs/<name>.log.gz` artifact successful builds already do, instead of only being interleaved into ci-operator's own stdout log.

No config schema changes. No behavior change for legitimate (non-infra) `DockerBuildFailed` failures — those still won't retry, they just also get a log artifact now.

## Context
Root-caused from a `DockerBuildFailed` flake on an `oadp-operator` rehearsal build (`oadp-operator-1.5-amd64`): a sibling job on the identical commit/Dockerfile succeeded in parallel on a different build pod, confirming a build-farm-node-level transient network flake rather than a real Dockerfile bug. The failing line (`dial tcp [...]:443: connect: network is unreachable`) was hard to find because it was buried inside the monolithic `build-log.txt` rather than a small dedicated per-build log artifact.

## Test plan
- [x] `go build ./pkg/steps/...`
- [x] `go vet ./pkg/steps/...`
- [x] `gofmt -l` clean on both changed files
- [x] `go test ./pkg/steps/...` — all packages pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updates `pkg/steps` to retry builds that fail with `"network is unreachable"` or `"no route to host"`.
- Captures `build-logs/<name>.log.gz` artifacts for successful, failed, cancelled, and errored builds.
- Preserves non-retryable behavior for legitimate `DockerBuildFailed` failures.
- Renames the internal helper to `gatherBuildLog`.
- No configuration schema changes.
- Tests and formatting checks pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->