### PR TITLE
`pj-rehearse`: drop `extra_refs` that duplicate the rehearsal PR

### DIFF
--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -581,18 +581,32 @@ func (jc *JobConfigurer) ConvertPeriodicsToPresubmits(periodics []prowconfig.Per
 			p.DecorationConfig.SparseCheckoutFiles = nil
 		}
 
-		if len(p.ExtraRefs) > 0 {
-			// we aren't injecting this as we do for presubmits, but we need it to be set
-			p.ExtraRefs[0].WorkDir = true
-		} else if len(p.ExtraRefs) > 1 {
-			// converted periodics already have a ref that should be removed to
-			// avoid conflicts with clonerefs
-			p.ExtraRefs = p.ExtraRefs[1:]
-		}
+		p.ExtraRefs = rehearsalExtraRefs(p.ExtraRefs, jc.refs)
 
 		presubmits = append(presubmits, p)
 	}
 	return presubmits, nil
+}
+
+// rehearsalExtraRefs drops extra_refs that clone the same org/repo as the
+// rehearsal PR. Periodics generated for a repo already include that repo as
+// extra_refs; when the rehearsal itself is a PR against that repo (typically
+// openshift/release), clonerefs would otherwise fail because both the primary
+// refs and extra_refs target the same checkout path.
+// Remaining extra_refs keep ExtraRefs[0] as the workdir so the job still runs
+// from the repo it was defined for.
+func rehearsalExtraRefs(extraRefs []pjapi.Refs, refs *pjapi.Refs) []pjapi.Refs {
+	var filtered []pjapi.Refs
+	for i, ref := range extraRefs {
+		if refs != nil && ref.Org == refs.Org && ref.Repo == refs.Repo {
+			continue
+		}
+		if i == 0 {
+			ref.WorkDir = true
+		}
+		filtered = append(filtered, ref)
+	}
+	return filtered
 }
 
 // Generic Prow periodics are not related to a repo, but in OpenShift CI many of them

--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -593,15 +593,15 @@ func (jc *JobConfigurer) ConvertPeriodicsToPresubmits(periodics []prowconfig.Per
 // extra_refs; when the rehearsal itself is a PR against that repo (typically
 // openshift/release), clonerefs would otherwise fail because both the primary
 // refs and extra_refs target the same checkout path.
-// Remaining extra_refs keep ExtraRefs[0] as the workdir so the job still runs
-// from the repo it was defined for.
+// The first remaining extra_ref is the workdir so the job still runs from the
+// repo it was defined for.
 func rehearsalExtraRefs(extraRefs []pjapi.Refs, refs *pjapi.Refs) []pjapi.Refs {
 	var filtered []pjapi.Refs
-	for i, ref := range extraRefs {
+	for _, ref := range extraRefs {
 		if refs != nil && ref.Org == refs.Org && ref.Repo == refs.Repo {
 			continue
 		}
-		if i == 0 {
+		if len(filtered) == 0 {
 			ref.WorkDir = true
 		}
 		filtered = append(filtered, ref)

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -1111,6 +1111,98 @@ func TestFilterPeriodics(t *testing.T) {
 	}
 }
 
+func TestConvertPeriodicsToPresubmits(t *testing.T) {
+	refs := &pjapi.Refs{
+		Org:     "openshift",
+		Repo:    "release",
+		BaseRef: "main",
+		Pulls:   []pjapi.Pull{{Number: 123}},
+	}
+	jc := &JobConfigurer{refs: refs}
+
+	periodic := func(name string, extraRefs []pjapi.Refs) prowconfig.Periodic {
+		return prowconfig.Periodic{
+			JobBase: prowconfig.JobBase{
+				Name: name,
+				UtilityConfig: prowconfig.UtilityConfig{
+					ExtraRefs: extraRefs,
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		description string
+		periodics   []prowconfig.Periodic
+		expected    [][]pjapi.Refs
+	}{
+		{
+			description: "periodic for a different repo keeps extra_refs with workdir",
+			periodics: []prowconfig.Periodic{
+				periodic("periodic-ci-super-duper-e2e", []pjapi.Refs{{Org: "super", Repo: "duper", BaseRef: "main"}}),
+			},
+			expected: [][]pjapi.Refs{
+				{{Org: "super", Repo: "duper", BaseRef: "main", WorkDir: true}},
+			},
+		},
+		{
+			description: "periodic for openshift/release drops extra_refs that duplicate the rehearsal PR",
+			periodics: []prowconfig.Periodic{
+				periodic("periodic-ci-openshift-release-e2e", []pjapi.Refs{{Org: "openshift", Repo: "release", BaseRef: "main"}}),
+			},
+			expected: [][]pjapi.Refs{nil},
+		},
+		{
+			description: "duplicate openshift/release extra_ref is dropped while other extra_refs are kept",
+			periodics: []prowconfig.Periodic{
+				periodic("periodic-multi-ref", []pjapi.Refs{
+					{Org: "openshift", Repo: "installer", BaseRef: "main"},
+					{Org: "openshift", Repo: "release", BaseRef: "main"},
+				}),
+			},
+			expected: [][]pjapi.Refs{
+				{{Org: "openshift", Repo: "installer", BaseRef: "main", WorkDir: true}},
+			},
+		},
+		{
+			description: "when openshift/release is the primary extra_ref, remaining extra_refs do not get workdir",
+			periodics: []prowconfig.Periodic{
+				periodic("periodic-release-with-other", []pjapi.Refs{
+					{Org: "openshift", Repo: "release", BaseRef: "main"},
+					{Org: "openshift", Repo: "installer", BaseRef: "main"},
+				}),
+			},
+			expected: [][]pjapi.Refs{
+				{{Org: "openshift", Repo: "installer", BaseRef: "main"}},
+			},
+		},
+		{
+			description: "periodic with no extra_refs stays that way",
+			periodics: []prowconfig.Periodic{
+				periodic("periodic-no-refs", nil),
+			},
+			expected: [][]pjapi.Refs{nil},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			presubmits, err := jc.ConvertPeriodicsToPresubmits(tc.periodics)
+			if err != nil {
+				t.Fatalf("ConvertPeriodicsToPresubmits failed: %v", err)
+			}
+			if len(presubmits) != len(tc.expected) {
+				t.Fatalf("got %d presubmits, expected %d", len(presubmits), len(tc.expected))
+			}
+			for i, p := range presubmits {
+				if diff := cmp.Diff(tc.expected[i], p.ExtraRefs); diff != "" {
+					t.Errorf("ExtraRefs mismatch for %s: %s", p.Name, diff)
+				}
+			}
+		})
+	}
+}
+
 func makePeriodic(extraLabels map[string]string, hidden bool) *prowconfig.Periodic {
 	labels := make(map[string]string)
 	if len(extraLabels) > 0 {

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -1165,7 +1165,7 @@ func TestConvertPeriodicsToPresubmits(t *testing.T) {
 			},
 		},
 		{
-			description: "when openshift/release is the primary extra_ref, remaining extra_refs do not get workdir",
+			description: "when openshift/release is the primary extra_ref, the first remaining extra_ref gets workdir",
 			periodics: []prowconfig.Periodic{
 				periodic("periodic-release-with-other", []pjapi.Refs{
 					{Org: "openshift", Repo: "release", BaseRef: "main"},
@@ -1173,7 +1173,7 @@ func TestConvertPeriodicsToPresubmits(t *testing.T) {
 				}),
 			},
 			expected: [][]pjapi.Refs{
-				{{Org: "openshift", Repo: "installer", BaseRef: "main"}},
+				{{Org: "openshift", Repo: "installer", BaseRef: "main", WorkDir: true}},
 			},
 		},
 		{

--- a/test/integration/pj-rehearse/candidate/ci-operator/jobs/openshift/release/openshift-release-master-periodics.yaml
+++ b/test/integration/pj-rehearse/candidate/ci-operator/jobs/openshift/release/openshift-release-master-periodics.yaml
@@ -1,0 +1,25 @@
+periodics:
+- agent: kubernetes
+  decorate: true
+  extra_refs:
+  - base_ref: master
+    org: openshift
+    repo: release
+  interval: 24h
+  labels:
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-release-master-e2e
+  spec:
+    containers:
+    - args:
+      - --no-ci-op-args
+      - --CHANGED
+      command:
+      - no-ci-op
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+    serviceAccountName: ci-operator

--- a/test/integration/pj-rehearse/expected.yaml
+++ b/test/integration/pj-rehearse/expected.yaml
@@ -2,6 +2,81 @@
   kind: ProwJob
   metadata:
     annotations:
+      prow.k8s.io/context: ci/rehearse/periodic-ci-openshift-release-master-e2e
+      prow.k8s.io/job: rehearse-1234-periodic-ci-openshift-release-master-e2e
+    creationTimestamp: null
+    labels:
+      ci.openshift.io/rehearse: "1234"
+      ci.openshift.io/rehearse.context: periodic-ci-openshift-release-master-e2e
+      created-by-prow: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      pj-rehearse.openshift.io/source-type: changedPeriodic
+      prow.k8s.io/context: periodic-ci-openshift-release-master-e2e
+      prow.k8s.io/job: rehearse-1234-periodic-ci-openshift-release-master-e2e
+      prow.k8s.io/refs.base_ref: master
+      prow.k8s.io/refs.org: openshift
+      prow.k8s.io/refs.pull: "1234"
+      prow.k8s.io/refs.repo: release
+      prow.k8s.io/type: presubmit
+    name: test-prowjob
+    namespace: test-namespace
+    resourceVersion: "1"
+  spec:
+    agent: kubernetes
+    cluster: default
+    context: ci/rehearse/periodic-ci-openshift-release-master-e2e
+    decoration_config:
+      gcs_configuration:
+        bucket: test-platform-results
+        default_org: openshift
+        default_repo: origin
+        job_url_prefix: https://openshift-gce-devel.appspot.com/build/
+        path_strategy: single
+      gcs_credentials_secret: gce-sa-credentials-gcs-publisher
+      grace_period: 15s
+      timeout: 4h0m0s
+      utility_images:
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20190129-0a3c54c
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20190129-0a3c54c
+        initupload: gcr.io/k8s-prow/initupload:v20190129-0a3c54c
+        sidecar: gcr.io/k8s-prow/sidecar:v20190129-0a3c54c
+    job: rehearse-1234-periodic-ci-openshift-release-master-e2e
+    namespace: test-namespace
+    pod_spec:
+      containers:
+      - args:
+        - --no-ci-op-args
+        - --CHANGED
+        command:
+        - no-ci-op
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+      serviceAccountName: ci-operator
+    prowjob_defaults:
+      tenant_id: GlobalDefaultID
+    refs:
+      base_ref: master
+      base_sha: test_sha
+      org: openshift
+      pulls:
+      - author: username
+        number: 1234
+        sha: test_sha
+      repo: release
+    report: true
+    rerun_command: /pj-rehearse periodic-ci-openshift-release-master-e2e
+    type: presubmit
+  status:
+    startTime: 2020-06-22T22:25:00Z
+    state: triggered
+- apiVersion: prow.k8s.io/v1
+  kind: ProwJob
+  metadata:
+    annotations:
       prow.k8s.io/context: ci/rehearse/periodic-ci-super-duper-e2e
       prow.k8s.io/job: rehearse-1234-periodic-ci-super-duper-e2e
     creationTimestamp: null

--- a/test/integration/pj-rehearse/master/ci-operator/jobs/openshift/release/openshift-release-master-periodics.yaml
+++ b/test/integration/pj-rehearse/master/ci-operator/jobs/openshift/release/openshift-release-master-periodics.yaml
@@ -1,0 +1,24 @@
+periodics:
+- agent: kubernetes
+  decorate: true
+  extra_refs:
+  - base_ref: master
+    org: openshift
+    repo: release
+  interval: 24h
+  labels:
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-release-master-e2e
+  spec:
+    containers:
+    - args:
+      - --no-ci-op-args
+      command:
+      - no-ci-op
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+    serviceAccountName: ci-operator


### PR DESCRIPTION
Periodics for openshift/release already extra_ref that repo. Rehearsing them as a presubmit against an openshift/release PR made clonerefs try to check the same path out twice. A previous fix was attempted in https://github.com/openshift/ci-tools/pull/4594, but resulted in an unreachable block of code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

`pj-rehearse` now removes duplicate `extra_refs` when it converts `openshift/release` periodics into presubmits. This prevents `clonerefs` from checking out the same repository path twice when users rehearse an `openshift/release` pull request.

The reference handling preserves unrelated references and assigns the work directory to the first retained reference. It also removes unreachable code from the previous fix.

Unit and integration fixtures now cover this rehearsal scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->