### PR TITLE
fix: source integrated stream tags from spec

### DIFF
--- a/cmd/ci-operator-configresolver/main_test.go
+++ b/cmd/ci-operator-configresolver/main_test.go
@@ -135,6 +135,12 @@ var (
 					"release.openshift.io/config": `{"name":"4.15.0-0.ci","to":"release","message":"This release contains CI image builds of all code in release-4.15 (master) branches, and is updated each time someone merges.","mirrorPrefix":"4.15","expires":"72h","maxUnreadyReleases":1,"minCreationIntervalSeconds":21600,"pullSecretName":"source","check":{},"publish":{"tag":{"tagRef":{"name":"4.15-ci"}}},"verify":{"aws-sdn-serial":{"maxRetries":3,"prowJob":{"name":"periodic-ci-openshift-release-master-ci-4.15-e2e-aws-sdn-serial"}},"gcp-sdn":{"optional":true,"prowJob":{"name":"periodic-ci-openshift-release-master-ci-4.15-e2e-gcp-sdn"}},"hypershift-e2e":{"maxRetries":3,"prowJob":{"name":"periodic-ci-openshift-hypershift-release-4.15-periodics-e2e-aws-ovn"},"upgrade":true},"upgrade":{"optional":true,"prowJob":{"name":"periodic-ci-openshift-release-master-ci-4.15-e2e-gcp-sdn-upgrade"},"disabled":true,"upgrade":true},"upgrade-minor-aws-ovn":{"optional":true,"prowJob":{"name":"periodic-ci-openshift-release-master-ci-4.15-upgrade-from-stable-4.14-e2e-aws-ovn-upgrade"},"disabled":true,"upgrade":true,"upgradeFromRelease":{"candidate":{"stream":"ci","version":"4.14"}}},"upgrade-minor-sdn":{"optional":true,"prowJob":{"name":"periodic-ci-openshift-release-master-ci-4.15-upgrade-from-stable-4.14-e2e-aws-sdn-upgrade"},"upgrade":true,"upgradeFromRelease":{"candidate":{"stream":"ci","version":"4.14"}}},"aws-ovn-upgrade-4.15-minor":{"maxRetries":3,"prowJob":{"name":"periodic-ci-openshift-release-master-ci-4.15-upgrade-from-stable-4.14-e2e-aws-ovn-upgrade"},"upgrade":true,"upgradeFromRelease":{"candidate":{"stream":"ci","version":"4.14"}}},"azure-sdn-upgrade-4.15-minor":{"maxRetries":3,"prowJob":{"name":"periodic-ci-openshift-release-master-ci-4.15-upgrade-from-stable-4.14-e2e-azure-sdn-upgrade"},"upgrade":true,"upgradeFromRelease":{"candidate":{"stream":"ci","version":"4.14"}}},"gcp-ovn-upgrade-4.15-micro":{"maxRetries":3,"prowJob":{"name":"periodic-ci-openshift-release-master-ci-4.15-e2e-gcp-ovn-upgrade"},"upgrade":true}}}`,
 				},
 			},
+			Spec: imagev1.ImageStreamSpec{
+				Tags: []imagev1.TagReference{
+					{Name: "bar"},
+					{Name: "foo"},
+				},
+			},
 			Status: imagev1.ImageStreamStatus{
 				Tags: []imagev1.NamedTagEventList{
 					{Tag: "bar"},
@@ -148,6 +154,12 @@ var (
 				Namespace: "ocp",
 				Annotations: map[string]string{
 					"release.openshift.io/config": `{"name":"5.0.0-0.ci","to":"release-5","message":"This release contains CI image builds of all code in release-5.0 (main) branches, and is updated each time someone merges.","mirrorPrefix":"5.0","expires":"72h","maxUnreadyReleases":1,"minCreationIntervalSeconds":21600,"pullSecretName":"source","alternateImageRepository":"quay.io/openshift-release-dev/dev-release","alternateImageRepositorySecretName":"release-controller-quay-mirror-secret","check":{},"publish":{"tag":{"tagRef":{"name":"5.0-ci"}}},"verify":{}}`,
+				},
+			},
+			Spec: imagev1.ImageStreamSpec{
+				Tags: []imagev1.TagReference{
+					{Name: "bar"},
+					{Name: "foo"},
 				},
 			},
 			Status: imagev1.ImageStreamStatus{

--- a/pkg/api/configresolver/configresolver.go
+++ b/pkg/api/configresolver/configresolver.go
@@ -50,8 +50,8 @@ func LocalIntegratedStream(ctx context.Context, client ctrlruntimeclient.Client,
 		return nil, fmt.Errorf("failed to get image stream %s/%s: %w", ns, name, err)
 	}
 	var tags []string
-	for _, tag := range is.Status.Tags {
-		tags = append(tags, tag.Tag)
+	for _, tag := range is.Spec.Tags {
+		tags = append(tags, tag.Name)
 	}
 	var releaseControllerConfigName string
 	if raw, ok := is.ObjectMeta.Annotations[api.ReleaseConfigAnnotation]; ok {

--- a/pkg/api/configresolver/configresolver_test.go
+++ b/pkg/api/configresolver/configresolver_test.go
@@ -32,6 +32,12 @@ var ocp415Stream = &imagev1.ImageStream{
 			{Tag: "foo"},
 		},
 	},
+	Spec: imagev1.ImageStreamSpec{
+		Tags: []imagev1.TagReference{
+			{Name: "bar"},
+			{Name: "foo"},
+		},
+	},
 }
 
 func init() {
@@ -45,6 +51,12 @@ func TestIntegratedStream(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "5.1",
 			Namespace: "ocp",
+		},
+		Spec: imagev1.ImageStreamSpec{
+			Tags: []imagev1.TagReference{
+				{Name: "bar"},
+				{Name: "foo"},
+			},
 		},
 		Status: imagev1.ImageStreamStatus{
 			Tags: []imagev1.NamedTagEventList{
@@ -82,6 +94,30 @@ func TestIntegratedStream(t *testing.T) {
 			isName:   "5.1",
 			client:   fakeclient.NewClientBuilder().WithRuntimeObjects(ocp51Stream.DeepCopy()).Build(),
 			expected: &IntegratedStream{Tags: []string{"bar", "foo"}, ReleaseControllerConfigName: ""},
+		},
+		{
+			name:   "tags sourced from spec instead of status",
+			isNS:   "ocp",
+			isName: "5.2",
+			client: fakeclient.NewClientBuilder().WithRuntimeObjects(&imagev1.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "5.2",
+					Namespace: "ocp",
+				},
+				Spec: imagev1.ImageStreamSpec{
+					Tags: []imagev1.TagReference{
+						{Name: "spec-only"},
+						{Name: "common"},
+					},
+				},
+				Status: imagev1.ImageStreamStatus{
+					Tags: []imagev1.NamedTagEventList{
+						{Tag: "status-only"},
+						{Tag: "common"},
+					},
+				},
+			}).Build(),
+			expected: &IntegratedStream{Tags: []string{"spec-only", "common"}, ReleaseControllerConfigName: ""},
 		},
 	}
 


### PR DESCRIPTION
Use integrated stream spec tags as presubmit snapshot source so ci-op stable includes required payload tags even when app.ci status lags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updates `configresolver` so `ci-op stable` sources integrated stream tag names from `ImageStream.Spec.Tags`. This keeps required payload tags available when `app.ci` status updates are delayed. Tests cover differences between specification and status tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->