### PR TITLE
Dispatcher hardening

### DIFF
--- a/cmd/prow-job-dispatcher/main.go
+++ b/cmd/prow-job-dispatcher/main.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"flag"
 	"fmt"
+	"hash/fnv"
 	"io/fs"
 	"net/http"
 	"os"
@@ -40,12 +44,13 @@ import (
 )
 
 const (
-	githubOrg      = "openshift"
-	githubRepo     = "release"
-	githubLogin    = "openshift-bot"
-	matchTitle     = "Automate prow job dispatcher"
-	upstreamBranch = "master"
-	listURL        = "https://github.com/openshift/release/pulls?q=is%3Apr+author%3Aopenshift-bot+prow+job+dispatcher+in%3Atitle+is%3Aopen"
+	githubOrg              = "openshift"
+	githubRepo             = "release"
+	githubLogin            = "openshift-bot"
+	matchTitle             = "Automate prow job dispatcher"
+	upstreamBranch         = "master"
+	listURL                = "https://github.com/openshift/release/pulls?q=is%3Apr+author%3Aopenshift-bot+prow+job+dispatcher+in%3Atitle+is%3Aopen"
+	inventoryDigestVersion = 1
 )
 
 var blockedClusterRelocationJobExceptions = []*regexp.Regexp{
@@ -206,6 +211,23 @@ type clusterVolume struct {
 	blocked            sets.Set[string]
 	volumeDistribution map[string]float64
 	clusterMap         dispatcher.ClusterMap
+	prowJobConfigDir   string
+}
+
+func sortedStringKeys[T any](values map[string]T) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+type projectedJob struct {
+	determinedCluster string
+	canBeRelocated    bool
+	blocked           sets.Set[string]
+	volume            float64
 }
 
 // findClusterForJobConfig finds a cluster running on a preferred cloud provider for the jobs in a Prow job config.
@@ -216,28 +238,69 @@ func (cv *clusterVolume) findClusterForJobConfig(cloudProvider string, jc *prowc
 		cloudProvider = ""
 	}
 	var cluster string
-	var totalVolume float64
-	for _, volume := range jobVolumes {
-		totalVolume += volume
+	projectedVolumes := make(map[string]float64)
+	var jobsForProjection []projectedJob
+	var jobsForProjectionErr error
+	jobsClassified := false
+	projectedVolume := func(candidate string) (float64, error) {
+		if volume, exists := projectedVolumes[candidate]; exists {
+			return volume, nil
+		}
+		if !jobsClassified {
+			jobsClassified = true
+			jobsForProjection, jobsForProjectionErr = cv.classifyJobsForProjection(jc, path, config, jobVolumes)
+		}
+		if jobsForProjectionErr != nil {
+			return 0, jobsForProjectionErr
+		}
+		volume := projectedVolumeForCandidate(candidate, string(config.Default), jobsForProjection)
+		projectedVolumes[candidate] = volume
+		return volume, nil
 	}
 
 	mostUsedCluster := dispatcher.FindMostUsedCluster(jc)
 	// TODO: 75% as we still have manual assignments and these are affecting even distribution, re-evaluate when manual assignments are gone
 	if determinedCloudProvider := config.IsInBuildFarm(api.Cluster(mostUsedCluster)); determinedCloudProvider != "" &&
-		cv.clusterVolumeMap[string(determinedCloudProvider)][mostUsedCluster] < cv.volumeDistribution[mostUsedCluster]*0.75 {
-		cluster = mostUsedCluster
-	} else {
-		min := float64(-1)
+		(cloudProvider == "" || cloudProvider == string(determinedCloudProvider)) {
+		volume, err := projectedVolume(mostUsedCluster)
+		if err != nil {
+			return "", err
+		}
+		if cv.clusterVolumeMap[string(determinedCloudProvider)][mostUsedCluster]+volume < cv.volumeDistribution[mostUsedCluster]*0.75 {
+			cluster = mostUsedCluster
+		}
+	}
+	if cluster == "" {
+		tieBreakPath, err := repositoryRelativeTieBreakPath(cv.prowJobConfigDir, path)
+		if err != nil {
+			return "", err
+		}
+		minScore := float64(-1)
+		var minTieBreak uint64
 		for _, cp := range sets.List(cv.cloudProviders) {
 			m := cv.clusterVolumeMap[cp]
-			for c, v := range m {
-				if cv.clusterMap[c].Capacity != 100 {
+			clusters := make([]string, 0, len(m))
+			for candidate := range m {
+				clusters = append(clusters, candidate)
+			}
+			sort.Strings(clusters)
+			for _, candidate := range clusters {
+				clusterInfo, exists := cv.clusterMap[candidate]
+				if !exists || clusterInfo.Capacity <= 0 {
 					continue
 				}
 				if cloudProvider == "" || cloudProvider == cp {
-					if min < 0 || min > v {
-						min = v
-						cluster = c
+					candidateVolume, err := projectedVolume(candidate)
+					if err != nil {
+						return "", err
+					}
+					score := (m[candidate] + candidateVolume) / float64(clusterInfo.Capacity)
+					tieBreak := stableClusterTieBreak(tieBreakPath, candidate)
+					if minScore < 0 || score < minScore ||
+						score == minScore && (tieBreak < minTieBreak || tieBreak == minTieBreak && candidate < cluster) {
+						minScore = score
+						minTieBreak = tieBreak
+						cluster = candidate
 					}
 				}
 			}
@@ -245,7 +308,7 @@ func (cv *clusterVolume) findClusterForJobConfig(cloudProvider string, jc *prowc
 	}
 
 	var errs []error
-	for k := range jc.PresubmitsStatic {
+	for _, k := range sortedStringKeys(jc.PresubmitsStatic) {
 		for _, job := range jc.PresubmitsStatic[k] {
 			if err := cv.addToVolume(cluster, job.JobBase, path, config, jobVolumes); err != nil {
 				errs = append(errs, err)
@@ -253,7 +316,7 @@ func (cv *clusterVolume) findClusterForJobConfig(cloudProvider string, jc *prowc
 		}
 	}
 
-	for k := range jc.PostsubmitsStatic {
+	for _, k := range sortedStringKeys(jc.PostsubmitsStatic) {
 		for _, job := range jc.PostsubmitsStatic[k] {
 			if err := cv.addToVolume(cluster, job.JobBase, path, config, jobVolumes); err != nil {
 				errs = append(errs, err)
@@ -269,6 +332,74 @@ func (cv *clusterVolume) findClusterForJobConfig(cloudProvider string, jc *prowc
 	return cluster, utilerrors.NewAggregate(errs)
 }
 
+func (cv *clusterVolume) classifyJobsForProjection(jc *prowconfig.JobConfig, path string, config *dispatcher.Config, jobVolumes map[string]float64) ([]projectedJob, error) {
+	var jobsForProjection []projectedJob
+	addProjectedJob := func(jobBase prowconfig.JobBase) error {
+		determinedCluster, canBeRelocated, err := config.DetermineClusterForJob(jobBase, path, cv.clusterMap)
+		if err != nil {
+			return fmt.Errorf("failed to determine projected cluster for job %s in path %q: %w", jobBase.Name, path, err)
+		}
+		jobsForProjection = append(jobsForProjection, projectedJob{
+			determinedCluster: string(determinedCluster),
+			canBeRelocated:    canBeRelocated,
+			blocked:           blockedClustersForJob(jobBase.Name, string(determinedCluster), cv.blocked),
+			volume:            jobVolumes[jobBase.Name],
+		})
+		return nil
+	}
+
+	for _, k := range sortedStringKeys(jc.PresubmitsStatic) {
+		for _, job := range jc.PresubmitsStatic[k] {
+			if err := addProjectedJob(job.JobBase); err != nil {
+				return nil, err
+			}
+		}
+	}
+	for _, k := range sortedStringKeys(jc.PostsubmitsStatic) {
+		for _, job := range jc.PostsubmitsStatic[k] {
+			if err := addProjectedJob(job.JobBase); err != nil {
+				return nil, err
+			}
+		}
+	}
+	for _, job := range jc.Periodics {
+		if err := addProjectedJob(job.JobBase); err != nil {
+			return nil, err
+		}
+	}
+	return jobsForProjection, nil
+}
+
+func projectedVolumeForCandidate(candidate, defaultCluster string, jobsForProjection []projectedJob) float64 {
+	var volume float64
+	for _, job := range jobsForProjection {
+		target := dispatcher.DetermineTargetCluster(candidate, job.determinedCluster, defaultCluster, job.canBeRelocated, job.blocked)
+		if target == candidate {
+			volume += job.volume
+		}
+	}
+	return volume
+}
+
+func stableClusterTieBreak(path, cluster string) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(path))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(cluster))
+	return h.Sum64()
+}
+
+func repositoryRelativeTieBreakPath(prowJobConfigDir, path string) (string, error) {
+	if prowJobConfigDir == "" {
+		return filepath.ToSlash(path), nil
+	}
+	relativePath, err := filepath.Rel(prowJobConfigDir, path)
+	if err != nil {
+		return "", fmt.Errorf("failed to derive tie-break path for %q: %w", path, err)
+	}
+	return filepath.ToSlash(relativePath), nil
+}
+
 func extractCapabilities(labels map[string]string) []string {
 	var capabilities []string
 	prefix := "capability/"
@@ -278,6 +409,7 @@ func extractCapabilities(labels map[string]string) []string {
 			capabilities = append(capabilities, value)
 		}
 	}
+	sort.Strings(capabilities)
 
 	return capabilities
 }
@@ -392,6 +524,252 @@ type fileSizeInfo struct {
 	size int64
 }
 
+type clusterConfigReconciler struct {
+	observedClusterMap       dispatcher.ClusterMap
+	observedBlocked          sets.Set[string]
+	hasObserved              bool
+	publishedInventoryDigest string
+}
+
+// reconcile publishes a changed cluster configuration and advances observed
+// state only after publication succeeds.
+func (r *clusterConfigReconciler) reconcile(clusterMap dispatcher.ClusterMap, blocked sets.Set[string], dispatch func(bool) error) (bool, error) {
+	currentInventoryDigest, err := clusterInventoryDigest(clusterMap, blocked)
+	if err != nil {
+		return false, fmt.Errorf("failed to calculate cluster inventory digest: %w", err)
+	}
+	if r.hasObserved && reflect.DeepEqual(clusterMap, r.observedClusterMap) && reflect.DeepEqual(blocked, r.observedBlocked) &&
+		currentInventoryDigest == r.publishedInventoryDigest {
+		return false, nil
+	}
+
+	forceDispatch := currentInventoryDigest != r.publishedInventoryDigest ||
+		r.hasObserved && dispatcher.HasCapacityOrCapabilitiesChanged(r.observedClusterMap, clusterMap)
+	if err := dispatch(forceDispatch); err != nil {
+		return true, err
+	}
+
+	r.observedClusterMap = clusterMap
+	r.observedBlocked = blocked
+	r.hasObserved = true
+	r.publishedInventoryDigest = currentInventoryDigest
+	return true, nil
+}
+
+type inventoryDigestCluster struct {
+	Name         string   `json:"name"`
+	Provider     string   `json:"provider"`
+	Capacity     int      `json:"capacity"`
+	Capabilities []string `json:"capabilities"`
+}
+
+type inventoryDigestInput struct {
+	Version  int                      `json:"version"`
+	Clusters []inventoryDigestCluster `json:"clusters"`
+	Blocked  []string                 `json:"blocked"`
+}
+
+func clusterInventoryDigest(clusterMap dispatcher.ClusterMap, blocked sets.Set[string]) (string, error) {
+	return clusterInventoryDigestForVersion(clusterMap, blocked, inventoryDigestVersion)
+}
+
+func clusterInventoryDigestForVersion(clusterMap dispatcher.ClusterMap, blocked sets.Set[string], version int) (string, error) {
+	clusterNames := make([]string, 0, len(clusterMap))
+	for clusterName := range clusterMap {
+		clusterNames = append(clusterNames, clusterName)
+	}
+	sort.Strings(clusterNames)
+
+	clusters := make([]inventoryDigestCluster, 0, len(clusterNames))
+	for _, clusterName := range clusterNames {
+		clusterInfo := clusterMap[clusterName]
+		capabilities := append([]string(nil), clusterInfo.Capabilities...)
+		sort.Strings(capabilities)
+		clusters = append(clusters, inventoryDigestCluster{
+			Name:         clusterName,
+			Provider:     clusterInfo.Provider,
+			Capacity:     clusterInfo.Capacity,
+			Capabilities: capabilities,
+		})
+	}
+
+	blockedClusters := sets.List(blocked)
+	if blockedClusters == nil {
+		blockedClusters = []string{}
+	}
+	input, err := json.Marshal(inventoryDigestInput{Version: version, Clusters: clusters, Blocked: blockedClusters})
+	if err != nil {
+		return "", err
+	}
+	digest := sha256.Sum256(input)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func publishedInventoryDigestPath(jobsStoragePath string) string {
+	return jobsStoragePath + ".inventory-digest"
+}
+
+func readPublishedInventoryDigest(path string) (string, bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("failed to read published inventory digest: %w", err)
+	}
+	digest := strings.TrimSpace(string(data))
+	decoded, err := hex.DecodeString(digest)
+	if err != nil || len(decoded) != sha256.Size {
+		return "", false, nil
+	}
+	return digest, true, nil
+}
+
+func writePublishedInventoryDigest(path, digest string) error {
+	directory := filepath.Dir(path)
+	temporary, err := os.CreateTemp(directory, "."+filepath.Base(path)+".tmp-")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary inventory digest: %w", err)
+	}
+	temporaryName := temporary.Name()
+	closed := false
+	defer func() {
+		if !closed {
+			_ = temporary.Close()
+		}
+		_ = os.Remove(temporaryName)
+	}()
+
+	if err := temporary.Chmod(0o644); err != nil {
+		return fmt.Errorf("failed to set permissions on temporary inventory digest: %w", err)
+	}
+	if _, err := temporary.WriteString(digest + "\n"); err != nil {
+		return fmt.Errorf("failed to write temporary inventory digest: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		return fmt.Errorf("failed to sync temporary inventory digest: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("failed to close temporary inventory digest: %w", err)
+	}
+	closed = true
+	if err := os.Rename(temporaryName, path); err != nil {
+		return fmt.Errorf("failed to atomically replace inventory digest: %w", err)
+	}
+	if err := syncDirectory(directory); err != nil {
+		return fmt.Errorf("failed to sync inventory digest directory: %w", err)
+	}
+	return nil
+}
+
+func invalidatePublishedInventoryDigest(path string) error {
+	if err := os.Remove(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to remove published inventory digest: %w", err)
+	}
+	if err := syncDirectory(filepath.Dir(path)); err != nil {
+		return fmt.Errorf("failed to sync published inventory digest directory: %w", err)
+	}
+	return nil
+}
+
+func writeFullDispatchAssignments(jobsStoragePath string, pjs map[string]dispatcher.ProwJobData, writeGob func(string, interface{}) error) error {
+	if err := invalidatePublishedInventoryDigest(publishedInventoryDigestPath(jobsStoragePath)); err != nil {
+		return fmt.Errorf("failed to invalidate cluster inventory digest: %w", err)
+	}
+	return writeGob(jobsStoragePath, pjs)
+}
+
+// fullDispatchController serializes complete generations and remembers a failed
+// generation regardless of whether it was triggered by config reconciliation,
+// the weekly cron, or the manual event endpoint.
+type fullDispatchController struct {
+	mu           sync.Mutex
+	dispatch     func(bool) error
+	retryPending bool
+}
+
+func (c *fullDispatchController) reconcile(force bool) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	err := c.dispatch(force || c.retryPending)
+	c.retryPending = err != nil
+	return err
+}
+
+func (c *fullDispatchController) hasPendingRetry() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.retryPending
+}
+
+func fallbackPublicationMarkerPath(jobsStoragePath string) string {
+	return jobsStoragePath + ".fallback-pending"
+}
+
+func fallbackPublicationPending(path string) (bool, error) {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to inspect fallback publication marker: %w", err)
+	}
+	return true, nil
+}
+
+func markFallbackPublicationPending(path string) error {
+	marker, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return fmt.Errorf("failed to create fallback publication marker: %w", err)
+	}
+	closed := false
+	defer func() {
+		if !closed {
+			_ = marker.Close()
+		}
+	}()
+
+	if _, err := marker.WriteString(time.Now().UTC().Format(time.RFC3339Nano) + "\n"); err != nil {
+		return fmt.Errorf("failed to write fallback publication marker: %w", err)
+	}
+	if err := marker.Sync(); err != nil {
+		return fmt.Errorf("failed to sync fallback publication marker: %w", err)
+	}
+	if err := marker.Close(); err != nil {
+		return fmt.Errorf("failed to close fallback publication marker: %w", err)
+	}
+	closed = true
+	if err := syncDirectory(filepath.Dir(path)); err != nil {
+		return fmt.Errorf("failed to sync fallback publication marker directory: %w", err)
+	}
+	return nil
+}
+
+func clearFallbackPublicationPending(path string) error {
+	if err := os.Remove(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to remove fallback publication marker: %w", err)
+	}
+	if err := syncDirectory(filepath.Dir(path)); err != nil {
+		return fmt.Errorf("failed to sync fallback publication marker directory: %w", err)
+	}
+	return nil
+}
+
+func syncDirectory(path string) error {
+	directory, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer directory.Close()
+	return directory.Sync()
+}
+
 // dispatchJobs loads the Prow jobs and chooses a cluster in the build farm if possible.
 // The current implementation walks through the Prow Job config files.
 // For each file, it tries to assign all jobs in it to a cluster in the build farm.
@@ -411,7 +789,8 @@ func dispatchJobs(prowJobConfigDir string, config *dispatcher.Config, jobVolumes
 		blocked:            blocked,
 		specialClusters:    map[string]float64{},
 		volumeDistribution: volumeDistribution,
-		clusterMap:         cm}
+		clusterMap:         cm,
+		prowJobConfigDir:   prowJobConfigDir}
 	for cloudProvider, v := range config.BuildFarm {
 		for cluster := range v {
 			cloudProviderString := string(cloudProvider)
@@ -449,7 +828,12 @@ func dispatchJobs(prowJobConfigDir string, config *dispatcher.Config, jobVolumes
 		return nil, fmt.Errorf("failed to dispatch all Prow jobs: %w", err)
 	}
 
-	sort.Slice(fileList, func(i, j int) bool { return fileList[i].size > fileList[j].size })
+	sort.Slice(fileList, func(i, j int) bool {
+		if fileList[i].size != fileList[j].size {
+			return fileList[i].size > fileList[j].size
+		}
+		return fileList[i].path < fileList[j].path
+	})
 	if err := dispatchEveryFile(fileList, dispatch); err != nil {
 		errs = append(errs, err)
 	}
@@ -484,7 +868,12 @@ func dispatchDeltaJobs(prowJobConfigDir string, config *dispatcher.Config, block
 		return fmt.Errorf("failed to dispatch all Prow jobs: %w", err)
 	}
 
-	sort.Slice(fileList, func(i, j int) bool { return fileList[i].size > fileList[j].size })
+	sort.Slice(fileList, func(i, j int) bool {
+		if fileList[i].size != fileList[j].size {
+			return fileList[i].size > fileList[j].size
+		}
+		return fileList[i].path < fileList[j].path
+	})
 	if err := dispatchEveryFile(fileList, dispatch); err != nil {
 		errs = append(errs, err)
 	}
@@ -544,66 +933,6 @@ func composeFileInfoList(prowJobConfigDir string) ([]fileSizeInfo, error) {
 	return fileList, utilerrors.NewAggregate(errs)
 }
 
-// removeDisabledClusters removes disabled clusters from BuildFarm and BuildFarmConfig
-func removeDisabledClusters(config *dispatcher.Config, disabled sets.Set[string]) {
-	for provider := range config.BuildFarm {
-		for cluster := range config.BuildFarm[provider] {
-			if disabled.Has(string(cluster)) {
-				delete(config.BuildFarm[provider], cluster)
-				if clusters, ok := config.BuildFarmCloud[provider]; ok {
-					c := sets.New[string](clusters...)
-					c = c.Delete(string(cluster))
-					config.BuildFarmCloud[provider] = sets.List(c)
-				}
-			}
-		}
-	}
-}
-
-type clusterProviderGetter func(cluster string) (api.Cloud, error)
-
-// addEnabledClusters adds enabled clusters to the BuildFarm and BuildFarmConfig
-func addEnabledClusters(config *dispatcher.Config, enabled sets.Set[string], getter clusterProviderGetter) {
-	if len(enabled) > 0 && config.BuildFarm == nil {
-		config.BuildFarm = make(map[api.Cloud]map[api.Cluster]*dispatcher.BuildFarmConfig)
-	}
-	for cluster := range enabled {
-		provider, err := getter(cluster)
-		if err != nil {
-			logrus.WithError(err).Fatal("Failed to get cluster cloud provider information")
-		}
-		if _, exists := config.BuildFarm[provider][api.Cluster(cluster)]; !exists {
-			if config.BuildFarm[provider] == nil {
-				config.BuildFarm[provider] = make(map[api.Cluster]*dispatcher.BuildFarmConfig)
-			}
-			config.BuildFarm[provider][api.Cluster(cluster)] = &dispatcher.BuildFarmConfig{FilenamesRaw: []string{}, Filenames: sets.New[string]()}
-		}
-		if clusters, ok := config.BuildFarmCloud[provider]; ok {
-			clusters = append(clusters, cluster)
-			config.BuildFarmCloud[provider] = clusters
-		} else {
-			if config.BuildFarmCloud == nil {
-				config.BuildFarmCloud = make(map[api.Cloud][]string)
-			}
-			config.BuildFarmCloud[provider] = []string{cluster}
-		}
-	}
-}
-
-func getEnabledClusters(config *dispatcher.Config) sets.Set[string] {
-	enabled := sets.New[string]()
-	for _, clusters := range config.BuildFarm {
-		for cluster := range clusters {
-			enabled.Insert(string(cluster))
-		}
-	}
-	return enabled
-}
-
-func getDiffClusters(enabledClusters, clustersFromConfig sets.Set[string]) (clustersToAdd, clustersToRemove sets.Set[string]) {
-	return clustersFromConfig.Difference(enabledClusters), enabledClusters.Difference(clustersFromConfig)
-}
-
 func clustersMapToSet(clusterMap dispatcher.ClusterMap) sets.Set[string] {
 	clusterSet := sets.Set[string]{}
 	for cluster := range clusterMap {
@@ -612,8 +941,9 @@ func clustersMapToSet(clusterMap dispatcher.ClusterMap) sets.Set[string] {
 	return clusterSet
 }
 
-func gitCloneRelease() error {
+func gitCloneRelease(targetDir string) error {
 	cmd := exec.Command("git", "clone", "--depth", "1", "--single-branch", "https://github.com/openshift/release.git")
+	cmd.Dir = targetDir
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -631,34 +961,46 @@ func cleanup(directory string) {
 	logrus.WithField("directory", directory).Info("Successfully removed directory")
 }
 
-// createPR creates PR with config changes and sanitizer changes, it causes app to exit in
-// case of failure to trigger re-run of logic
-func createPR(o options, config *dispatcher.Config, pjs map[string]dispatcher.ProwJobData, cm dispatcher.ClusterMap) {
+func withRestoredWorkingDirectory(operation func() error) (retErr error) {
+	workingDirectory, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to determine current working directory: %w", err)
+	}
+	defer func() {
+		if err := os.Chdir(workingDirectory); err != nil {
+			retErr = utilerrors.NewAggregate([]error{retErr, fmt.Errorf("failed to restore working directory %q: %w", workingDirectory, err)})
+		}
+	}()
+
+	return operation()
+}
+
+// createPR creates or updates the fallback assignment PR. Errors are returned to
+// reconciliation so the same generation can be retried without terminating the service.
+func createPR(o options, config *dispatcher.Config, pjs map[string]dispatcher.ProwJobData, cm dispatcher.ClusterMap) error {
 	targetDirWithRelease := filepath.Join(o.targetDir, "/release")
 	cleanup(targetDirWithRelease)
 	defer cleanup(targetDirWithRelease)
 
-	logrus.WithField("targetDir", o.targetDir).Info("Changing working directory ...")
-	if err := os.Chdir(o.targetDir); err != nil {
-		logrus.WithError(err).Fatal("failed to change to root dir")
-	}
-
-	if err := gitCloneRelease(); err != nil {
-		logrus.WithError(err).Fatal("failed to clone release repository")
+	if err := gitCloneRelease(o.targetDir); err != nil {
+		return fmt.Errorf("failed to clone release repository: %w", err)
 	}
 
 	if err := dispatcher.SaveConfig(config, filepath.Join(targetDirWithRelease, "/core-services/sanitize-prow-jobs/_config.yaml")); err != nil {
-		logrus.WithError(err).WithField("configPath", o.configPath).Fatal("failed to save config file")
+		return fmt.Errorf("failed to save config file %q: %w", o.configPath, err)
 	}
 
 	if err := sanitizer.DeterminizeJobs(filepath.Join(targetDirWithRelease, "/ci-operator/jobs"), config, pjs, make(sets.Set[string]), cm); err != nil {
-		logrus.WithError(err).Fatal("failed to determinize")
+		return fmt.Errorf("failed to determinize jobs: %w", err)
 	}
 
 	title := fmt.Sprintf("%s at %s", matchTitle, time.Now().Format(time.RFC1123))
-	if err := o.PRCreationOptions.UpsertPR(targetDirWithRelease, githubOrg, githubRepo, o.upstreamBranch, title, prcreation.PrAssignee(o.assign), prcreation.MatchTitle(matchTitle), prcreation.AdditionalLabels([]string{rehearse.RehearsalsAckLabel, "priority/ci-critical"}), prcreation.PrBody(o.prBody)); err != nil {
-		logrus.WithError(err).Fatal("failed to upsert PR")
+	if err := withRestoredWorkingDirectory(func() error {
+		return o.PRCreationOptions.UpsertPR(targetDirWithRelease, githubOrg, githubRepo, o.upstreamBranch, title, prcreation.PrAssignee(o.assign), prcreation.MatchTitle(matchTitle), prcreation.AdditionalLabels([]string{rehearse.RehearsalsAckLabel, "priority/ci-critical"}), prcreation.PrBody(o.prBody))
+	}); err != nil {
+		return fmt.Errorf("failed to upsert PR: %w", err)
 	}
+	return nil
 }
 
 func sendSlackMessage(slackClient slackClient, channelId string) error {
@@ -725,6 +1067,7 @@ func main() {
 
 	var dispatchWrapper func(forceDispatch bool)
 	var dispatchDeltaWrapper func()
+	var fullDispatch *fullDispatchController
 	prowjobs := dispatcher.NewProwjobs(o.jobsStoragePath)
 	c := cron.New()
 
@@ -736,88 +1079,137 @@ func main() {
 		var mu sync.Mutex
 		slackClient := slack.New(string(secret.GetSecret(o.slackTokenPath)))
 
-		dispatchDeltaWrapper = func() {
+		dispatchDelta := func() error {
 			mu.Lock()
 			defer mu.Unlock()
 			config, err := dispatcher.LoadConfig(o.configPath)
 			if err != nil {
-				logrus.WithError(err).Errorf("failed to load config from %q", o.configPath)
-				return
+				return fmt.Errorf("failed to load config from %q: %w", o.configPath, err)
 			}
 			cm, blocked, err := dispatcher.LoadClusterConfig(o.clusterConfigPath)
 			if err != nil {
-				logrus.WithError(err).Error("failed to load cluster config")
-				return
+				return fmt.Errorf("failed to load cluster config: %w", err)
+			}
+			if _, err := config.SynchronizeBuildFarm(cm); err != nil {
+				return fmt.Errorf("failed to synchronize build farm: %w", err)
 			}
 
 			pjs := prowjobs.GetDataCopy()
 
 			if err := dispatchDeltaJobs(o.prowJobConfigDir, config, blocked, pjs, cm); err != nil {
-				logrus.WithError(err).Error("failed to dispatch")
-				return
+				return fmt.Errorf("failed to dispatch delta jobs: %w", err)
+			}
+			if err := dispatcher.WriteGob(o.jobsStoragePath, pjs); err != nil {
+				if !dispatcher.IsGobWriteCommitted(err) {
+					return fmt.Errorf("failed to persist delta job assignments: %w", err)
+				}
+				prowjobs.Regenerate(pjs)
+				return fmt.Errorf("delta job assignments were replaced but their directory sync failed: %w", err)
 			}
 			prowjobs.Regenerate(pjs)
+			return nil
 		}
 
-		dispatchWrapper = func(forceDispatch bool) {
+		dispatch := func(forceDispatch bool) error {
 			mu.Lock()
 			defer mu.Unlock()
 
 			config, err := dispatcher.LoadConfig(o.configPath)
 			if err != nil {
-				logrus.WithError(err).Errorf("failed to load config from %q", o.configPath)
-				return
+				return fmt.Errorf("failed to load config from %q: %w", o.configPath, err)
 			}
 
 			configClusterMap, blocked, err := dispatcher.LoadClusterConfig(o.clusterConfigPath)
 			if err != nil {
-				logrus.WithError(err).Error("failed to load cluster config")
-				return
+				return fmt.Errorf("failed to load cluster config: %w", err)
+			}
+			inventoryDigest, err := clusterInventoryDigest(configClusterMap, blocked)
+			if err != nil {
+				return fmt.Errorf("failed to calculate cluster inventory digest: %w", err)
 			}
 			clustersFromConfig := clustersMapToSet(configClusterMap)
-
-			enabled, disabled := getDiffClusters(getEnabledClusters(config), clustersFromConfig)
-			if len(disabled) > 0 {
-				removeDisabledClusters(config, disabled)
+			inventoryChanged, err := config.SynchronizeBuildFarm(configClusterMap)
+			if err != nil {
+				return fmt.Errorf("failed to synchronize build farm: %w", err)
 			}
 
 			newBlockedClusters := prowjobs.HasAnyOfClusters(blocked)
+			missingAssignments := len(prowjobs.GetDataCopy()) == 0
 
-			if (!forceDispatch && enabled.Len() == 0 && disabled.Len() == 0) && !newBlockedClusters {
-				return
+			if !forceDispatch && !inventoryChanged && !newBlockedClusters && !missingAssignments {
+				// The ephemeral scheduler is not persisted in the Gob cache, so it still
+				// needs initialization after a restart when no generation is necessary.
+				ecd.Reset(sets.List(clustersFromConfig))
+				return nil
 			}
 
 			jobVolumes, err := promVolumes.GetJobVolumes()
 			if err != nil {
-				logrus.WithError(err).Fatal("failed to get job volumes")
+				return fmt.Errorf("failed to get job volumes: %w", err)
 			}
 
-			addEnabledClusters(config, enabled,
-				func(cluster string) (api.Cloud, error) {
-					info, exists := configClusterMap[cluster]
-					if !exists {
-						return "", fmt.Errorf("have not found provider for cluster %s", cluster)
-					}
-					return api.Cloud(info.Provider), nil
-				})
 			pjs, err := dispatchJobs(o.prowJobConfigDir, config, jobVolumes, blocked, promVolumes.CalculateVolumeDistribution(configClusterMap), configClusterMap)
 			if err != nil {
-				logrus.WithError(err).Error("failed to dispatch")
-				return
+				return fmt.Errorf("failed to dispatch jobs: %w", err)
+			}
+
+			markerPath := fallbackPublicationMarkerPath(o.jobsStoragePath)
+			if o.createPR {
+				if err := markFallbackPublicationPending(markerPath); err != nil {
+					return err
+				}
+			}
+
+			var committedWriteErr error
+			if err := writeFullDispatchAssignments(o.jobsStoragePath, pjs, dispatcher.WriteGob); err != nil {
+				if !dispatcher.IsGobWriteCommitted(err) {
+					return fmt.Errorf("failed to persist job assignments: %w", err)
+				}
+				committedWriteErr = fmt.Errorf("job assignments were replaced but their directory sync failed: %w", err)
 			}
 			prowjobs.Regenerate(pjs)
-
-			ecd.Reset(clustersFromConfig.UnsortedList())
-
-			if err := dispatcher.WriteGob(o.jobsStoragePath, pjs); err != nil {
-				logrus.WithError(err).Errorf("continuing on cache memory, error writing Gob file")
+			ecd.Reset(sets.List(clustersFromConfig))
+			if committedWriteErr == nil {
+				if err := writePublishedInventoryDigest(publishedInventoryDigestPath(o.jobsStoragePath), inventoryDigest); err != nil {
+					return fmt.Errorf("failed to publish cluster inventory digest: %w", err)
+				}
 			}
 
 			if o.createPR {
-				createPR(o, config, pjs, configClusterMap)
+				if err := createPR(o, config, pjs, configClusterMap); err != nil {
+					return utilerrors.NewAggregate([]error{committedWriteErr, err})
+				}
+				if err := clearFallbackPublicationPending(markerPath); err != nil {
+					return utilerrors.NewAggregate([]error{committedWriteErr, err})
+				}
 				if err := sendSlackMessage(slackClient, o.opsChannelId); err != nil {
 					logrus.WithError(err).Error("Failed to post message in ops channel")
 				}
+			}
+			return committedWriteErr
+		}
+
+		fallbackPending := false
+		if o.createPR {
+			var err error
+			fallbackPending, err = fallbackPublicationPending(fallbackPublicationMarkerPath(o.jobsStoragePath))
+			if err != nil {
+				logrus.WithError(err).Fatal("failed to determine fallback publication state")
+			}
+			if fallbackPending {
+				logrus.Warn("found an incomplete fallback publication; forcing a full dispatch")
+			}
+		}
+		fullDispatch = &fullDispatchController{dispatch: dispatch, retryPending: fallbackPending}
+
+		dispatchWrapper = func(forceDispatch bool) {
+			if err := fullDispatch.reconcile(forceDispatch); err != nil {
+				logrus.WithError(err).Error("failed to reconcile job assignments")
+			}
+		}
+		dispatchDeltaWrapper = func() {
+			if err := dispatchDelta(); err != nil {
+				logrus.WithError(err).Error("failed to reconcile delta job assignments")
 			}
 		}
 	}
@@ -843,30 +1235,43 @@ func main() {
 		deltaTicker := time.NewTicker(5 * time.Minute)
 		defer deltaTicker.Stop()
 
-		prevConfigClusterMap, prevBlocked, err := dispatcher.LoadClusterConfig(config)
+		publishedInventoryDigest, validPublishedInventoryDigest, err := readPublishedInventoryDigest(publishedInventoryDigestPath(o.jobsStoragePath))
 		if err != nil {
-			logrus.WithError(err).Fatal("failed to load initial cluster config")
-			return
+			logrus.WithError(err).Error("failed to load published cluster inventory digest; forcing a full dispatch")
+		} else if !validPublishedInventoryDigest {
+			logrus.Warn("published cluster inventory digest is missing or invalid; forcing a full dispatch")
 		}
-		// Run dispatch for the first time
-		dispatchWrapper(false)
+		clusterConfigState := &clusterConfigReconciler{publishedInventoryDigest: publishedInventoryDigest}
+
+		reconcileClusterConfig := func() {
+			currentConfigClusterMap, currentBlocked, err := dispatcher.LoadClusterConfig(config)
+			if err != nil {
+				logrus.WithError(err).Error("failed to load cluster config")
+				return
+			}
+			attempted, err := clusterConfigState.reconcile(currentConfigClusterMap, currentBlocked, func(forceDispatch bool) error {
+				logrus.WithField("prevConfigClusterMap", clusterConfigState.observedClusterMap).WithField("prevBlocked", clusterConfigState.observedBlocked).
+					WithField("currentConfigClusterMap", currentConfigClusterMap).WithField("currentBlocked", currentBlocked).Info("reconciling cluster config")
+				return fullDispatch.reconcile(forceDispatch)
+			})
+			if err != nil {
+				logrus.WithError(err).Error("failed to reconcile cluster config; the generation will be retried")
+				return
+			}
+			if !attempted && fullDispatch.hasPendingRetry() {
+				if err := fullDispatch.reconcile(true); err != nil {
+					logrus.WithError(err).Error("failed to retry full job assignment generation")
+				}
+			}
+		}
+
+		// Run dispatch for the first time. A failure is retried by the same loop.
+		reconcileClusterConfig()
 
 		for {
 			select {
 			case <-configTicker.C:
-				currentConfigClusterMap, currentBlocked, err := dispatcher.LoadClusterConfig(config)
-				if err != nil {
-					logrus.WithError(err).Error("failed to load cluster config")
-					continue
-				}
-
-				if !reflect.DeepEqual(currentConfigClusterMap, prevConfigClusterMap) || !reflect.DeepEqual(currentBlocked, prevBlocked) {
-					logrus.WithField("prevConfigClusterMap", prevConfigClusterMap).WithField("prevBlocked", prevBlocked).
-						WithField("currentConfigClusterMap", currentConfigClusterMap).WithField("currentBlocked", currentBlocked).Info("new dispatch")
-					dispatchWrapper(dispatcher.HasCapacityOrCapabilitiesChanged(prevConfigClusterMap, currentConfigClusterMap))
-					prevConfigClusterMap = currentConfigClusterMap
-					prevBlocked = currentBlocked
-				}
+				reconcileClusterConfig()
 
 			case <-deltaTicker.C:
 				dispatchDeltaWrapper()

--- a/cmd/prow-job-dispatcher/main_test.go
+++ b/cmd/prow-job-dispatcher/main_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -109,8 +111,8 @@ func TestDispatchJobs(t *testing.T) {
 				"build02": dispatcher.ClusterInfo{Capacity: 100},
 			},
 			expectedBuildFarm: map[api.Cloud]map[api.Cluster]*dispatcher.BuildFarmConfig{
-				"aws": {"build01": {FilenamesRaw: []string{"cluster-etcd-operator-master-presubmits.yaml", "cluster-api-provider-gcp-presubmits.yaml", "ci-tools-presubmits.yaml"}}},
-				"gcp": {"build02": {FilenamesRaw: []string{"wildfly-operator-presubmits.yaml", "xyz-operator-presubmits.yaml"}}},
+				"aws": {"build01": {FilenamesRaw: []string{"ci-tools-presubmits.yaml"}}},
+				"gcp": {"build02": {FilenamesRaw: []string{"cluster-etcd-operator-master-presubmits.yaml", "cluster-api-provider-gcp-presubmits.yaml", "wildfly-operator-presubmits.yaml", "xyz-operator-presubmits.yaml"}}},
 			},
 		},
 	}
@@ -257,6 +259,412 @@ func TestDispatchJobConfig(t *testing.T) {
 	}
 }
 
+func TestSortedStringKeys(t *testing.T) {
+	want := []string{"a", "b", "c"}
+	if diff := cmp.Diff(want, sortedStringKeys(map[string]int{"c": 3, "a": 1, "b": 2})); diff != "" {
+		t.Fatalf("sorted keys differ (-want +got):\n%s", diff)
+	}
+}
+
+func TestStaticJobVolumeAccumulationIsDeterministic(t *testing.T) {
+	config := &dispatcher.Config{
+		Default: "api.ci",
+		BuildFarm: map[api.Cloud]map[api.Cluster]*dispatcher.BuildFarmConfig{
+			api.CloudAWS: {"build01": {}, "build02": {}},
+		},
+		BuildFarmCloud: map[api.Cloud][]string{api.CloudAWS: {"build01", "build02"}},
+	}
+	clusterMap := dispatcher.ClusterMap{
+		"build01": {Provider: "aws", Capacity: 100},
+		"build02": {Provider: "aws", Capacity: 100},
+	}
+	jobVolumes := map[string]float64{"large": float64(1 << 53)}
+	for i := 1; i <= 8; i++ {
+		jobVolumes[fmt.Sprintf("small-%02d", i)] = 1
+	}
+
+	jobConfig := func(presubmits bool) *prowconfig.JobConfig {
+		jc := &prowconfig.JobConfig{}
+		if presubmits {
+			jc.PresubmitsStatic = make(map[string][]prowconfig.Presubmit)
+			for i := 8; i >= 1; i-- {
+				name := fmt.Sprintf("small-%02d", i)
+				jc.PresubmitsStatic[fmt.Sprintf("%02d-small", i)] = []prowconfig.Presubmit{{JobBase: prowconfig.JobBase{Name: name}}}
+			}
+			jc.PresubmitsStatic["00-large"] = []prowconfig.Presubmit{{JobBase: prowconfig.JobBase{Name: "large"}}}
+			return jc
+		}
+
+		jc.PostsubmitsStatic = make(map[string][]prowconfig.Postsubmit)
+		for i := 8; i >= 1; i-- {
+			name := fmt.Sprintf("small-%02d", i)
+			jc.PostsubmitsStatic[fmt.Sprintf("%02d-small", i)] = []prowconfig.Postsubmit{{JobBase: prowconfig.JobBase{Name: name}}}
+		}
+		jc.PostsubmitsStatic["00-large"] = []prowconfig.Postsubmit{{JobBase: prowconfig.JobBase{Name: "large"}}}
+		return jc
+	}
+	newClusterVolume := func() *clusterVolume {
+		return &clusterVolume{
+			clusterVolumeMap:   map[string]map[string]float64{"aws": {"build01": 0, "build02": 0}},
+			cloudProviders:     sets.New[string]("aws"),
+			pjs:                map[string]dispatcher.ProwJobData{},
+			blocked:            sets.New[string](),
+			specialClusters:    map[string]float64{},
+			volumeDistribution: map[string]float64{"build01": 1, "build02": 1},
+			clusterMap:         clusterMap,
+		}
+	}
+	expectedCluster := "build01"
+	if stableClusterTieBreak("jobs.yaml", "build02") < stableClusterTieBreak("jobs.yaml", "build01") {
+		expectedCluster = "build02"
+	}
+
+	for _, tc := range []struct {
+		name       string
+		presubmits bool
+	}{
+		{name: "presubmits", presubmits: true},
+		{name: "postsubmits"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			const iterations = 100
+			want := float64(1 << 53)
+			for i := 0; i < iterations; i++ {
+				cv := newClusterVolume()
+				jc := jobConfig(tc.presubmits)
+				jobsForProjection, err := cv.classifyJobsForProjection(jc, "jobs.yaml", config, jobVolumes)
+				if err != nil {
+					t.Fatalf("iteration %d job classification returned an error: %v", i, err)
+				}
+				projected := projectedVolumeForCandidate("build01", string(config.Default), jobsForProjection)
+				if projected != want {
+					t.Fatalf("iteration %d projected volume = %v, want %v", i, projected, want)
+				}
+				selected, err := cv.findClusterForJobConfig("", jc, "jobs.yaml", config, jobVolumes)
+				if err != nil {
+					t.Fatalf("iteration %d dispatch returned an error: %v", i, err)
+				}
+				if selected != expectedCluster {
+					t.Fatalf("iteration %d selected %q, want stable tie-break selection %q", i, selected, expectedCluster)
+				}
+				if recorded := cv.clusterVolumeMap["aws"][selected]; recorded != want {
+					t.Fatalf("iteration %d recorded volume = %v, want %v", i, recorded, want)
+				}
+				otherCluster := "build01"
+				if selected == otherCluster {
+					otherCluster = "build02"
+				}
+				if recorded := cv.clusterVolumeMap["aws"][otherCluster]; recorded != 0 {
+					t.Fatalf("iteration %d recorded volume %v on unselected cluster %q", i, recorded, otherCluster)
+				}
+			}
+		})
+	}
+}
+
+func TestFindClusterForJobConfigUsesProportionalCapacity(t *testing.T) {
+	config := &dispatcher.Config{
+		Default: "api.ci",
+		BuildFarm: map[api.Cloud]map[api.Cluster]*dispatcher.BuildFarmConfig{
+			api.CloudAWS: {
+				"build01": {},
+				"build05": {},
+			},
+		},
+		BuildFarmCloud: map[api.Cloud][]string{api.CloudAWS: {"build01", "build05"}},
+	}
+	clusterMap := dispatcher.ClusterMap{
+		"build01": {Provider: "aws", Capacity: 100},
+		"build05": {Provider: "aws", Capacity: 50},
+	}
+	cv := &clusterVolume{
+		clusterVolumeMap: map[string]map[string]float64{
+			"aws": {"build01": 80, "build05": 20},
+		},
+		cloudProviders:     sets.New[string]("aws"),
+		pjs:                map[string]dispatcher.ProwJobData{},
+		blocked:            sets.New[string](),
+		specialClusters:    map[string]float64{},
+		volumeDistribution: map[string]float64{"build01": 100, "build05": 50},
+		clusterMap:         clusterMap,
+	}
+	jobConfig := &prowconfig.JobConfig{Periodics: []prowconfig.Periodic{{JobBase: prowconfig.JobBase{Name: "periodic-a"}}}}
+
+	got, err := cv.findClusterForJobConfig("", jobConfig, "periodic-a.yaml", config, map[string]float64{"periodic-a": 10})
+	if err != nil {
+		t.Fatalf("findClusterForJobConfig() returned an error: %v", err)
+	}
+	if got != "build05" {
+		t.Fatalf("expected reduced-capacity build05 to win by projected normalized load, got %q", got)
+	}
+}
+
+func TestFindClusterForJobConfigProjectsOnlyCandidateDemand(t *testing.T) {
+	config := &dispatcher.Config{
+		Default: "api.ci",
+		BuildFarm: map[api.Cloud]map[api.Cluster]*dispatcher.BuildFarmConfig{
+			api.CloudAWS: {"build01": {}, "build05": {}},
+		},
+		BuildFarmCloud: map[api.Cloud][]string{api.CloudAWS: {"build01", "build05"}},
+	}
+	clusterMap := dispatcher.ClusterMap{
+		"build01": {Provider: "aws", Capacity: 100},
+		"build05": {Provider: "aws", Capacity: 50},
+	}
+	cv := &clusterVolume{
+		clusterVolumeMap: map[string]map[string]float64{
+			"aws": {"build01": 0, "build05": 0},
+		},
+		cloudProviders:     sets.New[string]("aws"),
+		pjs:                map[string]dispatcher.ProwJobData{},
+		blocked:            sets.New[string](),
+		specialClusters:    map[string]float64{},
+		volumeDistribution: map[string]float64{"build01": 100, "build05": 50},
+		clusterMap:         clusterMap,
+	}
+	jobConfig := &prowconfig.JobConfig{Periodics: []prowconfig.Periodic{
+		{JobBase: prowconfig.JobBase{Name: "pinned", Labels: map[string]string{api.ClusterLabel: "build01"}}},
+		{JobBase: prowconfig.JobBase{Name: "relocatable"}},
+	}}
+
+	got, err := cv.findClusterForJobConfig("", jobConfig, "mixed-periodics.yaml", config, map[string]float64{
+		"pinned":      1000,
+		"relocatable": 1,
+	})
+	if err != nil {
+		t.Fatalf("findClusterForJobConfig() returned an error: %v", err)
+	}
+	if got != "build05" {
+		t.Fatalf("expected relocatable demand on build05, got %q", got)
+	}
+	if got := cv.clusterVolumeMap["aws"]["build01"]; got != 1000 {
+		t.Fatalf("expected pinned demand 1000 on build01, got %v", got)
+	}
+	if got := cv.clusterVolumeMap["aws"]["build05"]; got != 1 {
+		t.Fatalf("expected relocatable demand 1 on build05, got %v", got)
+	}
+}
+
+func TestFindClusterForJobConfigPreservesManualClusterAssignments(t *testing.T) {
+	config := &dispatcher.Config{
+		Default:        "api.ci",
+		ManualClusters: []api.Cluster{"app.ci"},
+		BuildFarm: map[api.Cloud]map[api.Cluster]*dispatcher.BuildFarmConfig{
+			api.CloudAWS: {"build01": {}, "build02": {}},
+		},
+		BuildFarmCloud: map[api.Cloud][]string{api.CloudAWS: {"build01", "build02"}},
+	}
+	clusterMap := dispatcher.ClusterMap{
+		"build01": {Provider: "aws", Capacity: 100},
+		"build02": {Provider: "aws", Capacity: 100},
+	}
+	jobConfig := &prowconfig.JobConfig{Periodics: []prowconfig.Periodic{{JobBase: prowconfig.JobBase{
+		Name:    "manual-job",
+		Cluster: "app.ci",
+	}}}}
+	path := "manual-periodics.yaml"
+	expectedCandidate := "build01"
+	if stableClusterTieBreak(path, "build02") < stableClusterTieBreak(path, "build01") {
+		expectedCandidate = "build02"
+	}
+
+	for _, tc := range []struct {
+		name            string
+		blocked         sets.Set[string]
+		expectedCluster string
+	}{
+		{name: "manual cluster remains assigned", blocked: sets.New[string](), expectedCluster: "app.ci"},
+		{name: "blocked manual cluster relocates", blocked: sets.New[string]("app.ci"), expectedCluster: expectedCandidate},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cv := &clusterVolume{
+				clusterVolumeMap:   map[string]map[string]float64{"aws": {"build01": 0, "build02": 0}},
+				cloudProviders:     sets.New[string]("aws"),
+				pjs:                map[string]dispatcher.ProwJobData{},
+				blocked:            tc.blocked,
+				specialClusters:    map[string]float64{},
+				volumeDistribution: map[string]float64{"build01": 1, "build02": 1},
+				clusterMap:         clusterMap,
+			}
+
+			selected, err := cv.findClusterForJobConfig("", jobConfig, path, config, map[string]float64{"manual-job": 7})
+			if err != nil {
+				t.Fatalf("findClusterForJobConfig() returned an error: %v", err)
+			}
+			if selected != expectedCandidate {
+				t.Fatalf("selected candidate %q, expected %q", selected, expectedCandidate)
+			}
+			if got := cv.pjs["manual-job"].Cluster; got != tc.expectedCluster {
+				t.Fatalf("manual-job assigned to %q, expected %q", got, tc.expectedCluster)
+			}
+			if tc.expectedCluster == "app.ci" {
+				if got := cv.specialClusters["app.ci"]; got != 7 {
+					t.Fatalf("manual cluster volume = %v, expected 7", got)
+				}
+				if got := cv.clusterVolumeMap["aws"]["build01"] + cv.clusterVolumeMap["aws"]["build02"]; got != 0 {
+					t.Fatalf("manual job contributed %v volume to automatic candidates", got)
+				}
+			} else if got := cv.clusterVolumeMap["aws"][expectedCandidate]; got != 7 {
+				t.Fatalf("relocated manual job volume = %v, expected 7 on %q", got, expectedCandidate)
+			}
+		})
+	}
+}
+
+func TestFindClusterForJobConfigStickinessIncludesProjectedDemand(t *testing.T) {
+	config := &dispatcher.Config{
+		Default: "api.ci",
+		BuildFarm: map[api.Cloud]map[api.Cluster]*dispatcher.BuildFarmConfig{
+			api.CloudAWS: {"build01": {}, "build05": {}},
+		},
+		BuildFarmCloud: map[api.Cloud][]string{api.CloudAWS: {"build01", "build05"}},
+	}
+	clusterMap := dispatcher.ClusterMap{
+		"build01": {Provider: "aws", Capacity: 100},
+		"build05": {Provider: "aws", Capacity: 50},
+	}
+	jobConfig := &prowconfig.JobConfig{Periodics: []prowconfig.Periodic{{JobBase: prowconfig.JobBase{
+		Name:    "periodic-a",
+		Cluster: "build05",
+	}}}}
+
+	testCases := []struct {
+		name     string
+		volume   float64
+		expected string
+	}{
+		{name: "small group remains on existing cluster", volume: 10, expected: "build05"},
+		{name: "oversized group uses proportional scoring", volume: 100, expected: "build01"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cv := &clusterVolume{
+				clusterVolumeMap: map[string]map[string]float64{
+					"aws": {"build01": 0, "build05": 0},
+				},
+				cloudProviders:     sets.New[string]("aws"),
+				pjs:                map[string]dispatcher.ProwJobData{},
+				blocked:            sets.New[string](),
+				specialClusters:    map[string]float64{},
+				volumeDistribution: map[string]float64{"build01": 100, "build05": 50},
+				clusterMap:         clusterMap,
+			}
+
+			got, err := cv.findClusterForJobConfig("", jobConfig, "periodic-a.yaml", config, map[string]float64{"periodic-a": tc.volume})
+			if err != nil {
+				t.Fatalf("findClusterForJobConfig() returned an error: %v", err)
+			}
+			if got != tc.expected {
+				t.Fatalf("selected %q, expected %q", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestFindClusterForJobConfigBreaksTiesDeterministically(t *testing.T) {
+	config := &dispatcher.Config{
+		Default: "api.ci",
+		BuildFarm: map[api.Cloud]map[api.Cluster]*dispatcher.BuildFarmConfig{
+			api.CloudAWS: {"build01": {}, "build02": {}},
+		},
+		BuildFarmCloud: map[api.Cloud][]string{api.CloudAWS: {"build01", "build02"}},
+	}
+	clusterMap := dispatcher.ClusterMap{
+		"build01": {Provider: "aws", Capacity: 100},
+		"build02": {Provider: "aws", Capacity: 100},
+	}
+	jobConfig := &prowconfig.JobConfig{Periodics: []prowconfig.Periodic{{JobBase: prowconfig.JobBase{Name: "periodic-a"}}}}
+	path := "periodic-a.yaml"
+	expected := "build01"
+	if stableClusterTieBreak(path, "build02") < stableClusterTieBreak(path, "build01") {
+		expected = "build02"
+	}
+
+	for i := 0; i < 50; i++ {
+		cv := &clusterVolume{
+			clusterVolumeMap: map[string]map[string]float64{
+				"aws": {"build02": 0, "build01": 0},
+			},
+			cloudProviders:     sets.New[string]("aws"),
+			pjs:                map[string]dispatcher.ProwJobData{},
+			blocked:            sets.New[string](),
+			specialClusters:    map[string]float64{},
+			volumeDistribution: map[string]float64{"build01": 1, "build02": 1},
+			clusterMap:         clusterMap,
+		}
+		got, err := cv.findClusterForJobConfig("", jobConfig, path, config, nil)
+		if err != nil {
+			t.Fatalf("iteration %d returned an error: %v", i, err)
+		}
+		if got != expected {
+			t.Fatalf("iteration %d selected %q, expected stable selection %q", i, got, expected)
+		}
+	}
+}
+
+func TestFindClusterForJobConfigTieBreakIsIndependentOfCheckoutRoot(t *testing.T) {
+	config := &dispatcher.Config{
+		Default: "api.ci",
+		BuildFarm: map[api.Cloud]map[api.Cluster]*dispatcher.BuildFarmConfig{
+			api.CloudAWS: {"build01": {}, "build02": {}},
+		},
+		BuildFarmCloud: map[api.Cloud][]string{api.CloudAWS: {"build01", "build02"}},
+	}
+	clusterMap := dispatcher.ClusterMap{
+		"build01": {Provider: "aws", Capacity: 100},
+		"build02": {Provider: "aws", Capacity: 100},
+	}
+	jobConfig := &prowconfig.JobConfig{Periodics: []prowconfig.Periodic{{JobBase: prowconfig.JobBase{Name: "periodic-a"}}}}
+	relativePath := filepath.Join("org", "repo", "periodic-a.yaml")
+
+	winnerForPath := func(path string) string {
+		if stableClusterTieBreak(path, "build02") < stableClusterTieBreak(path, "build01") {
+			return "build02"
+		}
+		return "build01"
+	}
+	firstRoot := "checkout-a"
+	firstPath := filepath.Join(firstRoot, relativePath)
+	secondRoot := ""
+	for i := 0; i < 1000; i++ {
+		candidateRoot := fmt.Sprintf("checkout-%d", i)
+		if winnerForPath(filepath.Join(candidateRoot, relativePath)) != winnerForPath(firstPath) {
+			secondRoot = candidateRoot
+			break
+		}
+	}
+	if secondRoot == "" {
+		t.Fatal("failed to find checkout roots that expose absolute-path-dependent hashing")
+	}
+
+	var selected string
+	for _, root := range []string{firstRoot, secondRoot} {
+		cv := &clusterVolume{
+			clusterVolumeMap: map[string]map[string]float64{
+				"aws": {"build01": 0, "build02": 0},
+			},
+			cloudProviders:     sets.New[string]("aws"),
+			pjs:                map[string]dispatcher.ProwJobData{},
+			blocked:            sets.New[string](),
+			specialClusters:    map[string]float64{},
+			volumeDistribution: map[string]float64{"build01": 1, "build02": 1},
+			clusterMap:         clusterMap,
+			prowJobConfigDir:   root,
+		}
+		got, err := cv.findClusterForJobConfig("", jobConfig, filepath.Join(root, relativePath), config, nil)
+		if err != nil {
+			t.Fatalf("root %q returned an error: %v", root, err)
+		}
+		if selected == "" {
+			selected = got
+			continue
+		}
+		if got != selected {
+			t.Fatalf("root %q selected %q, first root selected %q", root, got, selected)
+		}
+	}
+}
+
 func TestGetCloudProvidersForE2ETests(t *testing.T) {
 	testCases := []struct {
 		name     string
@@ -337,94 +745,402 @@ func equalError(t *testing.T, expected, actual error) {
 	}
 }
 
-func TestAddEnabledClusters(t *testing.T) {
-	getProvider := func(cluster string) (api.Cloud, error) {
-		if cluster == "build02" || cluster == "build04" {
-			return "gcp", nil
+func TestSynchronizeBuildFarmUsesAuthoritativeInventory(t *testing.T) {
+	build12Assignment := &dispatcher.BuildFarmConfig{
+		FilenamesRaw: []string{"existing-presubmits.yaml"},
+		Filenames:    sets.New[string]("existing-presubmits.yaml"),
+	}
+	config := &dispatcher.Config{
+		BuildFarm: map[api.Cloud]map[api.Cluster]*dispatcher.BuildFarmConfig{
+			api.CloudAWS: {"build01": {}},
+			api.CloudGCP: {"build12": build12Assignment},
+		},
+		BuildFarmCloud: map[api.Cloud][]string{
+			api.CloudAWS: {"build01"},
+			api.CloudGCP: {"build12"},
+		},
+	}
+	inventory := dispatcher.ClusterMap{
+		"build02": {Provider: "gcp", Capacity: 100},
+		"build12": {Provider: "aws", Capacity: 100},
+	}
+
+	changed, err := config.SynchronizeBuildFarm(inventory)
+	if err != nil {
+		t.Fatalf("synchronizeBuildFarm() returned an error: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected provider move and inventory changes to be reported")
+	}
+	if got := config.BuildFarm[api.CloudAWS]["build12"]; got != build12Assignment {
+		t.Fatalf("build12 assignment was not preserved during provider move: got %#v", got)
+	}
+	if _, exists := config.BuildFarm[api.CloudAWS]["build01"]; exists {
+		t.Fatal("cluster absent from inventory remained in build farm")
+	}
+	if got := config.BuildFarm[api.CloudGCP]["build02"]; got == nil || got.Filenames == nil {
+		t.Fatalf("new inventory cluster was not initialized: got %#v", got)
+	}
+	if diff := cmp.Diff(map[api.Cloud][]string{
+		api.CloudAWS: {"build12"},
+		api.CloudGCP: {"build02"},
+	}, config.BuildFarmCloud); diff != "" {
+		t.Fatalf("BuildFarmCloud differs from authoritative inventory (-want +got):\n%s", diff)
+	}
+
+	changed, err = config.SynchronizeBuildFarm(inventory)
+	if err != nil {
+		t.Fatalf("second synchronizeBuildFarm() returned an error: %v", err)
+	}
+	if changed {
+		t.Fatal("unchanged authoritative inventory was reported as changed")
+	}
+}
+
+func TestSynchronizeBuildFarmRejectsDuplicateDispatcherCluster(t *testing.T) {
+	config := &dispatcher.Config{BuildFarm: map[api.Cloud]map[api.Cluster]*dispatcher.BuildFarmConfig{
+		api.CloudAWS: {"build01": {}},
+		api.CloudGCP: {"build01": {}},
+	}}
+	if _, err := config.SynchronizeBuildFarm(dispatcher.ClusterMap{"build01": {Provider: "aws", Capacity: 100}}); err == nil {
+		t.Fatal("expected duplicate dispatcher cluster to be rejected")
+	}
+}
+
+func TestClusterConfigReconcilerRetriesFailedGeneration(t *testing.T) {
+	clusterMap := dispatcher.ClusterMap{"build01": {Provider: "aws", Capacity: 100}}
+	blocked := sets.New[string]()
+	publishedDigest, err := clusterInventoryDigest(clusterMap, blocked)
+	if err != nil {
+		t.Fatalf("failed to calculate published inventory digest: %v", err)
+	}
+	state := &clusterConfigReconciler{publishedInventoryDigest: publishedDigest}
+	var forceValues []bool
+	attempt := 0
+	dispatch := func(force bool) error {
+		forceValues = append(forceValues, force)
+		attempt++
+		if attempt == 1 {
+			return errors.New("temporary failure")
 		}
-		return "aws", nil
+		return nil
 	}
-	tests := []struct {
-		name    string
-		config  *dispatcher.Config
-		enabled sets.Set[string]
+	controller := &fullDispatchController{dispatch: dispatch}
+
+	attempted, err := state.reconcile(clusterMap, blocked, controller.reconcile)
+	if !attempted || err == nil {
+		t.Fatalf("first reconcile = attempted %t, err %v; expected attempted failure", attempted, err)
+	}
+	if state.hasObserved {
+		t.Fatal("failed generation advanced observed state")
+	}
+
+	attempted, err = state.reconcile(clusterMap, blocked, controller.reconcile)
+	if !attempted || err != nil {
+		t.Fatalf("retry reconcile = attempted %t, err %v; expected success", attempted, err)
+	}
+	if !reflect.DeepEqual(forceValues, []bool{false, true}) {
+		t.Fatalf("unexpected force sequence: got %v, want [false true]", forceValues)
+	}
+
+	attempted, err = state.reconcile(clusterMap, blocked, controller.reconcile)
+	if attempted || err != nil {
+		t.Fatalf("unchanged observed generation = attempted %t, err %v; expected no-op", attempted, err)
+	}
+}
+
+func TestClusterConfigReconcilerForcesUnpublishedInventory(t *testing.T) {
+	currentClusterMap := dispatcher.ClusterMap{
+		"build01": {Provider: "aws", Capacity: 100, Capabilities: []string{"amd64"}},
+	}
+	currentBlocked := sets.New[string]()
+	currentDigest, err := clusterInventoryDigest(currentClusterMap, currentBlocked)
+	if err != nil {
+		t.Fatalf("failed to calculate current inventory digest: %v", err)
+	}
+	digestFor := func(clusterMap dispatcher.ClusterMap, blocked sets.Set[string]) string {
+		digest, err := clusterInventoryDigest(clusterMap, blocked)
+		if err != nil {
+			t.Fatalf("failed to calculate inventory digest: %v", err)
+		}
+		return digest
+	}
+	oldVersionDigest, err := clusterInventoryDigestForVersion(currentClusterMap, currentBlocked, inventoryDigestVersion-1)
+	if err != nil {
+		t.Fatalf("failed to calculate old-version inventory digest: %v", err)
+	}
+
+	testCases := []struct {
+		name            string
+		publishedDigest string
+		expectedForce   bool
 	}{
+		{name: "matching digest reuses snapshot", publishedDigest: currentDigest, expectedForce: false},
+		{name: "missing digest", expectedForce: true},
 		{
-			name:    "Add gcp cluster build04",
-			config:  &dispatcher.Config{},
-			enabled: sets.New[string]("build04"),
+			name: "capacity changed",
+			publishedDigest: digestFor(dispatcher.ClusterMap{
+				"build01": {Provider: "aws", Capacity: 50, Capabilities: []string{"amd64"}},
+			}, currentBlocked),
+			expectedForce: true,
 		},
 		{
-			name:    "Add multiple clusters, different providers",
-			config:  &dispatcher.Config{},
-			enabled: sets.New[string]("build03", "build04", "build05"),
+			name: "capabilities changed",
+			publishedDigest: digestFor(dispatcher.ClusterMap{
+				"build01": {Provider: "aws", Capacity: 100, Capabilities: []string{"arm64"}},
+			}, currentBlocked),
+			expectedForce: true,
 		},
+		{
+			name: "provider changed",
+			publishedDigest: digestFor(dispatcher.ClusterMap{
+				"build01": {Provider: "gcp", Capacity: 100, Capabilities: []string{"amd64"}},
+			}, currentBlocked),
+			expectedForce: true,
+		},
+		{
+			name:            "blocked state changed",
+			publishedDigest: digestFor(currentClusterMap, sets.New[string]("build02")),
+			expectedForce:   true,
+		},
+		{name: "compiler version changed", publishedDigest: oldVersionDigest, expectedForce: true},
 	}
-	for _, tc := range tests {
+
+	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			addEnabledClusters(tc.config, tc.enabled, getProvider)
-			for cluster := range tc.enabled {
-				provider, _ := getProvider(cluster)
-				if _, exists := tc.config.BuildFarm[provider][api.Cluster(cluster)]; !exists {
-					t.Errorf("%s: expected %s cluster to be added under %s provider in BuildFarm", t.Name(), cluster, provider)
-				}
-				c, exists := tc.config.BuildFarmCloud[provider]
-				if !exists {
-					t.Errorf("%s: cloud provider %s not found in BuildFarmCloud", t.Name(), provider)
-				}
-				clusters := sets.New[string](c...)
-				if !clusters.Has(cluster) {
-					t.Errorf("%s: expected %s cluster to be added under %s provider in BuildFarmCloud", t.Name(), cluster, provider)
-				}
+			state := &clusterConfigReconciler{publishedInventoryDigest: tc.publishedDigest}
+			var forced bool
+			attempted, err := state.reconcile(currentClusterMap, currentBlocked, func(force bool) error {
+				forced = force
+				return nil
+			})
+			if err != nil || !attempted {
+				t.Fatalf("reconcile = attempted %t, err %v; expected success", attempted, err)
+			}
+			if forced != tc.expectedForce {
+				t.Fatalf("forced = %t, expected %t", forced, tc.expectedForce)
+			}
+			if state.publishedInventoryDigest != currentDigest {
+				t.Fatalf("published digest was not advanced after success")
 			}
 		})
 	}
 }
 
-func TestRemoveDisabledClusters(t *testing.T) {
-	cfgWithCloud := &dispatcher.Config{
-		BuildFarmCloud: map[api.Cloud][]string{
-			"aws": {"build01"},
-			"gcp": {"build02"},
-		},
-		BuildFarm: map[api.Cloud]map[api.Cluster]*dispatcher.BuildFarmConfig{
-			api.CloudAWS: {
-				api.ClusterBuild01: {},
-			},
-			api.CloudGCP: {
-				api.ClusterBuild02: {},
-			},
-		},
+func TestClusterConfigReconcilerDoesNotAdvanceDigestOnFailure(t *testing.T) {
+	previousClusterMap := dispatcher.ClusterMap{"build01": {Provider: "aws", Capacity: 50}}
+	currentClusterMap := dispatcher.ClusterMap{"build01": {Provider: "aws", Capacity: 100}}
+	blocked := sets.New[string]()
+	previousDigest, err := clusterInventoryDigest(previousClusterMap, blocked)
+	if err != nil {
+		t.Fatalf("failed to calculate previous inventory digest: %v", err)
 	}
-	tests := []struct {
-		name     string
-		config   *dispatcher.Config
-		disabled sets.Set[string]
-	}{
-		{
-			name:     "Remove gcp and aws clusters",
-			config:   cfgWithCloud,
-			disabled: sets.New[string]("build01", "build02"),
-		},
+	state := &clusterConfigReconciler{publishedInventoryDigest: previousDigest}
+
+	attempted, err := state.reconcile(currentClusterMap, blocked, func(force bool) error {
+		if !force {
+			t.Fatal("stale published inventory did not force a dispatch")
+		}
+		return errors.New("publication failed")
+	})
+	if !attempted || err == nil {
+		t.Fatalf("reconcile = attempted %t, err %v; expected failed attempt", attempted, err)
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			removeDisabledClusters(tc.config, tc.disabled)
-			for provider := range tc.config.BuildFarm {
-				for cluster := range tc.config.BuildFarm[provider] {
-					if tc.disabled.Has(string(cluster)) {
-						t.Errorf("%s: expected %s cluster to be removed from BuildFarm config", t.Name(), cluster)
+	if state.publishedInventoryDigest != previousDigest {
+		t.Fatal("failed publication advanced the inventory digest")
+	}
+}
 
-					}
-					if clusters, ok := tc.config.BuildFarmCloud[provider]; ok {
-						if has := tc.disabled.HasAny(clusters...); has {
-							t.Errorf("%s: expected %s cluster to be removed from BuildFarmCloud config", t.Name(), cluster)
-						}
-					}
-				}
-			}
+func TestPublishedInventoryDigestLifecycle(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "assignments.gob.inventory-digest")
+	digest, err := clusterInventoryDigest(
+		dispatcher.ClusterMap{"build01": {Provider: "aws", Capacity: 100}},
+		sets.New[string]("build02"),
+	)
+	if err != nil {
+		t.Fatalf("failed to calculate inventory digest: %v", err)
+	}
 
-		})
+	if got, valid, err := readPublishedInventoryDigest(path); err != nil || valid || got != "" {
+		t.Fatalf("missing digest = %q, valid %t, err %v; expected empty, false, nil", got, valid, err)
+	}
+	if err := writePublishedInventoryDigest(path, digest); err != nil {
+		t.Fatalf("failed to publish inventory digest: %v", err)
+	}
+	if got, valid, err := readPublishedInventoryDigest(path); err != nil || !valid || got != digest {
+		t.Fatalf("published digest = %q, valid %t, err %v; expected %q, true, nil", got, valid, err, digest)
+	}
+	if err := os.WriteFile(path, []byte("corrupt\n"), 0o644); err != nil {
+		t.Fatalf("failed to write corrupt inventory digest: %v", err)
+	}
+	if got, valid, err := readPublishedInventoryDigest(path); err != nil || valid || got != "" {
+		t.Fatalf("corrupt digest = %q, valid %t, err %v; expected empty, false, nil", got, valid, err)
+	}
+}
+
+func TestFullDispatchInvalidatesDigestBeforeGobReplacement(t *testing.T) {
+	jobsStoragePath := filepath.Join(t.TempDir(), "assignments.gob")
+	digestPath := publishedInventoryDigestPath(jobsStoragePath)
+	digest, err := clusterInventoryDigest(
+		dispatcher.ClusterMap{"build01": {Provider: "aws", Capacity: 100}},
+		sets.New[string](),
+	)
+	if err != nil {
+		t.Fatalf("failed to calculate inventory digest: %v", err)
+	}
+	if err := writePublishedInventoryDigest(digestPath, digest); err != nil {
+		t.Fatalf("failed to publish existing inventory digest: %v", err)
+	}
+
+	writerCalled := false
+	directorySyncErr := &dispatcher.GobWriteCommittedError{Err: errors.New("directory sync failed")}
+	err = writeFullDispatchAssignments(jobsStoragePath, map[string]dispatcher.ProwJobData{}, func(_ string, _ interface{}) error {
+		writerCalled = true
+		if got, valid, err := readPublishedInventoryDigest(digestPath); err != nil || valid || got != "" {
+			t.Errorf("digest visible during Gob replacement = %q, valid %t, err %v; expected invalid", got, valid, err)
+		}
+		return directorySyncErr
+	})
+	if !writerCalled {
+		t.Fatal("Gob writer was not called")
+	}
+	if !dispatcher.IsGobWriteCommitted(err) {
+		t.Fatalf("write returned %v; expected committed Gob error", err)
+	}
+	if got, valid, err := readPublishedInventoryDigest(digestPath); err != nil || valid || got != "" {
+		t.Fatalf("digest after failed Gob directory sync = %q, valid %t, err %v; expected invalid", got, valid, err)
+	}
+}
+
+func TestClusterInventoryDigestIsCanonical(t *testing.T) {
+	first, err := clusterInventoryDigest(dispatcher.ClusterMap{
+		"build02": {Provider: "gcp", Capacity: 50, Capabilities: []string{"kvm", "amd64"}},
+		"build01": {Provider: "aws", Capacity: 100, Capabilities: []string{"arm64", "amd64"}},
+	}, sets.New[string]("build04", "build03"))
+	if err != nil {
+		t.Fatalf("failed to calculate first inventory digest: %v", err)
+	}
+	second, err := clusterInventoryDigest(dispatcher.ClusterMap{
+		"build01": {Provider: "aws", Capacity: 100, Capabilities: []string{"amd64", "arm64"}},
+		"build02": {Provider: "gcp", Capacity: 50, Capabilities: []string{"amd64", "kvm"}},
+	}, sets.New[string]("build03", "build04"))
+	if err != nil {
+		t.Fatalf("failed to calculate second inventory digest: %v", err)
+	}
+	if first != second {
+		t.Fatalf("semantically identical inventories produced different digests: %q != %q", first, second)
+	}
+}
+
+func TestFullDispatchControllerRetriesFailuresFromAnyTrigger(t *testing.T) {
+	var forceValues []bool
+	attempt := 0
+	controller := &fullDispatchController{dispatch: func(force bool) error {
+		forceValues = append(forceValues, force)
+		attempt++
+		if attempt == 1 {
+			return errors.New("temporary failure")
+		}
+		return nil
+	}}
+
+	if err := controller.reconcile(false); err == nil {
+		t.Fatal("expected initial dispatch to fail")
+	}
+	if !controller.hasPendingRetry() {
+		t.Fatal("failed dispatch did not record a pending retry")
+	}
+	if err := controller.reconcile(false); err != nil {
+		t.Fatalf("pending retry failed: %v", err)
+	}
+	if controller.hasPendingRetry() {
+		t.Fatal("successful retry did not clear pending state")
+	}
+	if err := controller.reconcile(false); err != nil {
+		t.Fatalf("subsequent dispatch failed: %v", err)
+	}
+	if !reflect.DeepEqual(forceValues, []bool{false, true, false}) {
+		t.Fatalf("unexpected force sequence: got %v, want [false true false]", forceValues)
+	}
+}
+
+func TestFallbackPublicationMarkerLifecycle(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "assignments.gob.fallback-pending")
+
+	pending, err := fallbackPublicationPending(path)
+	if err != nil || pending {
+		t.Fatalf("missing marker = pending %t, err %v; expected false, nil", pending, err)
+	}
+	if err := markFallbackPublicationPending(path); err != nil {
+		t.Fatalf("failed to mark fallback publication pending: %v", err)
+	}
+	pending, err = fallbackPublicationPending(path)
+	if err != nil || !pending {
+		t.Fatalf("existing marker = pending %t, err %v; expected true, nil", pending, err)
+	}
+	if err := clearFallbackPublicationPending(path); err != nil {
+		t.Fatalf("failed to clear fallback publication marker: %v", err)
+	}
+	if err := clearFallbackPublicationPending(path); err != nil {
+		t.Fatalf("clearing missing fallback publication marker was not idempotent: %v", err)
+	}
+	pending, err = fallbackPublicationPending(path)
+	if err != nil || pending {
+		t.Fatalf("cleared marker = pending %t, err %v; expected false, nil", pending, err)
+	}
+}
+
+func TestWorkingDirectoryIsRestoredBeforeRelativeMarkerCleanup(t *testing.T) {
+	workingDirectory := t.TempDir()
+	t.Chdir(workingDirectory)
+
+	markerPath := "assignments.gob.fallback-pending"
+	if err := markFallbackPublicationPending(markerPath); err != nil {
+		t.Fatalf("failed to mark fallback publication pending: %v", err)
+	}
+	cloneDirectory := t.TempDir()
+	if err := withRestoredWorkingDirectory(func() error {
+		return os.Chdir(cloneDirectory)
+	}); err != nil {
+		t.Fatalf("operation with working-directory restoration failed: %v", err)
+	}
+	if got, err := os.Getwd(); err != nil || got != workingDirectory {
+		t.Fatalf("working directory after operation = %q, err %v; expected %q", got, err, workingDirectory)
+	}
+	if err := os.RemoveAll(cloneDirectory); err != nil {
+		t.Fatalf("failed to remove simulated PR checkout: %v", err)
+	}
+	if err := clearFallbackPublicationPending(markerPath); err != nil {
+		t.Fatalf("failed to clear relative fallback publication marker: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(workingDirectory, markerPath)); !os.IsNotExist(err) {
+		t.Fatalf("fallback publication marker still exists after cleanup: %v", err)
+	}
+}
+
+func TestClusterConfigReconcilerForcesProviderChange(t *testing.T) {
+	previousClusterMap := dispatcher.ClusterMap{"build01": {Provider: "aws", Capacity: 100}}
+	publishedDigest, err := clusterInventoryDigest(previousClusterMap, sets.New[string]())
+	if err != nil {
+		t.Fatalf("failed to calculate published inventory digest: %v", err)
+	}
+	state := &clusterConfigReconciler{
+		observedClusterMap:       previousClusterMap,
+		observedBlocked:          sets.New[string](),
+		hasObserved:              true,
+		publishedInventoryDigest: publishedDigest,
+	}
+	var forced bool
+	attempted, err := state.reconcile(
+		dispatcher.ClusterMap{"build01": {Provider: "gcp", Capacity: 100}},
+		sets.New[string](),
+		func(force bool) error {
+			forced = force
+			return nil
+		},
+	)
+	if err != nil || !attempted || !forced {
+		t.Fatalf("provider change = attempted %t, forced %t, err %v; expected forced success", attempted, forced, err)
 	}
 }
 

--- a/cmd/sanitize-prow-jobs/main.go
+++ b/cmd/sanitize-prow-jobs/main.go
@@ -57,6 +57,9 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatalf("Failed to load cluster config from %q", opt.configPath)
 	}
+	if _, err := config.SynchronizeBuildFarm(cm); err != nil {
+		logrus.WithError(err).Fatal("Failed to synchronize dispatcher config with cluster inventory")
+	}
 	if err := config.Validate(); err != nil {
 		logrus.WithError(err).Fatal("Failed to validate the config")
 	}

--- a/pkg/dispatcher/config.go
+++ b/pkg/dispatcher/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"sort"
 	"strings"
@@ -43,6 +44,8 @@ type Config struct {
 	KVM []api.Cluster `json:"kvm"`
 	// the cluster names for no-builds jobs
 	NoBuilds []api.Cluster `json:"noBuilds,omitempty"`
+	// ManualClusters contains valid assignment targets that must never participate in automatic build-farm scheduling.
+	ManualClusters []api.Cluster `json:"manualClusters,omitempty"`
 	// Groups maps a group of jobs to a cluster
 	Groups JobGroups `json:"groups"`
 	// BuildFarm maps groups of jobs to a cloud provider, like GCP
@@ -54,6 +57,62 @@ type Config struct {
 type BuildFarmConfig struct {
 	FilenamesRaw []string         `json:"filenames,omitempty"`
 	Filenames    sets.Set[string] `json:"-"`
+}
+
+// SynchronizeBuildFarm makes the cluster inventory authoritative for which
+// build-farm clusters exist and which provider owns each cluster. Existing
+// generated filename assignments are preserved when a cluster moves between
+// providers. The returned boolean reports whether synchronization changed the
+// loaded dispatcher configuration.
+func (config *Config) SynchronizeBuildFarm(clusterMap ClusterMap) (bool, error) {
+	existingAssignments := make(map[api.Cluster]*BuildFarmConfig)
+	providers := make([]string, 0, len(config.BuildFarm))
+	for provider := range config.BuildFarm {
+		providers = append(providers, string(provider))
+	}
+	sort.Strings(providers)
+	for _, providerName := range providers {
+		provider := api.Cloud(providerName)
+		for cluster, assignment := range config.BuildFarm[provider] {
+			if _, exists := existingAssignments[cluster]; exists {
+				return false, fmt.Errorf("cluster %q is assigned to more than one provider in dispatcher config", cluster)
+			}
+			existingAssignments[cluster] = assignment
+		}
+	}
+
+	nextBuildFarm := make(map[api.Cloud]map[api.Cluster]*BuildFarmConfig)
+	nextBuildFarmCloud := make(map[api.Cloud][]string)
+	clusters := make([]string, 0, len(clusterMap))
+	for cluster := range clusterMap {
+		clusters = append(clusters, cluster)
+	}
+	sort.Strings(clusters)
+	for _, clusterName := range clusters {
+		if config.IsManualCluster(api.Cluster(clusterName)) {
+			return false, fmt.Errorf("manual cluster %q is present in the active cluster inventory", clusterName)
+		}
+		clusterInfo := clusterMap[clusterName]
+		provider := api.Cloud(clusterInfo.Provider)
+		if provider == "" {
+			return false, fmt.Errorf("cluster %q has an empty provider", clusterName)
+		}
+		if nextBuildFarm[provider] == nil {
+			nextBuildFarm[provider] = make(map[api.Cluster]*BuildFarmConfig)
+		}
+		cluster := api.Cluster(clusterName)
+		assignment := existingAssignments[cluster]
+		if assignment == nil {
+			assignment = &BuildFarmConfig{Filenames: sets.New[string]()}
+		}
+		nextBuildFarm[provider][cluster] = assignment
+		nextBuildFarmCloud[provider] = append(nextBuildFarmCloud[provider], clusterName)
+	}
+
+	changed := !reflect.DeepEqual(config.BuildFarm, nextBuildFarm) || !reflect.DeepEqual(config.BuildFarmCloud, nextBuildFarmCloud)
+	config.BuildFarm = nextBuildFarm
+	config.BuildFarmCloud = nextBuildFarmCloud
+	return changed, nil
 }
 
 // JobGroups maps a group of jobs to a cluster
@@ -146,6 +205,9 @@ func matchesAllCapabilities(clusterCapabilities, requiredCapabilities []string) 
 func (config *Config) DetermineClusterForJob(jobBase prowconfig.JobBase, path string, cm ClusterMap) (clusterName api.Cluster, mayBeRelocated bool, _ error) {
 	if jobBase.Agent != "kubernetes" && jobBase.Agent != "" {
 		return "", false, nil
+	}
+	if jobBase.Cluster != "" && config.IsManualCluster(api.Cluster(jobBase.Cluster)) {
+		return api.Cluster(jobBase.Cluster), false, nil
 	}
 
 	if strings.Contains(jobBase.Name, "vsphere") && !isApplyConfigJob(jobBase) {
@@ -303,6 +365,16 @@ func (config *Config) IsInBuildFarm(clusterName api.Cluster) api.Cloud {
 	return ""
 }
 
+// IsManualCluster reports whether clusterName is an allowed manual-only assignment target.
+func (config *Config) IsManualCluster(clusterName api.Cluster) bool {
+	for _, cluster := range config.ManualClusters {
+		if cluster == clusterName {
+			return true
+		}
+	}
+	return false
+}
+
 // MatchingPathRegEx returns true if the given path matches a path regular expression defined in a config's group
 func (config *Config) MatchingPathRegEx(path string) bool {
 	for _, group := range config.Groups {
@@ -368,6 +440,19 @@ func LoadConfig(configPath string) (*Config, error) {
 func (config *Config) Validate() error {
 	if config.Default == "" {
 		return fmt.Errorf("the default cluster must be set in the config")
+	}
+	manualClusters := sets.New[api.Cluster]()
+	for _, cluster := range config.ManualClusters {
+		if cluster == "" {
+			return fmt.Errorf("manualClusters must not contain an empty cluster name")
+		}
+		if manualClusters.Has(cluster) {
+			return fmt.Errorf("manual cluster %q is listed more than once", cluster)
+		}
+		if config.IsInBuildFarm(cluster) != "" {
+			return fmt.Errorf("manual cluster %q is also an automatic build-farm cluster", cluster)
+		}
+		manualClusters.Insert(cluster)
 	}
 	records := map[string]int{}
 	for _, group := range config.Groups {

--- a/pkg/dispatcher/config_test.go
+++ b/pkg/dispatcher/config_test.go
@@ -258,6 +258,21 @@ func TestLoadConfig(t *testing.T) {
 	}
 }
 
+func TestManualClustersConfigRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	want := &Config{Default: "api.ci", ManualClusters: []api.Cluster{"app.ci"}}
+	if err := SaveConfig(want, path); err != nil {
+		t.Fatalf("SaveConfig() returned an error: %v", err)
+	}
+	got, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig() returned an error: %v", err)
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("manual cluster config differs after round trip (-want +got):\n%s", diff)
+	}
+}
+
 var (
 	EquateRegexp = cmp.Comparer(func(x, y regexp.Regexp) bool {
 		return x.String() == y.String()
@@ -415,6 +430,15 @@ func TestDetermineClusterForJob(t *testing.T) {
 			jobBase:  config.JobBase{Name: "no-agent-job"},
 			path:     "ci-operator/jobs/openshift-s2i/s2i-wildfly/openshift-s2i-s2i-wildfly-master-postsubmits.yaml",
 			expected: "api.ci",
+		},
+		{
+			name: "existing manual cluster assignment",
+			config: &Config{
+				Default:        "api.ci",
+				ManualClusters: []api.Cluster{"app.ci"},
+			},
+			jobBase:  config.JobBase{Name: "manual-job", Cluster: "app.ci"},
+			expected: "app.ci",
 		},
 		{
 			name:                   "some job in build farm",
@@ -720,6 +744,40 @@ func TestValidate(t *testing.T) {
 			},
 			expected: fmt.Errorf("there are job names occurring more than once: [b c]"),
 		},
+		{
+			name: "valid manual cluster",
+			config: &Config{
+				Default:        "api.ci",
+				ManualClusters: []api.Cluster{"app.ci"},
+			},
+		},
+		{
+			name: "empty manual cluster",
+			config: &Config{
+				Default:        "api.ci",
+				ManualClusters: []api.Cluster{""},
+			},
+			expected: fmt.Errorf("manualClusters must not contain an empty cluster name"),
+		},
+		{
+			name: "duplicate manual cluster",
+			config: &Config{
+				Default:        "api.ci",
+				ManualClusters: []api.Cluster{"app.ci", "app.ci"},
+			},
+			expected: fmt.Errorf("manual cluster %q is listed more than once", "app.ci"),
+		},
+		{
+			name: "manual cluster overlaps build farm",
+			config: &Config{
+				Default:        "api.ci",
+				ManualClusters: []api.Cluster{"app.ci"},
+				BuildFarm: map[api.Cloud]map[api.Cluster]*BuildFarmConfig{
+					api.CloudAWS: {"app.ci": {}},
+				},
+			},
+			expected: fmt.Errorf("manual cluster %q is also an automatic build-farm cluster", "app.ci"),
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -728,6 +786,24 @@ func TestValidate(t *testing.T) {
 				t.Errorf("%s: actual does not match expected, diff: %s", tc.name, diff)
 			}
 		})
+	}
+}
+
+func TestSynchronizeBuildFarmKeepsManualClustersOutOfAutomaticInventory(t *testing.T) {
+	config := &Config{ManualClusters: []api.Cluster{"app.ci"}}
+	if _, err := config.SynchronizeBuildFarm(ClusterMap{"build01": {Provider: "aws", Capacity: 100}}); err != nil {
+		t.Fatalf("SynchronizeBuildFarm() returned an error: %v", err)
+	}
+	if config.IsInBuildFarm("app.ci") != "" {
+		t.Fatal("manual cluster app.ci was added to the automatic build farm")
+	}
+
+	_, err := config.SynchronizeBuildFarm(ClusterMap{
+		"app.ci":  {Provider: "aws", Capacity: 100},
+		"build01": {Provider: "aws", Capacity: 100},
+	})
+	if diff := cmp.Diff(fmt.Errorf("manual cluster %q is present in the active cluster inventory", "app.ci"), err, testhelper.EquateErrorMessage); diff != "" {
+		t.Fatalf("unexpected overlap error (-want +got):\n%s", diff)
 	}
 }
 

--- a/pkg/dispatcher/gob.go
+++ b/pkg/dispatcher/gob.go
@@ -2,8 +2,35 @@ package dispatcher
 
 import (
 	"encoding/gob"
+	"errors"
+	"fmt"
 	"os"
+	"path/filepath"
 )
+
+// GobWriteCommittedError reports a failure that happened after the destination
+// file was atomically replaced. Callers must publish the new in-memory state,
+// but should retry so the directory entry can be durably synced.
+type GobWriteCommittedError struct {
+	// Err is the underlying error encountered after the Gob file was replaced.
+	Err error
+}
+
+// Error returns the underlying committed-write error message.
+func (e *GobWriteCommittedError) Error() string {
+	return e.Err.Error()
+}
+
+// Unwrap returns the underlying committed-write error for errors.Is and errors.As.
+func (e *GobWriteCommittedError) Unwrap() error {
+	return e.Err
+}
+
+// IsGobWriteCommitted reports whether err indicates that the Gob destination was replaced before a later failure.
+func IsGobWriteCommitted(err error) bool {
+	var committedErr *GobWriteCommittedError
+	return errors.As(err, &committedErr)
+}
 
 func ReadGob(filename string, data interface{}) error {
 	file, err := os.Open(filename)
@@ -22,17 +49,53 @@ func ReadGob(filename string, data interface{}) error {
 }
 
 func WriteGob(filename string, data interface{}) error {
-	file, err := os.Create(filename)
+	return writeGob(filename, data, syncGobDirectory)
+}
+
+func writeGob(filename string, data interface{}, syncDirectory func(string) error) error {
+	directory := filepath.Dir(filename)
+	temporary, err := os.CreateTemp(directory, "."+filepath.Base(filename)+".tmp-")
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	temporaryName := temporary.Name()
+	closed := false
+	defer func() {
+		if !closed {
+			_ = temporary.Close()
+		}
+		_ = os.Remove(temporaryName)
+	}()
 
-	encoder := gob.NewEncoder(file)
-	err = encoder.Encode(data)
-	if err != nil {
-		return err
+	if err := temporary.Chmod(0o644); err != nil {
+		return fmt.Errorf("failed to set permissions on temporary Gob file: %w", err)
+	}
+	if err := gob.NewEncoder(temporary).Encode(data); err != nil {
+		return fmt.Errorf("failed to encode Gob data: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		return fmt.Errorf("failed to sync temporary Gob file: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("failed to close temporary Gob file: %w", err)
+	}
+	closed = true
+	if err := os.Rename(temporaryName, filename); err != nil {
+		return fmt.Errorf("failed to atomically replace Gob file: %w", err)
+	}
+
+	if err := syncDirectory(directory); err != nil {
+		return &GobWriteCommittedError{Err: fmt.Errorf("failed to sync Gob directory: %w", err)}
 	}
 
 	return nil
+}
+
+func syncGobDirectory(directory string) error {
+	directoryHandle, err := os.Open(directory)
+	if err != nil {
+		return err
+	}
+	defer directoryHandle.Close()
+	return directoryHandle.Sync()
 }

--- a/pkg/dispatcher/gob_test.go
+++ b/pkg/dispatcher/gob_test.go
@@ -1,0 +1,72 @@
+package dispatcher
+
+import (
+	"errors"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestWriteGobRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "assignments.gob")
+	want := map[string]ProwJobData{
+		"job-a": {Cluster: "build01", Capabilities: []string{"arm64"}},
+		"job-b": {Cluster: "build02"},
+	}
+
+	if err := WriteGob(path, want); err != nil {
+		t.Fatalf("WriteGob() returned an error: %v", err)
+	}
+	var got map[string]ProwJobData
+	if err := ReadGob(path, &got); err != nil {
+		t.Fatalf("ReadGob() returned an error: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("round trip differs: got %#v, want %#v", got, want)
+	}
+}
+
+func TestWriteGobReportsFailureAfterAtomicReplacementAsCommitted(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "assignments.gob")
+	want := map[string]ProwJobData{"job-a": {Cluster: "build02"}}
+	syncErr := errors.New("directory sync failed")
+
+	err := writeGob(path, want, func(string) error { return syncErr })
+	if err == nil {
+		t.Fatal("expected directory sync failure")
+	}
+	if !IsGobWriteCommitted(err) {
+		t.Fatalf("directory sync failure was not reported as committed: %v", err)
+	}
+	if !errors.Is(err, syncErr) {
+		t.Fatalf("committed error does not wrap sync failure: %v", err)
+	}
+
+	var got map[string]ProwJobData
+	if err := ReadGob(path, &got); err != nil {
+		t.Fatalf("failed to read atomically replaced Gob: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("atomically replaced Gob differs: got %#v, want %#v", got, want)
+	}
+}
+
+func TestWriteGobKeepsLastGoodFileWhenEncodingFails(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "assignments.gob")
+	want := map[string]ProwJobData{"job-a": {Cluster: "build01"}}
+	if err := WriteGob(path, want); err != nil {
+		t.Fatalf("failed to write initial Gob: %v", err)
+	}
+
+	if err := WriteGob(path, make(chan int)); err == nil {
+		t.Fatal("expected unsupported channel value to fail Gob encoding")
+	}
+
+	var got map[string]ProwJobData
+	if err := ReadGob(path, &got); err != nil {
+		t.Fatalf("failed to read last good Gob after failed write: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("failed write changed last good data: got %#v, want %#v", got, want)
+	}
+}

--- a/pkg/dispatcher/helpers.go
+++ b/pkg/dispatcher/helpers.go
@@ -1,8 +1,10 @@
 package dispatcher
 
 import (
+	"fmt"
 	"os"
 	"reflect"
+	"sort"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	prowconfig "sigs.k8s.io/prow/pkg/config"
@@ -22,8 +24,27 @@ func loadClusterConfigFromBytes(data []byte) (ClusterMap, sets.Set[string], erro
 	blockedClusters := sets.New[string]()
 	clusterMap := make(ClusterMap)
 
-	for provider, clusterList := range clusters {
+	providers := make([]string, 0, len(clusters))
+	for provider := range clusters {
+		providers = append(providers, provider)
+	}
+	sort.Strings(providers)
+
+	seenClusters := make(map[string]string)
+	for _, provider := range providers {
+		if !knownCloudProviders.Has(provider) {
+			return nil, nil, fmt.Errorf("unsupported cloud provider %q", provider)
+		}
+		clusterList := clusters[provider]
 		for _, cluster := range clusterList {
+			if cluster.Name == "" {
+				return nil, nil, fmt.Errorf("provider %q contains a cluster with an empty name", provider)
+			}
+			if previousProvider, exists := seenClusters[cluster.Name]; exists {
+				return nil, nil, fmt.Errorf("cluster %q is defined more than once under providers %q and %q", cluster.Name, previousProvider, provider)
+			}
+			seenClusters[cluster.Name] = provider
+
 			if cluster.Capacity == 0 || cluster.Capacity > 100 {
 				cluster.Capacity = 100
 			} else if cluster.Capacity < 0 {
@@ -36,7 +57,7 @@ func loadClusterConfigFromBytes(data []byte) (ClusterMap, sets.Set[string], erro
 			clusterMap[cluster.Name] = ClusterInfo{
 				Provider:     provider,
 				Capacity:     cluster.Capacity,
-				Capabilities: cluster.Capabilities,
+				Capabilities: sets.List(sets.New[string](cluster.Capabilities...)),
 			}
 		}
 	}
@@ -72,10 +93,15 @@ func FindMostUsedCluster(jc *prowconfig.JobConfig) string {
 	}
 	cluster := ""
 	value := 0
+	selected := false
 	for c, v := range clusters {
-		if v > value {
+		if c == "" {
+			continue
+		}
+		if !selected || v > value || v == value && c < cluster {
 			cluster = c
 			value = v
+			selected = true
 		}
 	}
 	return cluster
@@ -107,6 +133,9 @@ func HasCapacityOrCapabilitiesChanged(prev, next ClusterMap) bool {
 			continue
 		}
 		if info1.Capacity != info2.Capacity {
+			return true
+		}
+		if info1.Provider != info2.Provider {
 			return true
 		}
 		if !reflect.DeepEqual(info1.Capabilities, info2.Capabilities) {

--- a/pkg/dispatcher/helpers_test.go
+++ b/pkg/dispatcher/helpers_test.go
@@ -77,6 +77,29 @@ func TestFindMostUsedCluster(t *testing.T) {
 			},
 			expected: build01,
 		},
+		{
+			name: "equal usage chooses lexical cluster",
+			jobConfig: prowconfig.JobConfig{
+				PresubmitsStatic: map[string][]prowconfig.Presubmit{
+					"repo1": {{JobBase: prowconfig.JobBase{Cluster: build02}}},
+					"repo2": {{JobBase: prowconfig.JobBase{Cluster: build01}}},
+				},
+			},
+			expected: build01,
+		},
+		{
+			name: "empty cluster does not win a named tie",
+			jobConfig: prowconfig.JobConfig{
+				PresubmitsStatic: map[string][]prowconfig.Presubmit{
+					"repo1": {
+						{JobBase: prowconfig.JobBase{}},
+						{JobBase: prowconfig.JobBase{Cluster: build02}},
+						{JobBase: prowconfig.JobBase{Cluster: build01}},
+					},
+				},
+			},
+			expected: build01,
+		},
 	}
 
 	for _, tt := range tests {
@@ -301,6 +324,38 @@ gcp: []
 	}
 }
 
+func TestLoadClusterConfigFromBytesRejectsDuplicateClusters(t *testing.T) {
+	data := []byte(`
+aws:
+- name: build01
+gcp:
+- name: build01
+`)
+	if _, _, err := loadClusterConfigFromBytes(data); err == nil {
+		t.Fatal("expected duplicate cluster definition to be rejected")
+	}
+}
+
+func TestLoadClusterConfigFromBytesRejectsEmptyClusterName(t *testing.T) {
+	data := []byte(`
+aws:
+- capacity: 100
+`)
+	if _, _, err := loadClusterConfigFromBytes(data); err == nil {
+		t.Fatal("expected empty cluster name to be rejected")
+	}
+}
+
+func TestLoadClusterConfigFromBytesRejectsUnsupportedProvider(t *testing.T) {
+	data := []byte(`
+awss:
+- name: build01
+`)
+	if _, _, err := loadClusterConfigFromBytes(data); err == nil {
+		t.Fatal("expected unsupported provider to be rejected")
+	}
+}
+
 func TestHasCapacityOrCapabilitiesChanged(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -341,6 +396,16 @@ func TestHasCapacityOrCapabilitiesChanged(t *testing.T) {
 			next: ClusterMap{
 				"build01": {Provider: "AWS", Capacity: 10, Capabilities: []string{"aarch64", "intranet", "rce", "sshd-bastion"}},
 				"build02": {Provider: "GCP", Capacity: 20, Capabilities: []string{"aarch64", "intranet", "rce", "sshd-bastion"}},
+			},
+			expected: true,
+		},
+		{
+			name: "Change in provider for build01",
+			prev: ClusterMap{
+				"build01": {Provider: "AWS", Capacity: 10, Capabilities: []string{"amd64"}},
+			},
+			next: ClusterMap{
+				"build01": {Provider: "GCP", Capacity: 10, Capabilities: []string{"amd64"}},
 			},
 			expected: true,
 		},

--- a/pkg/sanitizer/determinize.go
+++ b/pkg/sanitizer/determinize.go
@@ -142,10 +142,11 @@ func isCIOperatorLatest(image string) bool {
 
 func determineCluster(jb prowconfig.JobBase, config *dispatcher.Config, pjs map[string]dispatcher.ProwJobData, path string, mostUsedCluster string, blocked sets.Set[string], cm dispatcher.ClusterMap) (string, error) {
 	if pjs == nil {
-		// If the job already has a cluster assigned, check if it's a valid build farm cluster
-		// that's not blocked. If so, preserve the existing assignment to avoid
+		// If the job already has a cluster assigned, check if it's a valid automatic or
+		// manual-only cluster that's not blocked. If so, preserve the existing assignment to avoid
 		// inconsistencies between what the dispatcher assigned and what this function would calculate.
-		if jb.Cluster != "" && !blocked.Has(jb.Cluster) && config.IsInBuildFarm(api.Cluster(jb.Cluster)) != "" {
+		if jb.Cluster != "" && !blocked.Has(jb.Cluster) &&
+			(config.IsInBuildFarm(api.Cluster(jb.Cluster)) != "" || config.IsManualCluster(api.Cluster(jb.Cluster))) {
 			return jb.Cluster, nil
 		}
 		c, canBeRelocated, err := config.DetermineClusterForJob(jb, path, cm)

--- a/pkg/sanitizer/determinize_test.go
+++ b/pkg/sanitizer/determinize_test.go
@@ -55,6 +55,7 @@ func TestDetermineClusterPreservesValidBuildFarmCluster(t *testing.T) {
 		jobCluster      string
 		blocked         sets.Set[string]
 		buildFarm       map[api.Cloud]map[api.Cluster]*dispatcher.BuildFarmConfig
+		manualClusters  []api.Cluster
 		groups          dispatcher.JobGroups
 		expectedCluster string
 	}{
@@ -69,6 +70,20 @@ func TestDetermineClusterPreservesValidBuildFarmCluster(t *testing.T) {
 				},
 			},
 			expectedCluster: "build01",
+		},
+		{
+			name:            "preserves existing manual cluster",
+			jobCluster:      "app.ci",
+			blocked:         sets.New[string](),
+			manualClusters:  []api.Cluster{"app.ci"},
+			expectedCluster: "app.ci",
+		},
+		{
+			name:            "does not preserve blocked manual cluster",
+			jobCluster:      "app.ci",
+			blocked:         sets.New[string]("app.ci"),
+			manualClusters:  []api.Cluster{"app.ci"},
+			expectedCluster: "api.ci",
 		},
 		{
 			name:       "uses algorithm when cluster is blocked",
@@ -121,9 +136,10 @@ func TestDetermineClusterPreservesValidBuildFarmCluster(t *testing.T) {
 			}
 
 			cfg := &dispatcher.Config{
-				Default:   "api.ci",
-				BuildFarm: tc.buildFarm,
-				Groups:    tc.groups,
+				Default:        "api.ci",
+				BuildFarm:      tc.buildFarm,
+				ManualClusters: tc.manualClusters,
+				Groups:         tc.groups,
 			}
 
 			if err := defaultJobConfig(jc, "org/repo/test.yaml", cfg, nil, tc.blocked, dispatcher.ClusterMap{}); err != nil {


### PR DESCRIPTION
Make cluster inventory authoritative, implement proportional deterministic scheduling, and harden reconciliation and assignment persistence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

The `prow-job-dispatcher` now treats cluster inventory as authoritative. It synchronizes build-farm configuration with available clusters and rejects invalid or conflicting definitions.

The dispatcher supports manual-only clusters and uses deterministic proportional-capacity scheduling. It projects workload, preserves valid assignments, and applies stable tie-breaking.

The dispatcher persists assignments and inventory digests safely. Atomic Gob writes protect the last valid configuration and identify failures that occur after replacement.

Reconciliation and dispatch paths retry failed generations, invalidate stale state, publish fallback markers, and restore the caller’s working directory. The `sanitize-prow-jobs` command stops when inventory synchronization fails.

These changes improve predictable scheduling, prevent stale cluster configuration, and strengthen recovery during configuration updates and dispatch failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->