### PR TITLE
Expansion of next-gen dispatcher's slack interface

### DIFF
--- a/cmd/slack-bot/main.go
+++ b/cmd/slack-bot/main.go
@@ -273,9 +273,12 @@ func main() {
 	if o.dispatcherControlURL != "" {
 		controlClient := dispatcher.NewControlClient(o.dispatcherControlURL, secret.GetTokenGenerator(o.dispatcherControlTokenPath))
 		dispatchHandler, err := dispatchcommand.NewHandler(controlClient, dispatchcommand.Options{
-			ChannelID:   o.dispatchCommandChannelID,
-			EnableApply: o.enableDispatchCapacity || o.enableDispatchDrain || o.enableDispatchCapabilityScope,
-			Messenger:   slackClient,
+			ChannelID:             o.dispatchCommandChannelID,
+			EnableApply:           o.enableDispatchCapacity || o.enableDispatchDrain || o.enableDispatchCapabilityScope,
+			EnableCapacity:        o.enableDispatchCapacity,
+			EnableDrain:           o.enableDispatchDrain,
+			EnableCapabilityScope: o.enableDispatchCapabilityScope,
+			Messenger:             slackClient,
 			OnDenial: func(command dispatchcommand.Command) {
 				dispatchCommandDenials.Inc()
 				logrus.WithFields(logrus.Fields{"channel_id": command.ChannelID, "user_id": command.UserID, "route": "tp-dispatch"}).Warn("denied dispatcher Slack mention outside the configured channel")

--- a/pkg/dispatcher/control.go
+++ b/pkg/dispatcher/control.go
@@ -674,6 +674,28 @@ func (c *ControlPlane) getPlan(id string) (DispatchPlan, bool) {
 	return plan, exists
 }
 
+// GetPlan returns a live plan or an error matching apply for missing or expired IDs.
+func (c *ControlPlane) GetPlan(id string) (DispatchPlan, error) {
+	plan, exists := c.getPlan(id)
+	if !exists || !c.now().Before(plan.ExpiresAt) {
+		return DispatchPlan{}, errors.New("plan is missing or expired; create a new plan")
+	}
+	return plan, nil
+}
+
+// Explain returns the current scheduling decision for a job.
+func (c *ControlPlane) Explain(job string) (Decision, error) {
+	snapshot := c.manager.Current()
+	if snapshot == nil || !c.manager.Ready() {
+		return Decision{}, errors.New("dispatcher has no ready policy generation")
+	}
+	decision, found := c.manager.Lookup(job, c.now().UTC())
+	if !found {
+		return Decision{}, fmt.Errorf("unknown job %q", job)
+	}
+	return decision, nil
+}
+
 func featureEnabled(options ControlOptions, request PlanRequest) error {
 	if request.Capability != "" && !options.EnableCapabilityScope {
 		return errors.New("capability-scoped operations are disabled")
@@ -979,6 +1001,34 @@ func (s *ControlServer) ServeHTTP(writer http.ResponseWriter, request *http.Requ
 			return
 		}
 		writeJSON(writer, http.StatusOK, plan)
+	case request.Method == http.MethodGet && strings.HasPrefix(path, "/plans/"):
+		planID := strings.TrimPrefix(path, "/plans/")
+		if planID == "" || strings.Contains(planID, "/") {
+			writeControlError(writer, http.StatusNotFound, errors.New("not found"))
+			return
+		}
+		plan, err := s.control.GetPlan(planID)
+		if err != nil {
+			writeControlError(writer, http.StatusNotFound, err)
+			return
+		}
+		writeJSON(writer, http.StatusOK, plan)
+	case request.Method == http.MethodGet && path == "/jobs":
+		job := request.URL.Query().Get("name")
+		if job == "" {
+			writeControlError(writer, http.StatusBadRequest, errors.New("job name is required"))
+			return
+		}
+		decision, err := s.control.Explain(job)
+		if err != nil {
+			status := http.StatusBadRequest
+			if strings.Contains(err.Error(), "unknown job") {
+				status = http.StatusNotFound
+			}
+			writeControlError(writer, status, err)
+			return
+		}
+		writeJSON(writer, http.StatusOK, decision)
 	case request.Method == http.MethodPost && strings.HasPrefix(path, "/plans/") && strings.HasSuffix(path, "/apply"):
 		planID := strings.TrimSuffix(strings.TrimPrefix(path, "/plans/"), "/apply")
 		var applyRequest ApplyRequest
@@ -1133,6 +1183,20 @@ func (c *ControlClient) Plan(ctx context.Context, request PlanRequest) (Dispatch
 	var plan DispatchPlan
 	err := c.request(ctx, http.MethodPost, "/control/v1/plans", request, &plan)
 	return plan, err
+}
+
+// GetPlan returns a previously created plan.
+func (c *ControlClient) GetPlan(ctx context.Context, id string) (DispatchPlan, error) {
+	var plan DispatchPlan
+	err := c.request(ctx, http.MethodGet, "/control/v1/plans/"+id, nil, &plan)
+	return plan, err
+}
+
+// Explain returns the current scheduling decision for a job.
+func (c *ControlClient) Explain(ctx context.Context, job string) (Decision, error) {
+	var decision Decision
+	err := c.request(ctx, http.MethodGet, "/control/v1/jobs?name="+url.QueryEscape(job), nil, &decision)
+	return decision, err
 }
 
 // Apply applies or approves a plan.

--- a/pkg/dispatcher/control_test.go
+++ b/pkg/dispatcher/control_test.go
@@ -542,6 +542,120 @@ func TestControlServerAuthenticationAndPlan(t *testing.T) {
 	}
 }
 
+func TestControlPlaneGetPlanAndHTTPGet(t *testing.T) {
+	control, _, _, now := testControlPlane(t, ControlOptions{EnableCapacity: true})
+	plan, err := control.Plan(context.Background(), capacityPlanRequest())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := control.GetPlan(plan.ID)
+	if err != nil || got.ID != plan.ID {
+		t.Fatalf("live plan was not returned: %#v, %v", got, err)
+	}
+	if _, err := control.GetPlan("missing-plan"); err == nil || !strings.Contains(err.Error(), "missing or expired") {
+		t.Fatalf("missing plan error: %v", err)
+	}
+	control.now = func() time.Time { return now.Add(16 * time.Minute) }
+	if _, err := control.GetPlan(plan.ID); err == nil || !strings.Contains(err.Error(), "missing or expired") {
+		t.Fatalf("expired plan error: %v", err)
+	}
+	control.now = func() time.Time { return now }
+
+	server := NewControlServer(control, func() []byte { return []byte("secret") })
+	get := httptest.NewRequest(http.MethodGet, "/control/v1/plans/"+plan.ID, nil)
+	get.Header.Set("Authorization", "Bearer secret")
+	gotResponse := httptest.NewRecorder()
+	server.ServeHTTP(gotResponse, get)
+	if gotResponse.Code != http.StatusOK {
+		t.Fatalf("expected GET plan success, got %d: %s", gotResponse.Code, gotResponse.Body.String())
+	}
+	var decoded DispatchPlan
+	if err := json.Unmarshal(gotResponse.Body.Bytes(), &decoded); err != nil || decoded.ID != plan.ID {
+		t.Fatalf("GET plan body: %#v, %v", decoded, err)
+	}
+
+	getApply := httptest.NewRequest(http.MethodGet, "/control/v1/plans/"+plan.ID+"/apply", nil)
+	getApply.Header.Set("Authorization", "Bearer secret")
+	getApplyResponse := httptest.NewRecorder()
+	server.ServeHTTP(getApplyResponse, getApply)
+	if getApplyResponse.Code == http.StatusOK {
+		t.Fatalf("GET plan apply path was treated as GetPlan: %d %s", getApplyResponse.Code, getApplyResponse.Body.String())
+	}
+
+	applyBody, err := json.Marshal(ApplyRequest{UserID: "U1", ChannelID: "C-team", IdempotencyKey: "apply"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	apply := httptest.NewRequest(http.MethodPost, "/control/v1/plans/"+plan.ID+"/apply", bytes.NewReader(applyBody))
+	apply.Header.Set("Authorization", "Bearer secret")
+	applied := httptest.NewRecorder()
+	server.ServeHTTP(applied, apply)
+	if applied.Code != http.StatusOK {
+		t.Fatalf("POST apply route broke after GET plan: %d %s", applied.Code, applied.Body.String())
+	}
+
+	missing := httptest.NewRequest(http.MethodGet, "/control/v1/plans/missing-plan", nil)
+	missing.Header.Set("Authorization", "Bearer secret")
+	missingResponse := httptest.NewRecorder()
+	server.ServeHTTP(missingResponse, missing)
+	if missingResponse.Code != http.StatusNotFound || !strings.Contains(missingResponse.Body.String(), "missing or expired") {
+		t.Fatalf("missing GET plan: %d %s", missingResponse.Code, missingResponse.Body.String())
+	}
+
+	control.now = func() time.Time { return now.Add(16 * time.Minute) }
+	expired := httptest.NewRequest(http.MethodGet, "/control/v1/plans/"+plan.ID, nil)
+	expired.Header.Set("Authorization", "Bearer secret")
+	expiredResponse := httptest.NewRecorder()
+	server.ServeHTTP(expiredResponse, expired)
+	if expiredResponse.Code != http.StatusNotFound || !strings.Contains(expiredResponse.Body.String(), "missing or expired") {
+		t.Fatalf("expired GET plan: %d %s", expiredResponse.Code, expiredResponse.Body.String())
+	}
+}
+
+func TestControlPlaneExplainHitAndMiss(t *testing.T) {
+	control, _, _, _ := testControlPlane(t, ControlOptions{})
+	decision, err := control.Explain("job-a")
+	if err != nil || decision.Cluster != "build01" || decision.Source != "baseline" || decision.PolicyGeneration == 0 {
+		t.Fatalf("explain hit: %#v, %v", decision, err)
+	}
+	if _, err := control.Explain("missing-job"); err == nil || !strings.Contains(err.Error(), "unknown job") {
+		t.Fatalf("explain miss: %v", err)
+	}
+
+	server := NewControlServer(control, func() []byte { return []byte("secret") })
+	hit := httptest.NewRequest(http.MethodGet, "/control/v1/jobs?name=job-a", nil)
+	hit.Header.Set("Authorization", "Bearer secret")
+	hitResponse := httptest.NewRecorder()
+	server.ServeHTTP(hitResponse, hit)
+	if hitResponse.Code != http.StatusOK {
+		t.Fatalf("expected explain success, got %d: %s", hitResponse.Code, hitResponse.Body.String())
+	}
+	var decoded Decision
+	if err := json.Unmarshal(hitResponse.Body.Bytes(), &decoded); err != nil || decoded.Cluster != "build01" {
+		t.Fatalf("explain body: %#v, %v", decoded, err)
+	}
+
+	miss := httptest.NewRequest(http.MethodGet, "/control/v1/jobs?name=missing-job", nil)
+	miss.Header.Set("Authorization", "Bearer secret")
+	missResponse := httptest.NewRecorder()
+	server.ServeHTTP(missResponse, miss)
+	if missResponse.Code == http.StatusInternalServerError || missResponse.Code != http.StatusNotFound || !strings.Contains(missResponse.Body.String(), "unknown job") {
+		t.Fatalf("explain miss HTTP: %d %s", missResponse.Code, missResponse.Body.String())
+	}
+
+	control.manager = NewSnapshotManager("")
+	if _, err := control.Explain("job-a"); err == nil || !strings.Contains(err.Error(), "ready") {
+		t.Fatalf("explain without a ready snapshot: %v", err)
+	}
+	unready := httptest.NewRequest(http.MethodGet, "/control/v1/jobs?name=job-a", nil)
+	unready.Header.Set("Authorization", "Bearer secret")
+	unreadyResponse := httptest.NewRecorder()
+	server.ServeHTTP(unreadyResponse, unready)
+	if unreadyResponse.Code != http.StatusBadRequest || !strings.Contains(unreadyResponse.Body.String(), "ready") {
+		t.Fatalf("unready explain HTTP: %d %s", unreadyResponse.Code, unreadyResponse.Body.String())
+	}
+}
+
 func TestFallbackObservationServerAuthenticationAndDigestBinding(t *testing.T) {
 	control, _, manager, now := testControlPlane(t, ControlOptions{})
 	server := NewFallbackObservationServer(control, func() []byte { return []byte("observer-secret") })

--- a/pkg/slack/dispatcher/commands.go
+++ b/pkg/slack/dispatcher/commands.go
@@ -22,6 +22,8 @@ import (
 type ControlClient interface {
 	Status(context.Context, string) (coredispatcher.ControlStatus, error)
 	Overrides(context.Context) ([]dispatcherv1.DispatchOverride, error)
+	GetPlan(context.Context, string) (coredispatcher.DispatchPlan, error)
+	Explain(context.Context, string) (coredispatcher.Decision, error)
 	Plan(context.Context, coredispatcher.PlanRequest) (coredispatcher.DispatchPlan, error)
 	Apply(context.Context, string, coredispatcher.ApplyRequest) (*dispatcherv1.DispatchOverride, error)
 	Cancel(context.Context, string, coredispatcher.CancelRequest) (*dispatcherv1.DispatchOverride, error)
@@ -37,10 +39,13 @@ type Options struct {
 	ChannelID string
 	Timeout   time.Duration
 	// EnableApply gates all mutating commands while status, overrides, and plan remain available.
-	EnableApply  bool
-	Messenger    Messenger
-	PollInterval time.Duration
-	OnDenial     func(Command)
+	EnableApply           bool
+	EnableCapacity        bool
+	EnableDrain           bool
+	EnableCapabilityScope bool
+	Messenger             Messenger
+	PollInterval          time.Duration
+	OnDenial              func(Command)
 }
 
 // Command is a dispatcher operation derived from a signed Slack event.
@@ -177,7 +182,17 @@ func formatOverrides(overrides []dispatcherv1.DispatchOverride) string {
 		if overrides[i].Spec.Scope.Capability != "" {
 			scope += "/capability:" + overrides[i].Spec.Scope.Capability
 		}
-		lines = append(lines, fmt.Sprintf("• `%s` %s %s — %s, expires %s", overrides[i].Spec.ID, overrides[i].Spec.Kind, scope, overrides[i].Status.State, overrides[i].Spec.ExpiresAt.Time.UTC().Format(time.RFC3339)))
+		fallbackProtected := overrides[i].Spec.FallbackProtected
+		if overrides[i].Status.State != "" {
+			fallbackProtected = overrides[i].Status.FallbackProtected
+		}
+		detail := fmt.Sprintf("reason %s; created by %s; approvals %d/%d; generation %d; fallback protected: *%t*",
+			overrides[i].Spec.Reason, overrides[i].Spec.CreatedBy, len(overrides[i].Spec.Approvals), overrides[i].Spec.RequiredApprovals,
+			overrides[i].Status.PolicyGeneration, fallbackProtected)
+		if overrides[i].Spec.IncidentURL != "" {
+			detail += "; incident " + overrides[i].Spec.IncidentURL
+		}
+		lines = append(lines, fmt.Sprintf("• `%s` %s %s — %s, expires %s\n  %s", overrides[i].Spec.ID, overrides[i].Spec.Kind, scope, overrides[i].Status.State, overrides[i].Spec.ExpiresAt.Time.UTC().Format(time.RFC3339), detail))
 	}
 	return strings.Join(lines, "\n")
 }
@@ -234,8 +249,46 @@ func fallbackSuffix(plan coredispatcher.DispatchPlan) string {
 	return ""
 }
 
+func formatHistory(override dispatcherv1.DispatchOverride) string {
+	if len(override.Status.History) == 0 {
+		return fmt.Sprintf("Override `%s` has no recorded history.", override.Spec.ID)
+	}
+	lines := []string{fmt.Sprintf("History for override `%s`:", override.Spec.ID)}
+	for _, event := range override.Status.History {
+		lines = append(lines, fmt.Sprintf("• %s %s by %s — %s (generation %d)", event.At.Time.UTC().Format(time.RFC3339), event.State, event.Actor, event.Message, event.Generation))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func formatDecision(job string, decision coredispatcher.Decision) string {
+	text := fmt.Sprintf("Job `%s` is on `%s` (%s), generation `%d`.", job, decision.Cluster, decision.Source, decision.PolicyGeneration)
+	if decision.OverrideID != "" {
+		text += fmt.Sprintf(" Override `%s`.", decision.OverrideID)
+	}
+	if !decision.ValidUntil.IsZero() {
+		text += fmt.Sprintf(" Valid until %s.", decision.ValidUntil.UTC().Format(time.RFC3339))
+	}
+	if decision.Explanation != "" {
+		text += " " + decision.Explanation
+	}
+	return text
+}
+
+func (h *Handler) disabledPlanKind(plan coredispatcher.DispatchPlan) string {
+	if plan.Request.Capability != "" && !h.options.EnableCapabilityScope {
+		return "capability-scoped operations are disabled"
+	}
+	if plan.Request.Kind == dispatcherv1.OverrideKindCapacity && !h.options.EnableCapacity {
+		return "capacity operations are disabled"
+	}
+	if plan.Request.Kind == dispatcherv1.OverrideKindDrain && !h.options.EnableDrain {
+		return "drain operations are disabled"
+	}
+	return ""
+}
+
 func usage() string {
-	return "Usage: `@dptp-bot tp-dispatch status [cluster]`, `overrides`, `plan capacity CLUSTER VALUE --for DURATION --reason REASON`, `plan drain CLUSTER --for DURATION --reason REASON`, `apply PLAN_ID`, or `cancel OVERRIDE_ID`. Add `--capability NAME` to scope a plan."
+	return "Usage: `@dptp-bot tp-dispatch status [cluster]`, `overrides`, `history OVERRIDE_ID`, `explain JOB`, `plan show PLAN_ID`, `plan capacity CLUSTER VALUE --for DURATION --reason REASON`, `plan drain CLUSTER --for DURATION --reason REASON`, `apply PLAN_ID`, `approve PLAN_ID`, or `cancel OVERRIDE_ID`. Add `--capability NAME` to scope a plan."
 }
 
 // DeniedResponse records and formats a channel-boundary denial without calling the dispatcher.
@@ -347,9 +400,51 @@ func (h *Handler) Handle(parent context.Context, command Command) Response {
 		if err == nil {
 			text = formatOverrides(overrides)
 		}
+	case "history":
+		positionals, _, parseErr := parseOptions(tokens[1:], 1)
+		if parseErr != nil {
+			return response(parseErr.Error() + ". " + usage())
+		}
+		var overrides []dispatcherv1.DispatchOverride
+		overrides, err = h.client.Overrides(ctx)
+		if err == nil {
+			found := false
+			for i := range overrides {
+				if overrides[i].Spec.ID == positionals[0] {
+					text = formatHistory(overrides[i])
+					found = true
+					break
+				}
+			}
+			if !found {
+				return response(fmt.Sprintf("Override `%s` was not found.", positionals[0]))
+			}
+		}
+	case "explain":
+		positionals, _, parseErr := parseOptions(tokens[1:], 1)
+		if parseErr != nil {
+			return response(parseErr.Error() + ". " + usage())
+		}
+		var decision coredispatcher.Decision
+		decision, err = h.client.Explain(ctx, positionals[0])
+		if err == nil {
+			text = formatDecision(positionals[0], decision)
+		}
 	case "plan":
 		if len(tokens) < 2 {
 			return response(usage())
+		}
+		if tokens[1] == "show" {
+			positionals, _, parseErr := parseOptions(tokens[2:], 1)
+			if parseErr != nil {
+				return response(parseErr.Error() + ". " + usage())
+			}
+			var shown coredispatcher.DispatchPlan
+			shown, err = h.client.GetPlan(ctx, positionals[0])
+			if err == nil {
+				text = formatPlan(shown)
+			}
+			break
 		}
 		kind := dispatcherv1.OverrideKind(strings.ToUpper(tokens[1][:1]) + strings.ToLower(tokens[1][1:]))
 		positionalCount := 1
@@ -385,22 +480,34 @@ func (h *Handler) Handle(parent context.Context, command Command) Response {
 		if err == nil {
 			text = formatPlan(plan)
 		}
-	case "apply":
+	case "apply", "approve":
 		if !h.options.EnableApply {
-			return response("Dispatcher apply is disabled while the command is in read-only shadow mode.")
+			return response(fmt.Sprintf("Dispatcher %s is disabled while the command is in read-only shadow mode.", tokens[0]))
 		}
 		positionals, options, parseErr := parseOptions(tokens[1:], 1, "confirm-fallback")
 		if parseErr != nil {
 			return response(parseErr.Error() + ". " + usage())
 		}
+		var preview coredispatcher.DispatchPlan
+		preview, err = h.client.GetPlan(ctx, positionals[0])
+		if err != nil {
+			break
+		}
+		if refusal := h.disabledPlanKind(preview); refusal != "" {
+			return response(refusal)
+		}
 		var override *dispatcherv1.DispatchOverride
 		override, err = h.client.Apply(ctx, positionals[0], coredispatcher.ApplyRequest{
-			UserID: command.UserID, ChannelID: command.ChannelID, IdempotencyKey: idempotencyKey(command, "apply"),
+			UserID: command.UserID, ChannelID: command.ChannelID, IdempotencyKey: idempotencyKey(command, tokens[0]),
 			FallbackConfirmed: options["confirm-fallback"] == "true", SlackThreadTS: command.ThreadTS,
 		})
 		if err == nil {
 			resultingOverride = override
-			text = fmt.Sprintf("Override `%s` is %s with %d/%d approvals. Policy generation: %d.", override.Spec.ID, override.Status.State, len(override.Spec.Approvals), override.Spec.RequiredApprovals, override.Status.PolicyGeneration)
+			if tokens[0] == "approve" {
+				text = fmt.Sprintf("Recorded approval for override `%s`; it is %s with %d/%d approvals. Policy generation: %d.", override.Spec.ID, override.Status.State, len(override.Spec.Approvals), override.Spec.RequiredApprovals, override.Status.PolicyGeneration)
+			} else {
+				text = fmt.Sprintf("Override `%s` is %s with %d/%d approvals. Policy generation: %d.", override.Spec.ID, override.Status.State, len(override.Spec.Approvals), override.Spec.RequiredApprovals, override.Status.PolicyGeneration)
+			}
 		}
 	case "cancel":
 		if !h.options.EnableApply {

--- a/pkg/slack/dispatcher/commands_test.go
+++ b/pkg/slack/dispatcher/commands_test.go
@@ -23,6 +23,12 @@ type fakeControlClient struct {
 	planRequest    coredispatcher.PlanRequest
 	applyRequests  []coredispatcher.ApplyRequest
 	cancelRequests []coredispatcher.CancelRequest
+	overrides      []dispatcherv1.DispatchOverride
+	getPlan        coredispatcher.DispatchPlan
+	getPlanErr     error
+	explain        coredispatcher.Decision
+	explainErr     error
+	explainJob     string
 }
 
 func (f *fakeControlClient) Status(context.Context, string) (coredispatcher.ControlStatus, error) {
@@ -32,7 +38,30 @@ func (f *fakeControlClient) Status(context.Context, string) (coredispatcher.Cont
 
 func (f *fakeControlClient) Overrides(context.Context) ([]dispatcherv1.DispatchOverride, error) {
 	f.calls++
-	return nil, nil
+	return f.overrides, nil
+}
+
+func (f *fakeControlClient) GetPlan(_ context.Context, id string) (coredispatcher.DispatchPlan, error) {
+	f.calls++
+	if f.getPlanErr != nil {
+		return coredispatcher.DispatchPlan{}, f.getPlanErr
+	}
+	if f.getPlan.ID != "" || f.getPlan.Request.Kind != "" {
+		return f.getPlan, nil
+	}
+	return coredispatcher.DispatchPlan{ID: id, Request: coredispatcher.PlanRequest{Kind: dispatcherv1.OverrideKindCapacity, Cluster: "build01"}}, nil
+}
+
+func (f *fakeControlClient) Explain(_ context.Context, job string) (coredispatcher.Decision, error) {
+	f.calls++
+	f.explainJob = job
+	if f.explainErr != nil {
+		return coredispatcher.Decision{}, f.explainErr
+	}
+	if f.explain.Cluster != "" {
+		return f.explain, nil
+	}
+	return coredispatcher.Decision{Cluster: "build01", Source: "baseline", PolicyGeneration: 3, Explanation: "assigned from Git baseline"}, nil
 }
 
 func (f *fakeControlClient) Plan(_ context.Context, request coredispatcher.PlanRequest) (coredispatcher.DispatchPlan, error) {
@@ -147,6 +176,10 @@ func TestReadOnlyShadowModeAllowsPlanButRejectsMutations(t *testing.T) {
 	if !strings.Contains(result.Text, "disabled") || client.calls != 1 {
 		t.Fatalf("apply was not held in shadow mode: %#v, calls=%d", result, client.calls)
 	}
+	result = handler.Handle(context.Background(), Command{ChannelID: "C-team", UserID: "U1", Text: "approve plan-1"})
+	if !strings.Contains(result.Text, "disabled") || client.calls != 1 {
+		t.Fatalf("approve was not held in shadow mode: %#v, calls=%d", result, client.calls)
+	}
 	result = handler.Handle(context.Background(), Command{ChannelID: "C-team", UserID: "U1", Text: "cancel override-1"})
 	if !strings.Contains(result.Text, "disabled") || client.calls != 1 {
 		t.Fatalf("cancel was not held in shadow mode: %#v, calls=%d", result, client.calls)
@@ -171,7 +204,7 @@ func TestUnknownOptionIsRejectedBeforeDispatcherCall(t *testing.T) {
 func TestMentionRetryIsIdempotentAndApplyUsesOriginatingThread(t *testing.T) {
 	client := &fakeControlClient{}
 	messenger := &fakeMessenger{}
-	handler, err := NewHandler(client, Options{ChannelID: "C-team", EnableApply: true, Messenger: messenger})
+	handler, err := NewHandler(client, Options{ChannelID: "C-team", EnableApply: true, EnableCapacity: true, Messenger: messenger})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -183,7 +216,7 @@ func TestMentionRetryIsIdempotentAndApplyUsesOriginatingThread(t *testing.T) {
 			t.Fatalf("apply mention was not handled: handled=%t err=%v", handled, err)
 		}
 	}
-	if client.calls != 1 || len(client.applyRequests) != 1 || len(messenger.posts) != 1 {
+	if client.calls != 2 || len(client.applyRequests) != 1 || len(messenger.posts) != 1 {
 		t.Fatalf("Slack retry was not deduplicated: calls=%d apply=%d posts=%d", client.calls, len(client.applyRequests), len(messenger.posts))
 	}
 	request := client.applyRequests[0]
@@ -197,7 +230,7 @@ func TestMentionRetryIsIdempotentAndApplyUsesOriginatingThread(t *testing.T) {
 
 func TestMutatingCommandsUseEventIdentity(t *testing.T) {
 	client := &fakeControlClient{}
-	handler, err := NewHandler(client, Options{ChannelID: "C-team", EnableApply: true})
+	handler, err := NewHandler(client, Options{ChannelID: "C-team", EnableApply: true, EnableCapacity: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -205,16 +238,197 @@ func TestMutatingCommandsUseEventIdentity(t *testing.T) {
 	if !strings.Contains(result.Text, "Active") {
 		t.Fatalf("apply failed: %#v", result)
 	}
+	result = handler.Handle(context.Background(), Command{ChannelID: "C-team", UserID: "U2", RequestID: "Ev-approve", ThreadTS: "100.1", Text: "approve plan-1 --confirm-fallback"})
+	if !strings.Contains(result.Text, "Recorded approval") || !strings.Contains(result.Text, "1/1") || len(client.applyRequests) != 2 || client.applyRequests[1].IdempotencyKey != "approve:Ev-approve" {
+		t.Fatalf("approve failed: %#v, apply=%#v", result, client.applyRequests)
+	}
 	result = handler.Handle(context.Background(), Command{ChannelID: "C-team", UserID: "U2", RequestID: "Ev-cancel", Text: "cancel override-1"})
-	if !strings.Contains(result.Text, "Revoked") || client.calls != 2 || client.cancelRequests[0].IdempotencyKey != "cancel:Ev-cancel" {
+	if !strings.Contains(result.Text, "Revoked") || client.calls != 5 || client.cancelRequests[0].IdempotencyKey != "cancel:Ev-cancel" {
 		t.Fatalf("cancel failed: %#v, calls=%d", result, client.calls)
 	}
 }
 
 func TestFormatOverridesIncludesExpiry(t *testing.T) {
-	override := dispatcherv1.DispatchOverride{Spec: dispatcherv1.DispatchOverrideSpec{ID: "o1", Kind: dispatcherv1.OverrideKindDrain, Cluster: "build01", ExpiresAt: metav1.NewTime(time.Date(2026, 8, 20, 14, 0, 0, 0, time.UTC))}, Status: dispatcherv1.DispatchOverrideStatus{State: dispatcherv1.OverrideStatePending}}
+	override := dispatcherv1.DispatchOverride{
+		Spec: dispatcherv1.DispatchOverrideSpec{
+			ID: "o1", Kind: dispatcherv1.OverrideKindDrain, Cluster: "build01", CreatedBy: "U9",
+			Reason: "INC-123 API outage", IncidentURL: "https://issues.example/INC-123",
+			RequiredApprovals: 2, Approvals: []dispatcherv1.DispatchApproval{{UserID: "U9"}},
+			ExpiresAt: metav1.NewTime(time.Date(2026, 8, 20, 14, 0, 0, 0, time.UTC)),
+		},
+		Status: dispatcherv1.DispatchOverrideStatus{State: dispatcherv1.OverrideStatePending, PolicyGeneration: 7, FallbackProtected: true},
+	}
 	formatted := formatOverrides([]dispatcherv1.DispatchOverride{override})
-	if !strings.Contains(formatted, "o1") || !strings.Contains(formatted, "Pending") || !strings.Contains(formatted, "2026-08-20T14:00:00Z") {
-		t.Fatalf("unexpected override presentation: %s", formatted)
+	for _, want := range []string{"o1", "Pending", "2026-08-20T14:00:00Z", "INC-123 API outage", "U9", "1/2", "generation 7", "fallback protected: *true*", "https://issues.example/INC-123"} {
+		if !strings.Contains(formatted, want) {
+			t.Fatalf("override presentation missing %q: %s", want, formatted)
+		}
+	}
+	withoutIncident := override
+	withoutIncident.Spec.IncidentURL = ""
+	withoutIncident.Spec.FallbackProtected = true
+	withoutIncident.Status.FallbackProtected = false
+	withoutIncident.Status.State = dispatcherv1.OverrideStatePending
+	formatted = formatOverrides([]dispatcherv1.DispatchOverride{withoutIncident})
+	if strings.Contains(formatted, "incident") {
+		t.Fatalf("empty incident URL was included: %s", formatted)
+	}
+	if !strings.Contains(formatted, "fallback protected: *false*") {
+		t.Fatalf("status fallback protection was not preferred: %s", formatted)
+	}
+}
+
+func TestHistoryFoundAndMissing(t *testing.T) {
+	client := &fakeControlClient{
+		overrides: []dispatcherv1.DispatchOverride{{
+			Spec: dispatcherv1.DispatchOverrideSpec{ID: "o1"},
+			Status: dispatcherv1.DispatchOverrideStatus{History: []dispatcherv1.DispatchAuditEvent{{
+				At:    metav1.NewTime(time.Date(2026, 8, 20, 14, 0, 0, 0, time.UTC)),
+				State: dispatcherv1.OverrideStateActive, Actor: "U1", Message: "active", Generation: 4,
+			}}},
+		}},
+	}
+	handler, err := NewHandler(client, Options{ChannelID: "C-team"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := handler.Handle(context.Background(), Command{ChannelID: "C-team", UserID: "U1", Text: "history o1"})
+	for _, want := range []string{"o1", "Active", "U1", "active", "generation 4", "2026-08-20T14:00:00Z"} {
+		if !strings.Contains(result.Text, want) {
+			t.Fatalf("history missing %q: %#v", want, result)
+		}
+	}
+	result = handler.Handle(context.Background(), Command{ChannelID: "C-team", UserID: "U1", Text: "history missing"})
+	if strings.Contains(result.Text, "Dispatcher request failed") || !strings.Contains(result.Text, "not found") {
+		t.Fatalf("missing override was not a human error: %#v", result)
+	}
+	client.overrides[0].Status.History = nil
+	result = handler.Handle(context.Background(), Command{ChannelID: "C-team", UserID: "U1", Text: "history o1"})
+	if !strings.Contains(result.Text, "no recorded history") {
+		t.Fatalf("empty history was not described: %#v", result)
+	}
+}
+
+func TestPlanShowAndExplain(t *testing.T) {
+	client := &fakeControlClient{
+		getPlan: coredispatcher.DispatchPlan{
+			ID: "plan-9", Request: coredispatcher.PlanRequest{Kind: dispatcherv1.OverrideKindCapacity, Cluster: "build01", DurationSeconds: 3600},
+			RequiredApprovals: 1, CurrentEffectiveCapacity: 100, RequestedEffectiveCapacity: 25,
+		},
+		explain: coredispatcher.Decision{
+			Cluster: "build02", Source: "runtime-override", PolicyGeneration: 8, OverrideID: "o1",
+			ValidUntil: time.Date(2026, 8, 20, 16, 0, 0, 0, time.UTC), Explanation: "moved by capacity override",
+		},
+	}
+	handler, err := NewHandler(client, Options{ChannelID: "C-team"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := handler.Handle(context.Background(), Command{ChannelID: "C-team", UserID: "U1", Text: "plan show plan-9"})
+	if !strings.Contains(result.Text, "plan-9") || !strings.Contains(result.Text, "Capacity") || client.calls != 1 {
+		t.Fatalf("plan show failed: %#v, calls=%d", result, client.calls)
+	}
+	result = handler.Handle(context.Background(), Command{ChannelID: "C-team", UserID: "U1", Text: "explain pull-ci-openshift-ci-tools-master-e2e"})
+	for _, want := range []string{"build02", "runtime-override", "8", "o1", "2026-08-20T16:00:00Z", "moved by capacity override"} {
+		if !strings.Contains(result.Text, want) {
+			t.Fatalf("explain missing %q: %#v", want, result)
+		}
+	}
+	if client.explainJob != "pull-ci-openshift-ci-tools-master-e2e" {
+		t.Fatalf("explain job was not forwarded: %q", client.explainJob)
+	}
+}
+
+func TestApplyRefusesDisabledDrainBeforeApply(t *testing.T) {
+	client := &fakeControlClient{getPlan: coredispatcher.DispatchPlan{
+		ID: "plan-drain", Request: coredispatcher.PlanRequest{Kind: dispatcherv1.OverrideKindDrain, Cluster: "build01"},
+	}}
+	handler, err := NewHandler(client, Options{ChannelID: "C-team", EnableApply: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := handler.Handle(context.Background(), Command{ChannelID: "C-team", UserID: "U1", Text: "apply plan-drain"})
+	if client.calls != 1 || len(client.applyRequests) != 0 || !strings.Contains(result.Text, "drain operations are disabled") {
+		t.Fatalf("drain apply was not refused locally: %#v, calls=%d apply=%d", result, client.calls, len(client.applyRequests))
+	}
+	result = handler.Handle(context.Background(), Command{ChannelID: "C-team", UserID: "U1", Text: "approve plan-drain"})
+	if client.calls != 2 || len(client.applyRequests) != 0 || !strings.Contains(result.Text, "drain operations are disabled") {
+		t.Fatalf("drain approve was not refused locally: %#v, calls=%d apply=%d", result, client.calls, len(client.applyRequests))
+	}
+}
+
+func TestApplyIsFailClosedWhenGetPlanErrors(t *testing.T) {
+	client := &fakeControlClient{getPlanErr: fmt.Errorf("plan lookup failed")}
+	handler, err := NewHandler(client, Options{ChannelID: "C-team", EnableApply: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := handler.Handle(context.Background(), Command{ChannelID: "C-team", UserID: "U1", Text: "apply plan-1"})
+	if len(client.applyRequests) != 0 || !strings.Contains(result.Text, "plan lookup failed") {
+		t.Fatalf("apply was not fail-closed on GetPlan error: %#v, apply=%d", result, len(client.applyRequests))
+	}
+	result = handler.Handle(context.Background(), Command{ChannelID: "C-team", UserID: "U1", Text: "approve plan-1"})
+	if len(client.applyRequests) != 0 || !strings.Contains(result.Text, "plan lookup failed") {
+		t.Fatalf("approve was not fail-closed on GetPlan error: %#v, apply=%d", result, len(client.applyRequests))
+	}
+}
+
+func TestApplyRefusesDisabledCapabilityScopeBeforeApply(t *testing.T) {
+	client := &fakeControlClient{getPlan: coredispatcher.DispatchPlan{
+		ID: "plan-cap", Request: coredispatcher.PlanRequest{Kind: dispatcherv1.OverrideKindCapacity, Cluster: "build01", Capability: "intranet"},
+	}}
+	handler, err := NewHandler(client, Options{ChannelID: "C-team", EnableApply: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := handler.Handle(context.Background(), Command{ChannelID: "C-team", UserID: "U1", Text: "apply plan-cap"})
+	if client.calls != 1 || len(client.applyRequests) != 0 || !strings.Contains(result.Text, "capability-scoped operations are disabled") {
+		t.Fatalf("capability apply was not refused locally: %#v, calls=%d apply=%d", result, client.calls, len(client.applyRequests))
+	}
+	result = handler.Handle(context.Background(), Command{ChannelID: "C-team", UserID: "U1", Text: "approve plan-cap"})
+	if client.calls != 2 || len(client.applyRequests) != 0 || !strings.Contains(result.Text, "capability-scoped operations are disabled") {
+		t.Fatalf("capability approve was not refused locally: %#v, calls=%d apply=%d", result, client.calls, len(client.applyRequests))
+	}
+}
+
+func TestDisabledPlanKindFeatureFlagCombinations(t *testing.T) {
+	plans := []struct {
+		name       string
+		kind       dispatcherv1.OverrideKind
+		capability string
+	}{
+		{name: "capacity", kind: dispatcherv1.OverrideKindCapacity},
+		{name: "drain", kind: dispatcherv1.OverrideKindDrain},
+		{name: "capability capacity", kind: dispatcherv1.OverrideKindCapacity, capability: "intranet"},
+		{name: "capability drain", kind: dispatcherv1.OverrideKindDrain, capability: "intranet"},
+	}
+
+	for mask := 0; mask < 8; mask++ {
+		options := Options{
+			EnableCapacity:        mask&1 != 0,
+			EnableDrain:           mask&2 != 0,
+			EnableCapabilityScope: mask&4 != 0,
+		}
+		for _, plan := range plans {
+			plan := plan
+			t.Run(fmt.Sprintf("flags_%03b/%s", mask, plan.name), func(t *testing.T) {
+				want := ""
+				switch {
+				case plan.capability != "" && !options.EnableCapabilityScope:
+					want = "capability-scoped operations are disabled"
+				case plan.kind == dispatcherv1.OverrideKindCapacity && !options.EnableCapacity:
+					want = "capacity operations are disabled"
+				case plan.kind == dispatcherv1.OverrideKindDrain && !options.EnableDrain:
+					want = "drain operations are disabled"
+				}
+				handler := &Handler{options: options}
+				got := handler.disabledPlanKind(coredispatcher.DispatchPlan{Request: coredispatcher.PlanRequest{
+					Kind: plan.kind, Capability: plan.capability,
+				}})
+				if got != want {
+					t.Fatalf("disabledPlanKind() = %q, want %q with options %#v", got, want, options)
+				}
+			})
+		}
 	}
 }


### PR DESCRIPTION
The commit expands the next-generation dispatcher’s Slack interface with history explain, plan show, and explicit approve commands. It adds control-plane API endpoints and client methods for retrieving live plans and explaining a job’s current scheduling decision. Override listings now include reasons, creators, approval progress, policy generations, fallback protection, and incident links. Before applying or approving a plan, Slack fetches the plan and enforces the configured drain and capability-scope feature gates. It also wires those gates through the Slack bot and adds tests for the new commands, API behavior, safety checks, and richer output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

The next-generation dispatcher now provides safer Slack controls for CI operators:

- Added `history`, `explain`, `plan show`, and explicit `approve` commands.
- Added control-plane APIs and client methods to retrieve live plans and explain job scheduling decisions.
- Expanded override details with reasons, creators, approval status, policy generations, fallback protection, incident links, and history.
- Enforced capacity, drain, and capability-scope feature gates before plan retrieval, application, or approval.
- Wired feature-gate settings through the Slack bot.
- Added tests for commands, API behavior, approval safety, feature gates, and output formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->