### PR TITLE
Add Namespace to Secret struct

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1404,6 +1404,11 @@ type Secret struct {
 	// Secret name, used inside test containers.
 	// Mutually exclusive with Bundle and Collection/Group.
 	Name string `json:"name,omitempty"`
+	// Namespace is where the source secret exists. Only relevant when
+	// Bundle references a bundle with sync_to_cluster: true, in which case
+	// the underlying Kubernetes secret is fetched from this namespace
+	// instead of GSM.
+	Namespace string `json:"namespace,omitempty"`
 	// Secret mount path. Defaults to /usr/test-secrets for first
 	// secret. /usr/test-secrets-2 for second, and so on.
 	MountPath string `json:"mount_path"`

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -448,6 +448,7 @@ func (s *podStep) resolveAndCreateGSMSecrets(ctx context.Context) error {
 			Field:      secret.Field,
 			Group:      secret.Group,
 			Bundle:     secret.Bundle,
+			Namespace:  secret.Namespace,
 			MountPath:  mountPath,
 		})
 	}

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -1159,6 +1159,11 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"            # Secret name, used inside test containers.\n" +
 	"            # Mutually exclusive with Bundle and Collection/Group.\n" +
 	"            name: ' '\n" +
+	"            # Namespace is where the source secret exists. Only relevant when\n" +
+	"            # Bundle references a bundle with sync_to_cluster: true, in which case\n" +
+	"            # the underlying Kubernetes secret is fetched from this namespace\n" +
+	"            # instead of GSM.\n" +
+	"            namespace: ' '\n" +
 	"        # Secrets is an optional array of secret objects\n" +
 	"        # which will be mounted inside the test container.\n" +
 	"        # You cannot set the Secret and Secrets attributes\n" +
@@ -1186,6 +1191,11 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"              # Secret name, used inside test containers.\n" +
 	"              # Mutually exclusive with Bundle and Collection/Group.\n" +
 	"              name: ' '\n" +
+	"              # Namespace is where the source secret exists. Only relevant when\n" +
+	"              # Bundle references a bundle with sync_to_cluster: true, in which case\n" +
+	"              # the underlying Kubernetes secret is fetched from this namespace\n" +
+	"              # instead of GSM.\n" +
+	"              namespace: ' '\n" +
 	"        # ShardCount describes the number of jobs that should be generated as shards for this test\n" +
 	"        # Each generated job will be a duplication, but contain a suffix and the necessary SHARD_ARGS will be passed to the steps\n" +
 	"        # Only applicable to presubmits and periodics\n" +
@@ -2140,6 +2150,11 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"        # Secret name, used inside test containers.\n" +
 	"        # Mutually exclusive with Bundle and Collection/Group.\n" +
 	"        name: ' '\n" +
+	"        # Namespace is where the source secret exists. Only relevant when\n" +
+	"        # Bundle references a bundle with sync_to_cluster: true, in which case\n" +
+	"        # the underlying Kubernetes secret is fetched from this namespace\n" +
+	"        # instead of GSM.\n" +
+	"        namespace: ' '\n" +
 	"      # Secrets is an optional array of secret objects\n" +
 	"      # which will be mounted inside the test container.\n" +
 	"      # You cannot set the Secret and Secrets attributes\n" +
@@ -2167,6 +2182,11 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"          # Secret name, used inside test containers.\n" +
 	"          # Mutually exclusive with Bundle and Collection/Group.\n" +
 	"          name: ' '\n" +
+	"          # Namespace is where the source secret exists. Only relevant when\n" +
+	"          # Bundle references a bundle with sync_to_cluster: true, in which case\n" +
+	"          # the underlying Kubernetes secret is fetched from this namespace\n" +
+	"          # instead of GSM.\n" +
+	"          namespace: ' '\n" +
 	"      # ShardCount describes the number of jobs that should be generated as shards for this test\n" +
 	"      # Each generated job will be a duplication, but contain a suffix and the necessary SHARD_ARGS will be passed to the steps\n" +
 	"      # Only applicable to presubmits and periodics\n" +


### PR DESCRIPTION
Bundles with `sync_to_cluster: true` referenced in tests need also `Namespace` specified, so that we know from which ns in the cluster to pull the k8s secret. `secrets` struct didn't have that. This is a corner case that is not even used right now in actual user tests, but we should support it.

https://redhat.atlassian.net/browse/DPTP-5187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds an optional `Namespace` field to the `Secret` API type.
- Passes the namespace when ci-operator resolves GSM credential references.
- This allows test bundles with `sync_to_cluster: true` to identify the Kubernetes namespace that contains the referenced secret.
- Updates the MultiArchBuildConfig CRD to support `fileKeyRef` environment-variable sources and broader environment-variable name validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->