### PR TITLE
Allow five-minute scheduler propagation bound

### DIFF
--- a/cmd/prow-job-dispatcher/main.go
+++ b/cmd/prow-job-dispatcher/main.go
@@ -150,7 +150,7 @@ func gatherOptions() options {
 	fs.DurationVar(&o.maxDrainTTL, "max-runtime-drain-ttl", 2*time.Hour, "Maximum TTL for a runtime drain.")
 	fs.DurationVar(&o.planTTL, "runtime-plan-ttl", 15*time.Minute, "How long an unapplied runtime plan remains valid.")
 	fs.Float64Var(&o.affectedDemandApprovalThreshold, "runtime-second-approval-demand", 0, "Affected demand at or above this value requires a distinct second approver. A positive value is required before writes can be enabled.")
-	fs.DurationVar(&o.schedulerPropagationBound, "scheduler-propagation-bound", 0, "Measured upper bound from dispatcher publication through the Prow external-scheduler cache. Required and at most 30s before writes can be enabled.")
+	fs.DurationVar(&o.schedulerPropagationBound, "scheduler-propagation-bound", 0, "Measured upper bound from dispatcher publication through the Prow external-scheduler cache. Required and at most 5m before writes can be enabled.")
 	fs.StringVar(&o.prowSchedulerConfigPath, "prow-scheduler-config-path", "", "Path to the live Prow configuration mounted from the same source used by the scheduler. Required before runtime writes can be enabled.")
 	fs.BoolVar(&o.legacyEventEndpoint, "enable-legacy-event-endpoint", false, "Expose the unauthenticated legacy /event dispatch endpoint. Disabled for the next-generation control plane.")
 

--- a/pkg/dispatcher/control.go
+++ b/pkg/dispatcher/control.go
@@ -27,7 +27,10 @@ import (
 	dispatcherv1 "github.com/openshift/ci-tools/pkg/api/dispatcher/v1"
 )
 
-const maxAuditHistory = 50
+const (
+	maxAuditHistory              = 50
+	maxSchedulerPropagationBound = 5 * time.Minute
+)
 
 var controlIDPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,62}$`)
 
@@ -82,8 +85,8 @@ func (o *ControlOptions) Validate() error {
 	if o.EnableCapabilityScope && !o.EnableCapacity {
 		return errors.New("capability-scoped operations require capacity operations to be enabled")
 	}
-	if o.EnableCapacity && (o.SchedulerPropagationBound <= 0 || o.SchedulerPropagationBound > 30*time.Second) {
-		return errors.New("write operations require a measured scheduler propagation bound no greater than 30 seconds")
+	if o.EnableCapacity && (o.SchedulerPropagationBound <= 0 || o.SchedulerPropagationBound > maxSchedulerPropagationBound) {
+		return fmt.Errorf("write operations require a measured scheduler propagation bound no greater than %s", maxSchedulerPropagationBound)
 	}
 	if o.EnableCapacity && o.AffectedDemandApproval <= 0 {
 		return errors.New("write operations require a positive affected-demand threshold for second approval")

--- a/pkg/dispatcher/control_test.go
+++ b/pkg/dispatcher/control_test.go
@@ -148,6 +148,34 @@ func TestControlPlaneRejectsWritesWithoutMeasuredPropagationBound(t *testing.T) 
 	}
 }
 
+func TestControlOptionsSchedulerPropagationBound(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		bound   time.Duration
+		wantErr bool
+	}{
+		{name: "maximum", bound: 5 * time.Minute},
+		{name: "above maximum", bound: 5*time.Minute + time.Nanosecond, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			options := ControlOptions{
+				AllowedChannelID:          "C-team",
+				EnableCapacity:            true,
+				SchedulerPropagationBound: tc.bound,
+				AffectedDemandApproval:    1,
+				WriteSafetyCheck:          func() error { return nil },
+			}
+			err := options.Validate()
+			if tc.wantErr && err == nil {
+				t.Fatal("expected propagation bound validation to fail")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected propagation bound validation to pass: %v", err)
+			}
+		})
+	}
+}
+
 func TestControlPlaneRechecksWriteSafety(t *testing.T) {
 	var safetyErr error
 	control, _, _, _ := testControlPlane(t, ControlOptions{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

The prow-job-dispatcher now permits scheduler propagation bounds up to five minutes.

This gives CI operators more time for scheduler updates to reach the dispatcher. Validation rejects values above five minutes and reports the configured maximum. Tests cover both accepted and rejected bounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->