### PR TITLE
dptp-controller-manager: relax `--release-repo-git-sync-path` validation constraints

### DIFF
--- a/cmd/dptp-controller-manager/main.go
+++ b/cmd/dptp-controller-manager/main.go
@@ -163,24 +163,33 @@ func newOpts() (*options, error) {
 
 	var errs []error
 	if opts.releaseRepoGitSyncPath != "" {
-		if opts.ciOperatorconfigPath != "" || opts.stepConfigPath != "" || opts.prowconfig.JobConfigPath != "" || opts.prowconfig.SupplementalProwConfigDirs.String() != "" {
-			errs = append(errs, fmt.Errorf("--release-repo-path is mutually exclusive with --ci-operator-config-path and --step-config-path and --%s and --supplemental-prow-config-dir", opts.prowconfig.JobConfigPathFlagName))
-		} else {
-			if _, err := os.Stat(opts.releaseRepoGitSyncPath); err != nil {
-				if os.IsNotExist(err) {
-					errs = append(errs, fmt.Errorf("--release-repo-path points to a nonexistent directory: %w", err))
-				}
-				errs = append(errs, fmt.Errorf("error getting stat info for --release-repo-path directory: %w", err))
+		if _, err := os.Stat(opts.releaseRepoGitSyncPath); err != nil {
+			if os.IsNotExist(err) {
+				errs = append(errs, fmt.Errorf("--release-repo-path points to a nonexistent directory: %w", err))
 			}
+			errs = append(errs, fmt.Errorf("error getting stat info for --release-repo-path directory: %w", err))
+		}
 
+		if opts.ciOperatorconfigPath == "" {
 			opts.ciOperatorconfigPath = filepath.Join(opts.releaseRepoGitSyncPath, config.CiopConfigInRepoPath)
+		}
+
+		if opts.stepConfigPath == "" {
 			opts.stepConfigPath = filepath.Join(opts.releaseRepoGitSyncPath, config.RegistryPath)
+		}
+
+		if opts.prowconfig.JobConfigPath == "" {
 			opts.prowconfig.JobConfigPath = filepath.Join(opts.releaseRepoGitSyncPath, config.JobConfigInRepoPath)
+		}
+
+		if opts.prowconfig.ConfigPath == "" {
 			opts.prowconfig.ConfigPath = filepath.Join(opts.releaseRepoGitSyncPath, config.ConfigInRepoPath)
+		}
+
+		if opts.prowconfig.SupplementalProwConfigDirs.String() == "" {
 			if err := opts.prowconfig.SupplementalProwConfigDirs.Set(filepath.Dir(filepath.Join(opts.releaseRepoGitSyncPath, config.ConfigInRepoPath))); err != nil {
 				errs = append(errs, fmt.Errorf("could not set supplemental prow config dirs: %w", err))
 			}
-
 		}
 	}
 	if opts.leaderElectionNamespace == "" {


### PR DESCRIPTION
Allow Prow flags like `--job-config-path` to be explicitly set even when `--release-repo-git-sync-path` exists.

This enables future optmizations like the following:

```bash
mkdir -p /tmp/empty-jobs-dir

dptp-controller-manager \
  --release-repo-git-sync-path=/var/repo/release \
  --job-config-path=/tmp/empty-jobs-dir
  ...
```

In this say the ProwConfig agent loads only the Prow config with no job definitions at all, saving tons of memory (`~2.5Gi` based on the latest `pprof` trace from the `ephemeral-cluster` deployment).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Relaxes `dptp-controller-manager` validation for `--release-repo-git-sync-path`.

When the release repository exists, operators can explicitly set Prow flags such as `--job-config-path`. The sync path supplies defaults only for options that remain unset. This supports configurations that load Prow configuration without job definitions and can reduce memory usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->