### PR TITLE
Drop fallback confirmation and post Slack transitions only on state changes, require one approval

### DIFF
--- a/cmd/prow-job-dispatcher/main.go
+++ b/cmd/prow-job-dispatcher/main.go
@@ -96,7 +96,6 @@ type options struct {
 
 	overrideNamespace               string
 	controlAPITokenPath             string
-	fallbackObserverTokenPath       string
 	dispatchCommandChannelID        string
 	enableRuntimeCapacity           bool
 	enableRuntimeDrain              bool
@@ -141,7 +140,6 @@ func gatherOptions() options {
 	fs.StringVar(&o.opsChannelId, "ops-channel-id", "CHY2E1BL4", "Channel ID for #ops-testplatform")
 	fs.StringVar(&o.overrideNamespace, "dispatch-override-namespace", "", "Namespace containing DispatchOverride resources. Empty disables the runtime control plane.")
 	fs.StringVar(&o.controlAPITokenPath, "control-api-token-path", "", "Path to the bearer token accepted from the DPTP bot control client.")
-	fs.StringVar(&o.fallbackObserverTokenPath, "fallback-observer-token-path", "", "Path to the separate bearer token accepted from the Prow fallback-state observer.")
 	fs.StringVar(&o.dispatchCommandChannelID, "dispatch-command-channel-id", "", "Immutable Slack channel ID for #team-dp-testplatform.")
 	fs.BoolVar(&o.enableRuntimeCapacity, "enable-runtime-capacity", false, "Allow whole-cluster capacity overrides to be applied.")
 	fs.BoolVar(&o.enableRuntimeDrain, "enable-runtime-drain", false, "Allow whole-cluster drains to be applied.")
@@ -149,7 +147,7 @@ func gatherOptions() options {
 	fs.DurationVar(&o.maxOverrideTTL, "max-runtime-override-ttl", 24*time.Hour, "Maximum TTL for a runtime capacity override.")
 	fs.DurationVar(&o.maxDrainTTL, "max-runtime-drain-ttl", 2*time.Hour, "Maximum TTL for a runtime drain.")
 	fs.DurationVar(&o.planTTL, "runtime-plan-ttl", 15*time.Minute, "How long an unapplied runtime plan remains valid.")
-	fs.Float64Var(&o.affectedDemandApprovalThreshold, "runtime-second-approval-demand", 0, "Affected demand at or above this value requires a distinct second approver. A positive value is required before writes can be enabled.")
+	fs.Float64Var(&o.affectedDemandApprovalThreshold, "runtime-second-approval-demand", 0, "Deprecated and ignored. One approval is sufficient to apply a runtime override.")
 	fs.DurationVar(&o.schedulerPropagationBound, "scheduler-propagation-bound", 0, "Measured upper bound from dispatcher publication through the Prow external-scheduler cache. Required and at most 5m before writes can be enabled.")
 	fs.StringVar(&o.prowSchedulerConfigPath, "prow-scheduler-config-path", "", "Path to the live Prow configuration mounted from the same source used by the scheduler. Required before runtime writes can be enabled.")
 	fs.BoolVar(&o.legacyEventEndpoint, "enable-legacy-event-endpoint", false, "Expose the unauthenticated legacy /event dispatch endpoint. Disabled for the next-generation control plane.")
@@ -197,7 +195,7 @@ func (o *options) validate() error {
 	if o.slackTokenPath == "" {
 		logrus.Fatal("mandatory argument --slack-token-path wasn't set")
 	}
-	controlConfigured := o.overrideNamespace != "" || o.controlAPITokenPath != "" || o.fallbackObserverTokenPath != "" || o.dispatchCommandChannelID != "" ||
+	controlConfigured := o.overrideNamespace != "" || o.controlAPITokenPath != "" || o.dispatchCommandChannelID != "" ||
 		o.enableRuntimeCapacity || o.enableRuntimeDrain || o.enableRuntimeCapabilityScope
 	if controlConfigured && (o.overrideNamespace == "" || o.controlAPITokenPath == "" || o.dispatchCommandChannelID == "") {
 		return fmt.Errorf("--dispatch-override-namespace, --control-api-token-path, and --dispatch-command-channel-id are all required for runtime controls")
@@ -205,18 +203,12 @@ func (o *options) validate() error {
 	if o.enableRuntimeDrain && !o.enableRuntimeCapacity {
 		return fmt.Errorf("--enable-runtime-drain requires --enable-runtime-capacity")
 	}
-	if o.enableRuntimeDrain && o.fallbackObserverTokenPath == "" {
-		return fmt.Errorf("--enable-runtime-drain requires --fallback-observer-token-path")
-	}
-	if o.fallbackObserverTokenPath != "" && o.fallbackObserverTokenPath == o.controlAPITokenPath {
-		return fmt.Errorf("--fallback-observer-token-path must use a token distinct from --control-api-token-path")
-	}
 	if o.enableRuntimeCapabilityScope && !o.enableRuntimeCapacity {
 		return fmt.Errorf("--enable-runtime-capability-scope requires --enable-runtime-capacity")
 	}
 	controlOptions := dispatcher.ControlOptions{
 		AllowedChannelID: o.dispatchCommandChannelID, MaxTTL: o.maxOverrideTTL, MaxDrainTTL: o.maxDrainTTL,
-		PlanTTL: o.planTTL, AffectedDemandApproval: o.affectedDemandApprovalThreshold,
+		PlanTTL:        o.planTTL,
 		EnableCapacity: o.enableRuntimeCapacity, EnableDrain: o.enableRuntimeDrain, EnableCapabilityScope: o.enableRuntimeCapabilityScope,
 		SchedulerPropagationBound: o.schedulerPropagationBound,
 		WriteSafetyCheck:          o.schedulerWriteSafetyCheck(),
@@ -1343,9 +1335,6 @@ func main() {
 	if o.controlAPITokenPath != "" {
 		secretPaths = append(secretPaths, o.controlAPITokenPath)
 	}
-	if o.fallbackObserverTokenPath != "" {
-		secretPaths = append(secretPaths, o.fallbackObserverTokenPath)
-	}
 	if err := secret.Add(secretPaths...); err != nil {
 		logrus.WithError(err).Fatal("failed to start secrets agent")
 	}
@@ -1385,7 +1374,7 @@ func main() {
 		}
 		controlPlane, err = dispatcher.NewControlPlane(snapshots, dispatcher.NewKubernetesOverrideStore(kubeClient, o.overrideNamespace), dispatcher.ControlOptions{
 			AllowedChannelID: o.dispatchCommandChannelID, MaxTTL: o.maxOverrideTTL, MaxDrainTTL: o.maxDrainTTL,
-			PlanTTL: o.planTTL, AffectedDemandApproval: o.affectedDemandApprovalThreshold,
+			PlanTTL:        o.planTTL,
 			EnableCapacity: o.enableRuntimeCapacity, EnableDrain: o.enableRuntimeDrain, EnableCapabilityScope: o.enableRuntimeCapabilityScope,
 			SchedulerPropagationBound: o.schedulerPropagationBound,
 			WriteSafetyCheck:          o.schedulerWriteSafetyCheck(),
@@ -1647,9 +1636,6 @@ func main() {
 	}
 	if controlPlane != nil {
 		mux.Handle("/control/v1/", dispatcher.NewControlServer(controlPlane, secret.GetTokenGenerator(o.controlAPITokenPath)))
-		if o.fallbackObserverTokenPath != "" {
-			mux.Handle("/fallback-observer/v1/protection", dispatcher.NewFallbackObservationServer(controlPlane, secret.GetTokenGenerator(o.fallbackObserverTokenPath)))
-		}
 	}
 	httpServer := &http.Server{
 		Addr:              ":8080",

--- a/pkg/api/dispatcher/v1/ci.openshift.io_dispatchoverrides.yaml
+++ b/pkg/api/dispatcher/v1/ci.openshift.io_dispatchoverrides.yaml
@@ -89,10 +89,6 @@ spec:
               expiresAt:
                 format: date-time
                 type: string
-              fallbackConfirmed:
-                type: boolean
-              fallbackProtected:
-                type: boolean
               id:
                 minLength: 1
                 type: string
@@ -151,7 +147,6 @@ spec:
             - cluster
             - createdBy
             - expiresAt
-            - fallbackProtected
             - id
             - idempotencyKey
             - kind
@@ -173,8 +168,7 @@ spec:
                 self.startsAt == oldSelf.startsAt && self.expiresAt == oldSelf.expiresAt
                 && self.createdBy == oldSelf.createdBy && self.sourceChannelID ==
                 oldSelf.sourceChannelID && self.reason == oldSelf.reason && self.requiredApprovals
-                == oldSelf.requiredApprovals && self.fallbackProtected == oldSelf.fallbackProtected
-                && self.idempotencyKey == oldSelf.idempotencyKey
+                == oldSelf.requiredApprovals && self.idempotencyKey == oldSelf.idempotencyKey
             - message: override scope is immutable
               rule: has(self.scope) == has(oldSelf.scope) && (!has(self.scope) ||
                 self.scope == oldSelf.scope)
@@ -187,9 +181,6 @@ spec:
             - message: approvals may only be appended
               rule: '!has(oldSelf.approvals) || (has(self.approvals) && oldSelf.approvals.all(a,
                 self.approvals.exists(b, b.userID == a.userID && b.at == a.at)))'
-            - message: fallback confirmation cannot be withdrawn
-              rule: '!has(oldSelf.fallbackConfirmed) || !oldSelf.fallbackConfirmed
-                || (has(self.fallbackConfirmed) && self.fallbackConfirmed)'
             - message: revokedAt and a non-empty revokedBy must be set together
               rule: has(self.revokedAt) == has(self.revokedBy) && (!has(self.revokedBy)
                 || size(self.revokedBy) > 0)
@@ -200,11 +191,6 @@ spec:
             - message: Slack thread binding cannot be changed
               rule: '!has(oldSelf.slackThreadTS) || (has(self.slackThreadTS) && self.slackThreadTS
                 == oldSelf.slackThreadTS)'
-            - message: drain overrides require two approvals
-              rule: self.kind != 'Drain' || self.requiredApprovals == 2
-            - message: an unprotected drain requires explicit fallback confirmation
-              rule: self.kind != 'Drain' || self.fallbackProtected || (has(self.fallbackConfirmed)
-                && self.fallbackConfirmed)
           status:
             description: DispatchOverrideStatus is the observed override and publication
               state.
@@ -268,8 +254,6 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
-              fallbackProtected:
-                type: boolean
               history:
                 items:
                   description: DispatchAuditEvent records a durable state transition

--- a/pkg/api/dispatcher/v1/types.go
+++ b/pkg/api/dispatcher/v1/types.go
@@ -50,17 +50,14 @@ type DispatchAuditEvent struct {
 
 // DispatchOverrideSpec is the desired temporary scheduling policy.
 // +kubebuilder:validation:XValidation:rule="self.kind == 'Capacity' ? has(self.capacity) : !has(self.capacity)",message="capacity is required only for Capacity overrides"
-// +kubebuilder:validation:XValidation:rule="self.id == oldSelf.id && self.planID == oldSelf.planID && self.sourceGeneration == oldSelf.sourceGeneration && self.policyInputDigest == oldSelf.policyInputDigest && self.kind == oldSelf.kind && self.cluster == oldSelf.cluster && self.startsAt == oldSelf.startsAt && self.expiresAt == oldSelf.expiresAt && self.createdBy == oldSelf.createdBy && self.sourceChannelID == oldSelf.sourceChannelID && self.reason == oldSelf.reason && self.requiredApprovals == oldSelf.requiredApprovals && self.fallbackProtected == oldSelf.fallbackProtected && self.idempotencyKey == oldSelf.idempotencyKey",message="immutable override identity and policy fields cannot change"
+// +kubebuilder:validation:XValidation:rule="self.id == oldSelf.id && self.planID == oldSelf.planID && self.sourceGeneration == oldSelf.sourceGeneration && self.policyInputDigest == oldSelf.policyInputDigest && self.kind == oldSelf.kind && self.cluster == oldSelf.cluster && self.startsAt == oldSelf.startsAt && self.expiresAt == oldSelf.expiresAt && self.createdBy == oldSelf.createdBy && self.sourceChannelID == oldSelf.sourceChannelID && self.reason == oldSelf.reason && self.requiredApprovals == oldSelf.requiredApprovals && self.idempotencyKey == oldSelf.idempotencyKey",message="immutable override identity and policy fields cannot change"
 // +kubebuilder:validation:XValidation:rule="has(self.scope) == has(oldSelf.scope) && (!has(self.scope) || self.scope == oldSelf.scope)",message="override scope is immutable"
 // +kubebuilder:validation:XValidation:rule="has(self.capacity) == has(oldSelf.capacity) && (!has(self.capacity) || self.capacity == oldSelf.capacity)",message="override capacity is immutable"
 // +kubebuilder:validation:XValidation:rule="has(self.incidentURL) == has(oldSelf.incidentURL) && (!has(self.incidentURL) || self.incidentURL == oldSelf.incidentURL)",message="incident URL is immutable"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.approvals) || (has(self.approvals) && oldSelf.approvals.all(a, self.approvals.exists(b, b.userID == a.userID && b.at == a.at)))",message="approvals may only be appended"
-// +kubebuilder:validation:XValidation:rule="!has(oldSelf.fallbackConfirmed) || !oldSelf.fallbackConfirmed || (has(self.fallbackConfirmed) && self.fallbackConfirmed)",message="fallback confirmation cannot be withdrawn"
 // +kubebuilder:validation:XValidation:rule="has(self.revokedAt) == has(self.revokedBy) && (!has(self.revokedBy) || size(self.revokedBy) > 0)",message="revokedAt and a non-empty revokedBy must be set together"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.revokedAt) || (has(self.revokedAt) && self.revokedAt == oldSelf.revokedAt && has(oldSelf.revokedBy) && has(self.revokedBy) && self.revokedBy == oldSelf.revokedBy)",message="revocation cannot be removed or changed"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.slackThreadTS) || (has(self.slackThreadTS) && self.slackThreadTS == oldSelf.slackThreadTS)",message="Slack thread binding cannot be changed"
-// +kubebuilder:validation:XValidation:rule="self.kind != 'Drain' || self.requiredApprovals == 2",message="drain overrides require two approvals"
-// +kubebuilder:validation:XValidation:rule="self.kind != 'Drain' || self.fallbackProtected || (has(self.fallbackConfirmed) && self.fallbackConfirmed)",message="an unprotected drain requires explicit fallback confirmation"
 type DispatchOverrideSpec struct {
 	// +kubebuilder:validation:MinLength=1
 	ID string `json:"id"`
@@ -93,8 +90,6 @@ type DispatchOverrideSpec struct {
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=2
 	RequiredApprovals int32        `json:"requiredApprovals"`
-	FallbackProtected bool         `json:"fallbackProtected"`
-	FallbackConfirmed bool         `json:"fallbackConfirmed,omitempty"`
 	RevokedAt         *metav1.Time `json:"revokedAt,omitempty"`
 	RevokedBy         string       `json:"revokedBy,omitempty"`
 	SlackThreadTS     string       `json:"slackThreadTS,omitempty"`
@@ -108,7 +103,6 @@ type DispatchOverrideStatus struct {
 	ObservedGeneration int64         `json:"observedGeneration,omitempty"`
 	PolicyGeneration   uint64        `json:"policyGeneration,omitempty"`
 	SnapshotChecksum   string        `json:"snapshotChecksum,omitempty"`
-	FallbackProtected  bool          `json:"fallbackProtected,omitempty"`
 	Message            string        `json:"message,omitempty"`
 	// +listType=map
 	// +listMapKey=type

--- a/pkg/dispatcher/control.go
+++ b/pkg/dispatcher/control.go
@@ -40,7 +40,6 @@ type ControlOptions struct {
 	MaxTTL                    time.Duration
 	MaxDrainTTL               time.Duration
 	PlanTTL                   time.Duration
-	AffectedDemandApproval    float64
 	EnableCapacity            bool
 	EnableDrain               bool
 	EnableCapabilityScope     bool
@@ -76,9 +75,6 @@ func (o *ControlOptions) Validate() error {
 	if o.MaxDrainTTL > o.MaxTTL {
 		return errors.New("maximum drain TTL cannot exceed maximum override TTL")
 	}
-	if o.AffectedDemandApproval < 0 {
-		return errors.New("affected-demand approval threshold cannot be negative")
-	}
 	if o.EnableDrain && !o.EnableCapacity {
 		return errors.New("drain operations require capacity operations to be enabled")
 	}
@@ -87,9 +83,6 @@ func (o *ControlOptions) Validate() error {
 	}
 	if o.EnableCapacity && (o.SchedulerPropagationBound <= 0 || o.SchedulerPropagationBound > maxSchedulerPropagationBound) {
 		return fmt.Errorf("write operations require a measured scheduler propagation bound no greater than %s", maxSchedulerPropagationBound)
-	}
-	if o.EnableCapacity && o.AffectedDemandApproval <= 0 {
-		return errors.New("write operations require a positive affected-demand threshold for second approval")
 	}
 	if o.EnableCapacity && o.WriteSafetyCheck == nil {
 		return errors.New("write operations require verification of the Prow scheduler cache bound")
@@ -104,17 +97,16 @@ func (o *ControlOptions) Validate() error {
 
 // PlanRequest is a read-only request to preview a temporary override.
 type PlanRequest struct {
-	Kind              dispatcherv1.OverrideKind `json:"kind"`
-	Cluster           string                    `json:"cluster"`
-	Capability        string                    `json:"capability,omitempty"`
-	Capacity          *int32                    `json:"capacity,omitempty"`
-	DurationSeconds   int64                     `json:"durationSeconds"`
-	Reason            string                    `json:"reason"`
-	IncidentURL       string                    `json:"incidentURL,omitempty"`
-	UserID            string                    `json:"userID"`
-	ChannelID         string                    `json:"channelID"`
-	IdempotencyKey    string                    `json:"idempotencyKey"`
-	FallbackConfirmed bool                      `json:"fallbackConfirmed,omitempty"`
+	Kind            dispatcherv1.OverrideKind `json:"kind"`
+	Cluster         string                    `json:"cluster"`
+	Capability      string                    `json:"capability,omitempty"`
+	Capacity        *int32                    `json:"capacity,omitempty"`
+	DurationSeconds int64                     `json:"durationSeconds"`
+	Reason          string                    `json:"reason"`
+	IncidentURL     string                    `json:"incidentURL,omitempty"`
+	UserID          string                    `json:"userID"`
+	ChannelID       string                    `json:"channelID"`
+	IdempotencyKey  string                    `json:"idempotencyKey"`
 }
 
 // DispatchPlan is an immutable impact preview tied to one policy generation.
@@ -127,7 +119,6 @@ type DispatchPlan struct {
 	Request                    PlanRequest    `json:"request"`
 	Impact                     CompileSummary `json:"impact"`
 	RequiredApprovals          int32          `json:"requiredApprovals"`
-	FallbackProtected          bool           `json:"fallbackProtected"`
 	PropagationBound           time.Duration  `json:"propagationBound"`
 	CurrentEffectiveCapacity   int            `json:"currentEffectiveCapacity"`
 	RequestedEffectiveCapacity int            `json:"requestedEffectiveCapacity"`
@@ -135,11 +126,10 @@ type DispatchPlan struct {
 
 // ApplyRequest applies or approves a plan.
 type ApplyRequest struct {
-	UserID            string `json:"userID"`
-	ChannelID         string `json:"channelID"`
-	IdempotencyKey    string `json:"idempotencyKey"`
-	FallbackConfirmed bool   `json:"fallbackConfirmed,omitempty"`
-	SlackThreadTS     string `json:"slackThreadTS,omitempty"`
+	UserID         string `json:"userID"`
+	ChannelID      string `json:"channelID"`
+	IdempotencyKey string `json:"idempotencyKey"`
+	SlackThreadTS  string `json:"slackThreadTS,omitempty"`
 }
 
 // CancelRequest revokes an override idempotently.
@@ -167,18 +157,7 @@ type ControlStatus struct {
 	ClusterInfo       *ClusterInfo                    `json:"clusterInfo,omitempty"`
 	EffectiveCapacity *int                            `json:"effectiveCapacity,omitempty"`
 	Overrides         []dispatcherv1.DispatchOverride `json:"overrides,omitempty"`
-	FallbackProtected bool                            `json:"fallbackProtected"`
 }
-
-// FallbackProtectionObservation reports a short-lived external verification of
-// the fallback assignments currently loaded by Prow.
-type FallbackProtectionObservation struct {
-	FallbackDigest    string    `json:"fallbackDigest"`
-	ProtectedClusters []string  `json:"protectedClusters"`
-	ValidUntil        time.Time `json:"validUntil"`
-}
-
-const maxFallbackObservationTTL = 5 * time.Minute
 
 // ControlPlane compiles durable overrides into serving snapshots and implements plan/apply/cancel.
 type ControlPlane struct {
@@ -192,13 +171,8 @@ type ControlPlane struct {
 	baseline    map[string]ProwJobData
 	inventory   ClusterMap
 	blocked     sets.Set[string]
-	// fallbackProtected is populated only from an external observation that Prow
-	// loaded the matching Git fallback generation. Desired inventory is not proof.
-	fallbackProtected        sets.Set[string]
-	fallbackDigest           string
-	fallbackProtectionExpiry time.Time
-	plans                    map[string]DispatchPlan
-	wake                     chan struct{}
+	plans       map[string]DispatchPlan
+	wake        chan struct{}
 }
 
 // NewControlPlane creates a single-replica control plane.
@@ -209,7 +183,7 @@ func NewControlPlane(manager *SnapshotManager, store OverrideStore, options Cont
 	if err := options.Validate(); err != nil {
 		return nil, err
 	}
-	return &ControlPlane{manager: manager, store: store, options: options, now: time.Now, fallbackProtected: sets.New[string](), plans: make(map[string]DispatchPlan), wake: make(chan struct{}, 1)}, nil
+	return &ControlPlane{manager: manager, store: store, options: options, now: time.Now, plans: make(map[string]DispatchPlan), wake: make(chan struct{}, 1)}, nil
 }
 
 // UpdateBaseline installs the latest durable Git baseline inputs and triggers compilation.
@@ -218,55 +192,8 @@ func (c *ControlPlane) UpdateBaseline(baseline map[string]ProwJobData, inventory
 	c.baseline = copyBaseline(baseline)
 	c.inventory = copyInventory(inventory)
 	c.blocked = blocked.Clone()
-	if digest, err := fallbackDigestForBaseline(baseline); err != nil || digest != c.fallbackDigest {
-		c.fallbackProtected = sets.New[string]()
-		c.fallbackDigest = ""
-		c.fallbackProtectionExpiry = time.Time{}
-	}
 	c.mu.Unlock()
 	c.trigger()
-}
-
-// ObserveFallbackProtection installs a digest-bound, short-lived observation
-// from a trusted external process that inspects Prow's loaded fallback state.
-func (c *ControlPlane) ObserveFallbackProtection(observation FallbackProtectionObservation) error {
-	now := c.now().UTC()
-	if !observation.ValidUntil.After(now) || observation.ValidUntil.After(now.Add(maxFallbackObservationTTL)) {
-		return fmt.Errorf("fallback observation validUntil must be after now and at most %s in the future", maxFallbackObservationTTL)
-	}
-	snapshot := c.manager.Current()
-	if snapshot == nil || !c.manager.Ready() {
-		return errors.New("dispatcher has no ready policy generation")
-	}
-	expectedDigest, err := fallbackDigestForBaseline(snapshot.Baseline)
-	if err != nil {
-		return fmt.Errorf("calculate current fallback digest: %w", err)
-	}
-	if observation.FallbackDigest == "" || observation.FallbackDigest != expectedDigest {
-		return errors.New("fallback observation does not match the current baseline")
-	}
-	protected := sets.New[string]()
-	for _, cluster := range observation.ProtectedClusters {
-		if strings.TrimSpace(cluster) == "" {
-			return errors.New("fallback protected cluster names must not be empty")
-		}
-		if protected.Has(cluster) {
-			return fmt.Errorf("fallback protected cluster %q is duplicated", cluster)
-		}
-		for jobName, assignment := range snapshot.Baseline {
-			if assignment.Cluster == cluster {
-				return fmt.Errorf("fallback cluster %q is still targeted by job %q", cluster, jobName)
-			}
-		}
-		protected.Insert(cluster)
-	}
-	c.mu.Lock()
-	c.fallbackProtected = protected
-	c.fallbackDigest = observation.FallbackDigest
-	c.fallbackProtectionExpiry = observation.ValidUntil.UTC()
-	c.mu.Unlock()
-	c.trigger()
-	return nil
 }
 
 func (c *ControlPlane) trigger() {
@@ -280,40 +207,6 @@ func (c *ControlPlane) inputs() (map[string]ProwJobData, ClusterMap, sets.Set[st
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return copyBaseline(c.baseline), copyInventory(c.inventory), c.blocked.Clone()
-}
-
-func (c *ControlPlane) verifiedFallbackProtection() sets.Set[string] {
-	c.mu.Lock()
-	protected := c.fallbackProtected.Clone()
-	digest := c.fallbackDigest
-	expires := c.fallbackProtectionExpiry
-	c.mu.Unlock()
-	if digest == "" || !expires.After(c.now().UTC()) {
-		return sets.New[string]()
-	}
-	snapshot := c.manager.Current()
-	if snapshot == nil || !c.manager.Ready() {
-		return sets.New[string]()
-	}
-	currentDigest, err := fallbackDigestForBaseline(snapshot.Baseline)
-	if err != nil || currentDigest != digest {
-		return sets.New[string]()
-	}
-	return protected
-}
-
-// FallbackAssignmentDigest returns the stable digest of the job-to-cluster
-// assignments observed in Prow's loaded fallback configuration.
-func FallbackAssignmentDigest(assignments map[string]string) (string, error) {
-	return digestJSON(assignments)
-}
-
-func fallbackDigestForBaseline(baseline map[string]ProwJobData) (string, error) {
-	assignments := make(map[string]string, len(baseline))
-	for jobName, assignment := range baseline {
-		assignments[jobName] = assignment.Cluster
-	}
-	return FallbackAssignmentDigest(assignments)
 }
 
 // Run reconciles baseline and override changes until ctx is cancelled.
@@ -372,10 +265,9 @@ func appendAudit(status *dispatcherv1.DispatchOverrideStatus, event dispatcherv1
 	}
 }
 
-func (c *ControlPlane) updateStatus(ctx context.Context, override *dispatcherv1.DispatchOverride, state dispatcherv1.OverrideState, snapshot *PolicySnapshot, fallbackProtected bool, message string) error {
+func (c *ControlPlane) updateStatus(ctx context.Context, override *dispatcherv1.DispatchOverride, state dispatcherv1.OverrideState, snapshot *PolicySnapshot, message string) error {
 	if override.Status.State == state && override.Status.ObservedGeneration == override.Generation &&
 		override.Status.Message == message &&
-		override.Status.FallbackProtected == fallbackProtected &&
 		(snapshot == nil || override.Status.PolicyGeneration == snapshot.Generation && override.Status.SnapshotChecksum == snapshot.Checksum) {
 		return nil
 	}
@@ -383,7 +275,6 @@ func (c *ControlPlane) updateStatus(ctx context.Context, override *dispatcherv1.
 	override.Status.State = state
 	override.Status.ObservedGeneration = override.Generation
 	override.Status.Message = message
-	override.Status.FallbackProtected = fallbackProtected
 	if snapshot != nil {
 		override.Status.PolicyGeneration = snapshot.Generation
 		override.Status.SnapshotChecksum = snapshot.Checksum
@@ -432,7 +323,6 @@ func (c *ControlPlane) Reconcile(ctx context.Context) error {
 		return err
 	}
 	now := c.now().UTC()
-	verifiedFallback := c.verifiedFallbackProtection()
 	current := c.manager.Current()
 	generation := uint64(1)
 	if current != nil {
@@ -461,8 +351,7 @@ func (c *ControlPlane) Reconcile(ctx context.Context) error {
 			state = dispatcherv1.OverrideStateFailed
 			message = invalidErr.Error()
 		}
-		fallbackProtected := verifiedFallback.Has(overrides[i].Spec.Cluster)
-		if err := c.updateStatus(ctx, &overrides[i], state, snapshot, fallbackProtected, message); err != nil {
+		if err := c.updateStatus(ctx, &overrides[i], state, snapshot, message); err != nil {
 			statusErrors = append(statusErrors, fmt.Errorf("update override %q status: %w", overrides[i].Name, err))
 		}
 	}
@@ -529,7 +418,7 @@ func (c *ControlPlane) validatePlanRequest(request PlanRequest) error {
 	return nil
 }
 
-func (c *ControlPlane) validateStoredOverride(override *dispatcherv1.DispatchOverride, fallbackProtected bool) error {
+func (c *ControlPlane) validateStoredOverride(override *dispatcherv1.DispatchOverride) error {
 	if override.Name == "" || override.Name != override.Spec.ID || !controlIDPattern.MatchString(override.Spec.ID) {
 		return errors.New("override resource name and spec ID must be the same valid identifier")
 	}
@@ -545,14 +434,10 @@ func (c *ControlPlane) validateStoredOverride(override *dispatcherv1.DispatchOve
 	if !override.Spec.ExpiresAt.Time.After(override.Spec.StartsAt.Time) || override.Spec.ExpiresAt.Sub(override.Spec.StartsAt.Time) > c.options.MaxTTL {
 		return errors.New("override has an invalid or excessive TTL")
 	}
-	if override.Spec.Kind == dispatcherv1.OverrideKindDrain {
-		if override.Spec.ExpiresAt.Sub(override.Spec.StartsAt.Time) > c.options.MaxDrainTTL || override.Spec.RequiredApprovals != 2 {
-			return errors.New("drain exceeds its TTL or does not require two approvals")
-		}
-		if !fallbackProtected && !override.Spec.FallbackProtected && !override.Spec.FallbackConfirmed {
-			return errors.New("unprotected drain lacks explicit fallback confirmation")
-		}
-	} else if override.Spec.RequiredApprovals < 1 || override.Spec.RequiredApprovals > 2 {
+	if override.Spec.Kind == dispatcherv1.OverrideKindDrain && override.Spec.ExpiresAt.Sub(override.Spec.StartsAt.Time) > c.options.MaxDrainTTL {
+		return errors.New("drain exceeds its TTL")
+	}
+	if override.Spec.RequiredApprovals < 1 || override.Spec.RequiredApprovals > 2 {
 		return errors.New("override required approvals must be one or two")
 	}
 	return nil
@@ -561,11 +446,10 @@ func (c *ControlPlane) validateStoredOverride(override *dispatcherv1.DispatchOve
 func (c *ControlPlane) compileableOverrides(overrides []dispatcherv1.DispatchOverride, baseline map[string]ProwJobData, inventory ClusterMap, blocked sets.Set[string], generation uint64, now time.Time) ([]dispatcherv1.DispatchOverride, map[string]error) {
 	result := make([]dispatcherv1.DispatchOverride, 0, len(overrides))
 	invalid := make(map[string]error)
-	verifiedFallback := c.verifiedFallbackProtection()
 	for i := range overrides {
 		live := overrides[i].Spec.RevokedAt == nil && now.Before(overrides[i].Spec.ExpiresAt.Time)
 		if live {
-			if err := c.validateStoredOverride(&overrides[i], verifiedFallback.Has(overrides[i].Spec.Cluster)); err != nil {
+			if err := c.validateStoredOverride(&overrides[i]); err != nil {
 				invalid[overrides[i].Name] = err
 				continue
 			}
@@ -618,7 +502,7 @@ func (c *ControlPlane) Plan(ctx context.Context, request PlanRequest) (DispatchP
 		StartsAt: metav1.NewTime(now), ExpiresAt: metav1.NewTime(now.Add(time.Duration(request.DurationSeconds) * time.Second)),
 		CreatedBy: request.UserID, SourceChannelID: request.ChannelID, Reason: request.Reason, IncidentURL: request.IncidentURL,
 		Approvals: []dispatcherv1.DispatchApproval{{UserID: request.UserID, At: metav1.NewTime(now)}}, RequiredApprovals: 1,
-		FallbackConfirmed: request.FallbackConfirmed, IdempotencyKey: request.IdempotencyKey,
+		IdempotencyKey: request.IdempotencyKey,
 	})
 	preview.Name = planID
 	overrides = append(overrides, preview)
@@ -639,15 +523,10 @@ func (c *ControlPlane) Plan(ctx context.Context, request PlanRequest) (DispatchP
 	if impact.MovedJobs == 0 {
 		return DispatchPlan{}, errors.New("override would not change any assignment")
 	}
-	requiredApprovals := int32(1)
-	if request.Kind == dispatcherv1.OverrideKindDrain || c.options.AffectedDemandApproval > 0 && impact.AffectedDemand >= c.options.AffectedDemandApproval {
-		requiredApprovals = 2
-	}
-	fallbackProtected := c.verifiedFallbackProtection().Has(request.Cluster)
 	plan := DispatchPlan{
 		ID: planID, CreatedAt: now, ExpiresAt: now.Add(c.options.PlanTTL), SourceGeneration: snapshot.Generation,
-		PolicyInputDigest: snapshot.InputDigest, Request: request, Impact: impact, RequiredApprovals: requiredApprovals,
-		FallbackProtected: fallbackProtected, PropagationBound: c.options.SchedulerPropagationBound,
+		PolicyInputDigest: snapshot.InputDigest, Request: request, Impact: impact, RequiredApprovals: 1,
+		PropagationBound:         c.options.SchedulerPropagationBound,
 		CurrentEffectiveCapacity: snapshot.Inventory[request.Cluster].Capacity,
 	}
 	if request.Kind == dispatcherv1.OverrideKindDrain {
@@ -747,13 +626,6 @@ func (c *ControlPlane) Apply(ctx context.Context, planID string, request ApplyRe
 	if err := c.verifyWriteSafety(); err != nil {
 		return nil, err
 	}
-	fallbackProtected := false
-	if plan.Request.Kind == dispatcherv1.OverrideKindDrain {
-		fallbackProtected = c.verifiedFallbackProtection().Has(plan.Request.Cluster)
-		if !fallbackProtected && !request.FallbackConfirmed {
-			return nil, errors.New("drain requires explicit confirmation that the Git fallback is not protected")
-		}
-	}
 	overrideID, err := stableID("override", struct {
 		Plan string `json:"plan"`
 	}{plan.ID})
@@ -770,18 +642,23 @@ func (c *ControlPlane) Apply(ctx context.Context, planID string, request ApplyRe
 		return apierrors.IsAlreadyExists(err) || apierrors.IsConflict(err)
 	}, func() error {
 		stored, err := c.store.Get(ctx, overrideID)
-		if apierrors.IsNotFound(err) {
-			if !planIsCurrent() {
+		if apierrors.IsNotFound(err) && !planIsCurrent() {
+			// A concurrent apply can create this override and publish a new
+			// generation before this Get is processed. Re-read so an already
+			// applied override is treated as a no-op instead of a stale plan.
+			stored, err = c.store.Get(ctx, overrideID)
+			if apierrors.IsNotFound(err) {
 				return errors.New("plan is stale; create a new plan")
 			}
+		}
+		if apierrors.IsNotFound(err) {
 			overrideValue := NewOverride(dispatcherv1.DispatchOverrideSpec{
 				ID: overrideID, PlanID: plan.ID, SourceGeneration: plan.SourceGeneration, PolicyInputDigest: plan.PolicyInputDigest,
 				Kind: plan.Request.Kind, Cluster: plan.Request.Cluster, Scope: dispatcherv1.DispatchOverrideScope{Capability: plan.Request.Capability}, Capacity: plan.Request.Capacity,
 				StartsAt: metav1.NewTime(now), ExpiresAt: metav1.NewTime(now.Add(time.Duration(plan.Request.DurationSeconds) * time.Second)),
 				CreatedBy: plan.Request.UserID, SourceChannelID: plan.Request.ChannelID, Reason: plan.Request.Reason, IncidentURL: plan.Request.IncidentURL,
 				Approvals: []dispatcherv1.DispatchApproval{{UserID: request.UserID, At: metav1.NewTime(now)}}, RequiredApprovals: plan.RequiredApprovals,
-				FallbackProtected: fallbackProtected, FallbackConfirmed: request.FallbackConfirmed, SlackThreadTS: request.SlackThreadTS,
-				IdempotencyKey: request.IdempotencyKey,
+				SlackThreadTS: request.SlackThreadTS, IdempotencyKey: request.IdempotencyKey,
 			})
 			override = &overrideValue
 			return c.store.Create(ctx, override)
@@ -798,16 +675,13 @@ func (c *ControlPlane) Apply(ctx context.Context, planID string, request ApplyRe
 				return nil
 			}
 		}
+		if uniqueApprovals(override) >= int(override.Spec.RequiredApprovals) {
+			return nil
+		}
 		if !planIsCurrent() {
 			return errors.New("plan is stale; create a new plan")
 		}
 		override.Spec.Approvals = append(override.Spec.Approvals, dispatcherv1.DispatchApproval{UserID: request.UserID, At: metav1.NewTime(now)})
-		if request.FallbackConfirmed {
-			override.Spec.FallbackConfirmed = true
-		}
-		if fallbackProtected {
-			override.Spec.FallbackProtected = true
-		}
 		return c.store.Update(ctx, override)
 	})
 	if err != nil {
@@ -911,7 +785,6 @@ func (c *ControlPlane) Status(ctx context.Context, cluster string) (ControlStatu
 		status.ClusterInfo = &info
 		effectiveCapacity := info.Capacity
 		status.EffectiveCapacity = &effectiveCapacity
-		status.FallbackProtected = c.verifiedFallbackProtection().Has(cluster)
 	}
 	overrides, err := c.store.List(ctx)
 	if err != nil {
@@ -1078,41 +951,6 @@ func (s *ControlServer) ServeHTTP(writer http.ResponseWriter, request *http.Requ
 	default:
 		writeControlError(writer, http.StatusNotFound, errors.New("not found"))
 	}
-}
-
-// FallbackObservationServer accepts narrowly authenticated observations from
-// the process that inspects the fallback assignments loaded by Prow.
-type FallbackObservationServer struct {
-	control *ControlPlane
-	token   func() []byte
-}
-
-// NewFallbackObservationServer creates the fallback observation API handler.
-func NewFallbackObservationServer(control *ControlPlane, token func() []byte) *FallbackObservationServer {
-	return &FallbackObservationServer{control: control, token: token}
-}
-
-// ServeHTTP validates and installs one leased fallback-protection observation.
-func (s *FallbackObservationServer) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
-	if !bearerTokenAuthorized(request, s.token) {
-		writeControlError(writer, http.StatusUnauthorized, errors.New("unauthorized"))
-		return
-	}
-	if request.Method != http.MethodPost || request.URL.Path != "/fallback-observer/v1/protection" {
-		writeControlError(writer, http.StatusNotFound, errors.New("not found"))
-		return
-	}
-	request.Body = http.MaxBytesReader(writer, request.Body, 64<<10)
-	var observation FallbackProtectionObservation
-	if err := json.NewDecoder(request.Body).Decode(&observation); err != nil {
-		writeControlError(writer, http.StatusBadRequest, err)
-		return
-	}
-	if err := s.control.ObserveFallbackProtection(observation); err != nil {
-		writeControlError(writer, http.StatusConflict, err)
-		return
-	}
-	writeJSON(writer, http.StatusOK, map[string]string{"status": "observed"})
 }
 
 // ControlClient is used by the DPTP bot to call the dispatcher control API.

--- a/pkg/dispatcher/control_test.go
+++ b/pkg/dispatcher/control_test.go
@@ -13,8 +13,6 @@ import (
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	dispatcherv1 "github.com/openshift/ci-tools/pkg/api/dispatcher/v1"
 )
@@ -25,9 +23,6 @@ func testControlPlane(t *testing.T, options ControlOptions) (*ControlPlane, *Mem
 	options.AllowedChannelID = "C-team"
 	if options.EnableCapacity && options.SchedulerPropagationBound == 0 {
 		options.SchedulerPropagationBound = 30 * time.Second
-	}
-	if options.EnableCapacity && options.AffectedDemandApproval == 0 {
-		options.AffectedDemandApproval = 1000
 	}
 	if options.EnableCapacity && options.WriteSafetyCheck == nil {
 		options.WriteSafetyCheck = func() error { return nil }
@@ -162,7 +157,6 @@ func TestControlOptionsSchedulerPropagationBound(t *testing.T) {
 				AllowedChannelID:          "C-team",
 				EnableCapacity:            true,
 				SchedulerPropagationBound: tc.bound,
-				AffectedDemandApproval:    1,
 				WriteSafetyCheck:          func() error { return nil },
 			}
 			err := options.Validate()
@@ -226,18 +220,18 @@ func TestControlPlaneRejectsStalePlan(t *testing.T) {
 	}
 }
 
-func TestControlPlaneRejectsStaleSecondApproval(t *testing.T) {
-	control, store, _, _ := testControlPlane(t, ControlOptions{EnableCapacity: true, AffectedDemandApproval: 15})
+func TestControlPlaneAdditionalApplyOnActiveOverrideIsIdempotent(t *testing.T) {
+	control, store, _, _ := testControlPlane(t, ControlOptions{EnableCapacity: true})
 	plan, err := control.Plan(context.Background(), capacityPlanRequest())
 	if err != nil {
 		t.Fatal(err)
 	}
-	pending, err := control.Apply(context.Background(), plan.ID, ApplyRequest{UserID: "U1", ChannelID: "C-team", IdempotencyKey: "apply-1"})
+	active, err := control.Apply(context.Background(), plan.ID, ApplyRequest{UserID: "U1", ChannelID: "C-team", IdempotencyKey: "apply-1"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if pending.Status.State != dispatcherv1.OverrideStatePending || len(pending.Spec.Approvals) != 1 {
-		t.Fatalf("first approval was not pending: %#v", pending)
+	if active.Status.State != dispatcherv1.OverrideStateActive || len(active.Spec.Approvals) != 1 {
+		t.Fatalf("single approval did not activate: %#v", active)
 	}
 
 	control.UpdateBaseline(map[string]ProwJobData{
@@ -251,15 +245,19 @@ func TestControlPlaneRejectsStaleSecondApproval(t *testing.T) {
 	if err := control.Reconcile(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := control.Apply(context.Background(), plan.ID, ApplyRequest{UserID: "U2", ChannelID: "C-team", IdempotencyKey: "apply-2"}); err == nil || !strings.Contains(err.Error(), "stale") {
-		t.Fatalf("stale second approval was accepted: %v", err)
-	}
-	stored, err := store.Get(context.Background(), pending.Name)
+	repeated, err := control.Apply(context.Background(), plan.ID, ApplyRequest{UserID: "U2", ChannelID: "C-team", IdempotencyKey: "apply-2"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(stored.Spec.Approvals) != 1 || stored.Status.State != dispatcherv1.OverrideStatePending {
-		t.Fatalf("stale approval changed the pending override: %#v", stored)
+	if len(repeated.Spec.Approvals) != 1 || repeated.Status.State != dispatcherv1.OverrideStateActive {
+		t.Fatalf("additional apply changed an already active override: %#v", repeated)
+	}
+	stored, err := store.Get(context.Background(), active.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stored.Spec.Approvals) != 1 || stored.Status.State != dispatcherv1.OverrideStateActive {
+		t.Fatalf("additional apply persisted a new approval: %#v", stored)
 	}
 }
 
@@ -285,56 +283,6 @@ func TestControlPlaneQuarantinesInvalidStoredOverride(t *testing.T) {
 	decision, found := manager.Lookup("job-a", now)
 	if !found || decision.Cluster != "build01" || decision.OverrideID != "" {
 		t.Fatalf("invalid override affected serving policy: %#v", decision)
-	}
-}
-
-func TestControlPlaneRequiresExplicitVerifiedFallbackProtection(t *testing.T) {
-	control, store, manager, now := testControlPlane(t, ControlOptions{EnableCapacity: true, EnableDrain: true})
-	override := activeOverride("drain", dispatcherv1.OverrideKindDrain, "build01", nil, "", now)
-	override.Name = override.Spec.ID
-	override.Spec.SourceChannelID = "C-team"
-	override.Spec.RequiredApprovals = 2
-	override.Spec.Approvals = append(override.Spec.Approvals, dispatcherv1.DispatchApproval{UserID: "U2", At: metav1.NewTime(now)})
-	override.Spec.FallbackConfirmed = true
-	if err := store.Create(context.Background(), &override); err != nil {
-		t.Fatal(err)
-	}
-	if err := control.Reconcile(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-	control.UpdateBaseline(map[string]ProwJobData{"job": {Cluster: "build02", Demand: 1}}, ClusterMap{"build02": {Provider: "aws", Capacity: 100}}, sets.New[string]("build01"))
-	if err := control.Reconcile(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-	stored, err := store.Get(context.Background(), override.Name)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if stored.Status.FallbackProtected || stored.Status.State != dispatcherv1.OverrideStateActive {
-		t.Fatalf("desired blocked inventory was incorrectly treated as verified fallback protection: %#v", stored.Status)
-	}
-	digest, err := fallbackDigestForBaseline(manager.Current().Baseline)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := control.ObserveFallbackProtection(FallbackProtectionObservation{
-		FallbackDigest: digest, ProtectedClusters: []string{"build01"}, ValidUntil: now.Add(time.Minute),
-	}); err != nil {
-		t.Fatal(err)
-	}
-	if err := control.Reconcile(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-	stored, err = store.Get(context.Background(), override.Name)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !stored.Status.FallbackProtected {
-		t.Fatalf("explicit verified fallback protection was not observed: %#v", stored.Status)
-	}
-	control.now = func() time.Time { return now.Add(2 * time.Minute) }
-	if control.verifiedFallbackProtection().Has("build01") {
-		t.Fatal("expired fallback observation remained protected")
 	}
 }
 
@@ -468,19 +416,19 @@ func TestParsePositiveDurationRejectsSubSecondValues(t *testing.T) {
 	}
 }
 
-func TestControlPlaneLargeCapacityChangeRequiresSecondApproval(t *testing.T) {
-	control, _, _, _ := testControlPlane(t, ControlOptions{EnableCapacity: true, AffectedDemandApproval: 15})
+func TestControlPlanePlansRequireOneApproval(t *testing.T) {
+	control, _, _, _ := testControlPlane(t, ControlOptions{EnableCapacity: true})
 	plan, err := control.Plan(context.Background(), capacityPlanRequest())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if plan.RequiredApprovals != 2 || plan.Impact.AffectedDemand != 20 {
-		t.Fatalf("large capacity change did not require two approvals: %#v", plan)
+	if plan.RequiredApprovals != 1 || plan.Impact.AffectedDemand != 20 {
+		t.Fatalf("capacity plan did not require a single approval: %#v", plan)
 	}
 }
 
 func TestControlPlaneMergesConcurrentInitialApprovals(t *testing.T) {
-	control, baseStore, _, _ := testControlPlane(t, ControlOptions{EnableCapacity: true, AffectedDemandApproval: 15})
+	control, baseStore, _, _ := testControlPlane(t, ControlOptions{EnableCapacity: true})
 	store := &concurrentCreateStore{MemoryOverrideStore: baseStore, release: make(chan struct{})}
 	control.store = store
 	plan, err := control.Plan(context.Background(), capacityPlanRequest())
@@ -508,12 +456,12 @@ func TestControlPlaneMergesConcurrentInitialApprovals(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(overrides) != 1 || uniqueApprovals(&overrides[0]) != 2 || overrides[0].Status.State != dispatcherv1.OverrideStateActive {
-		t.Fatalf("concurrent approvals were not merged: %#v", overrides)
+	if len(overrides) != 1 || uniqueApprovals(&overrides[0]) < 1 || overrides[0].Status.State != dispatcherv1.OverrideStateActive {
+		t.Fatalf("concurrent applies did not converge on one active override: %#v", overrides)
 	}
 }
 
-func TestControlPlaneDrainRequiresDistinctSecondApprovalAndFallbackConfirmation(t *testing.T) {
+func TestControlPlaneDrainActivatesOnSingleApproval(t *testing.T) {
 	control, _, _, _ := testControlPlane(t, ControlOptions{EnableCapacity: true, EnableDrain: true})
 	request := PlanRequest{
 		Kind: dispatcherv1.OverrideKindDrain, Cluster: "build01", DurationSeconds: 3600,
@@ -523,29 +471,19 @@ func TestControlPlaneDrainRequiresDistinctSecondApprovalAndFallbackConfirmation(
 	if err != nil {
 		t.Fatal(err)
 	}
-	if plan.RequiredApprovals != 2 || plan.FallbackProtected {
+	if plan.RequiredApprovals != 1 {
 		t.Fatalf("unexpected drain safety policy: %#v", plan)
 	}
-	if _, err := control.Apply(context.Background(), plan.ID, ApplyRequest{UserID: "U1", ChannelID: "C-team", IdempotencyKey: "apply-1"}); err == nil || !strings.Contains(err.Error(), "confirmation") {
-		t.Fatalf("unconfirmed drain was accepted: %v", err)
-	}
-	pending, err := control.Apply(context.Background(), plan.ID, ApplyRequest{UserID: "U1", ChannelID: "C-team", IdempotencyKey: "apply-1", FallbackConfirmed: true})
+	active, err := control.Apply(context.Background(), plan.ID, ApplyRequest{UserID: "U1", ChannelID: "C-team", IdempotencyKey: "apply-1"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if pending.Status.State != dispatcherv1.OverrideStatePending || len(pending.Spec.Approvals) != 1 {
-		t.Fatalf("first drain approval was not pending: %#v", pending)
+	if active.Status.State != dispatcherv1.OverrideStateActive || len(active.Spec.Approvals) != 1 {
+		t.Fatalf("single drain approval did not activate: %#v", active)
 	}
-	repeated, err := control.Apply(context.Background(), plan.ID, ApplyRequest{UserID: "U1", ChannelID: "C-team", IdempotencyKey: "apply-retry", FallbackConfirmed: true})
+	repeated, err := control.Apply(context.Background(), plan.ID, ApplyRequest{UserID: "U1", ChannelID: "C-team", IdempotencyKey: "apply-retry"})
 	if err != nil || len(repeated.Spec.Approvals) != 1 {
 		t.Fatalf("same user counted twice: %#v, %v", repeated, err)
-	}
-	active, err := control.Apply(context.Background(), plan.ID, ApplyRequest{UserID: "U2", ChannelID: "C-team", IdempotencyKey: "apply-2", FallbackConfirmed: true})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if active.Status.State != dispatcherv1.OverrideStateActive || len(active.Spec.Approvals) != 2 {
-		t.Fatalf("second approval did not activate drain: %#v", active)
 	}
 }
 
@@ -681,41 +619,5 @@ func TestControlPlaneExplainHitAndMiss(t *testing.T) {
 	server.ServeHTTP(unreadyResponse, unready)
 	if unreadyResponse.Code != http.StatusBadRequest || !strings.Contains(unreadyResponse.Body.String(), "ready") {
 		t.Fatalf("unready explain HTTP: %d %s", unreadyResponse.Code, unreadyResponse.Body.String())
-	}
-}
-
-func TestFallbackObservationServerAuthenticationAndDigestBinding(t *testing.T) {
-	control, _, manager, now := testControlPlane(t, ControlOptions{})
-	server := NewFallbackObservationServer(control, func() []byte { return []byte("observer-secret") })
-	digest, err := fallbackDigestForBaseline(manager.Current().Baseline)
-	if err != nil {
-		t.Fatal(err)
-	}
-	body, err := json.Marshal(FallbackProtectionObservation{FallbackDigest: digest, ValidUntil: now.Add(time.Minute)})
-	if err != nil {
-		t.Fatal(err)
-	}
-	unauthorized := httptest.NewRecorder()
-	server.ServeHTTP(unauthorized, httptest.NewRequest(http.MethodPost, "/fallback-observer/v1/protection", bytes.NewReader(body)))
-	if unauthorized.Code != http.StatusUnauthorized {
-		t.Fatalf("expected unauthorized, got %d", unauthorized.Code)
-	}
-	staleBody, err := json.Marshal(FallbackProtectionObservation{FallbackDigest: "stale", ValidUntil: now.Add(time.Minute)})
-	if err != nil {
-		t.Fatal(err)
-	}
-	staleRequest := httptest.NewRequest(http.MethodPost, "/fallback-observer/v1/protection", bytes.NewReader(staleBody))
-	staleRequest.Header.Set("Authorization", "Bearer observer-secret")
-	stale := httptest.NewRecorder()
-	server.ServeHTTP(stale, staleRequest)
-	if stale.Code != http.StatusConflict {
-		t.Fatalf("expected stale digest conflict, got %d: %s", stale.Code, stale.Body.String())
-	}
-	request := httptest.NewRequest(http.MethodPost, "/fallback-observer/v1/protection", bytes.NewReader(body))
-	request.Header.Set("Authorization", "Bearer observer-secret")
-	response := httptest.NewRecorder()
-	server.ServeHTTP(response, request)
-	if response.Code != http.StatusOK {
-		t.Fatalf("expected observation to be accepted, got %d: %s", response.Code, response.Body.String())
 	}
 }

--- a/pkg/dispatcher/metrics.go
+++ b/pkg/dispatcher/metrics.go
@@ -25,10 +25,6 @@ var (
 		Name: "prowjob_dispatcher_overrides",
 		Help: "Durable runtime overrides by kind and lifecycle state.",
 	}, []string{"kind", "state"})
-	unprotectedDrainMetric = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "prowjob_dispatcher_active_unprotected_drains",
-		Help: "Active runtime drains whose Git fallback still targets the drained cluster.",
-	})
 	capabilityCoverageJobsMetric = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "prowjob_dispatcher_capability_coverage_jobs",
 		Help: "Number of baseline jobs classified under each scheduling capability; __unclassified__ has none.",
@@ -52,7 +48,7 @@ var (
 func init() {
 	prometheus.MustRegister(
 		policyGenerationMetric, policyReadyMetric, decisionMetric, overrideStateMetric,
-		unprotectedDrainMetric, capabilityCoverageJobsMetric, capabilityCoverageDemandMetric,
+		capabilityCoverageJobsMetric, capabilityCoverageDemandMetric,
 		compileDurationMetric, overrideActivationMetric,
 	)
 }
@@ -91,12 +87,7 @@ func observeSnapshot(snapshot *PolicySnapshot) {
 
 func observeOverrides(overrides []dispatcherv1.DispatchOverride) {
 	overrideStateMetric.Reset()
-	unprotectedDrains := 0.0
 	for i := range overrides {
 		overrideStateMetric.WithLabelValues(string(overrides[i].Spec.Kind), string(overrides[i].Status.State)).Inc()
-		if overrides[i].Spec.Kind == dispatcherv1.OverrideKindDrain && overrides[i].Status.State == dispatcherv1.OverrideStateActive && !overrides[i].Status.FallbackProtected {
-			unprotectedDrains++
-		}
 	}
-	unprotectedDrainMetric.Set(unprotectedDrains)
 }

--- a/pkg/slack/dispatcher/commands.go
+++ b/pkg/slack/dispatcher/commands.go
@@ -146,10 +146,6 @@ func parseOptions(tokens []string, positionalCount int, allowedOptions ...string
 		if _, exists := options[name]; exists {
 			return nil, nil, fmt.Errorf("option --%s was specified more than once", name)
 		}
-		if name == "confirm-fallback" {
-			options[name] = "true"
-			continue
-		}
 		if i+1 >= len(tokens) || strings.HasPrefix(tokens[i+1], "--") {
 			return nil, nil, fmt.Errorf("--%s requires a value", name)
 		}
@@ -182,13 +178,9 @@ func formatOverrides(overrides []dispatcherv1.DispatchOverride) string {
 		if overrides[i].Spec.Scope.Capability != "" {
 			scope += "/capability:" + overrides[i].Spec.Scope.Capability
 		}
-		fallbackProtected := overrides[i].Spec.FallbackProtected
-		if overrides[i].Status.State != "" {
-			fallbackProtected = overrides[i].Status.FallbackProtected
-		}
-		detail := fmt.Sprintf("reason %s; created by %s; approvals %d/%d; generation %d; fallback protected: *%t*",
+		detail := fmt.Sprintf("reason %s; created by %s; approvals %d/%d; generation %d",
 			overrides[i].Spec.Reason, overrides[i].Spec.CreatedBy, len(overrides[i].Spec.Approvals), overrides[i].Spec.RequiredApprovals,
-			overrides[i].Status.PolicyGeneration, fallbackProtected)
+			overrides[i].Status.PolicyGeneration)
 		if overrides[i].Spec.IncidentURL != "" {
 			detail += "; incident " + overrides[i].Spec.IncidentURL
 		}
@@ -205,7 +197,6 @@ func formatStatus(status coredispatcher.ControlStatus) string {
 			effective = *status.EffectiveCapacity
 		}
 		text += fmt.Sprintf("\n`%s`: provider %s, baseline/effective capacity %d/%d, capabilities %s.", status.Cluster, status.ClusterInfo.Provider, status.ClusterInfo.Capacity, effective, strings.Join(status.ClusterInfo.Capabilities, ", "))
-		text += fmt.Sprintf("\nFallback protected: *%t*.", status.FallbackProtected)
 	}
 	if len(status.Overrides) > 0 {
 		text += "\n" + formatOverrides(status.Overrides)
@@ -234,19 +225,12 @@ func formatPlan(plan coredispatcher.DispatchPlan) string {
 	if plan.PropagationBound > 0 {
 		propagation = plan.PropagationBound.String()
 	}
-	return fmt.Sprintf("Plan `%s`: %s %s for %s; effective capacity %d → %d.\nAffected: %d jobs in %d placement groups / %.1f demand; movable: %d / %.1f; immovable: %d.\nDestinations: %s.\nApprovals required: %d. Fallback protected: *%t*. Maximum propagation: %s.\nApply with `@dptp-bot tp-dispatch apply %s%s`.",
+	return fmt.Sprintf("Plan `%s`: %s %s for %s; effective capacity %d → %d.\nAffected: %d jobs in %d placement groups / %.1f demand; movable: %d / %.1f; immovable: %d.\nDestinations: %s.\nApprovals required: %d. Maximum propagation: %s.\nApply with `@dptp-bot tp-dispatch apply %s`.",
 		plan.ID, plan.Request.Kind, scope, coredispatcher.FormatDurationSeconds(plan.Request.DurationSeconds),
 		plan.CurrentEffectiveCapacity, plan.RequestedEffectiveCapacity,
 		plan.Impact.AffectedJobs, plan.Impact.AffectedGroups, plan.Impact.AffectedDemand, plan.Impact.MovableJobs, plan.Impact.MovableDemand, len(plan.Impact.ImmovableJobs),
-		strings.Join(destinations, ", "), plan.RequiredApprovals, plan.FallbackProtected, propagation,
-		plan.ID, fallbackSuffix(plan))
-}
-
-func fallbackSuffix(plan coredispatcher.DispatchPlan) string {
-	if plan.Request.Kind == dispatcherv1.OverrideKindDrain && !plan.FallbackProtected {
-		return " --confirm-fallback"
-	}
-	return ""
+		strings.Join(destinations, ", "), plan.RequiredApprovals, propagation,
+		plan.ID)
 }
 
 func formatHistory(override dispatcherv1.DispatchOverride) string {
@@ -300,11 +284,13 @@ func (h *Handler) DeniedResponse(command Command) Response {
 }
 
 func transitionKey(override *dispatcherv1.DispatchOverride) string {
-	return fmt.Sprintf("%s/%d", override.Status.State, override.Status.PolicyGeneration)
+	// Policy generation is stamped on every reconcile, including terminal overrides.
+	// Notify only when lifecycle state changes.
+	return string(override.Status.State)
 }
 
 func transitionText(override *dispatcherv1.DispatchOverride) string {
-	return fmt.Sprintf("Dispatcher override `%s` transitioned to *%s* at policy generation `%d`. Fallback protected: *%t*.", override.Spec.ID, override.Status.State, override.Status.PolicyGeneration, override.Status.FallbackProtected)
+	return fmt.Sprintf("Dispatcher override `%s` transitioned to *%s* at policy generation `%d`.", override.Spec.ID, override.Status.State, override.Status.PolicyGeneration)
 }
 
 func (h *Handler) markObserved(override *dispatcherv1.DispatchOverride) {
@@ -334,24 +320,9 @@ func (h *Handler) Run(ctx context.Context) {
 	defer ticker.Stop()
 	initialized := false
 	for {
-		overrides, err := h.client.Overrides(ctx)
-		if err != nil {
+		if err := h.pollTransitions(ctx, initialized); err != nil {
 			logrus.WithError(err).Warn("failed to list dispatcher overrides for Slack transition polling")
 		} else {
-			for i := range overrides {
-				if overrides[i].Spec.SourceChannelID != h.options.ChannelID || overrides[i].Spec.SlackThreadTS == "" {
-					continue
-				}
-				key := transitionKey(&overrides[i])
-				h.mu.Lock()
-				previous, seen := h.observed[overrides[i].Spec.ID]
-				h.mu.Unlock()
-				if !initialized {
-					h.markObserved(&overrides[i])
-				} else if !seen || previous != key {
-					h.postTransition(&overrides[i])
-				}
-			}
 			initialized = true
 		}
 		select {
@@ -360,6 +331,30 @@ func (h *Handler) Run(ctx context.Context) {
 		case <-ticker.C:
 		}
 	}
+}
+
+func (h *Handler) pollTransitions(ctx context.Context, initialized bool) error {
+	overrides, err := h.client.Overrides(ctx)
+	if err != nil {
+		return err
+	}
+	for i := range overrides {
+		if overrides[i].Spec.SourceChannelID != h.options.ChannelID || overrides[i].Spec.SlackThreadTS == "" {
+			continue
+		}
+		key := transitionKey(&overrides[i])
+		h.mu.Lock()
+		previous, seen := h.observed[overrides[i].Spec.ID]
+		h.mu.Unlock()
+		if !initialized {
+			h.markObserved(&overrides[i])
+			continue
+		}
+		if !seen || previous != key {
+			h.postTransition(&overrides[i])
+		}
+	}
+	return nil
 }
 
 // Handle enforces the channel boundary before any dispatcher API call.
@@ -451,7 +446,7 @@ func (h *Handler) Handle(parent context.Context, command Command) Response {
 		if kind == dispatcherv1.OverrideKindCapacity {
 			positionalCount = 2
 		}
-		positionals, options, parseErr := parseOptions(tokens[2:], positionalCount, "for", "reason", "incident", "capability", "confirm-fallback")
+		positionals, options, parseErr := parseOptions(tokens[2:], positionalCount, "for", "reason", "incident", "capability")
 		if parseErr != nil {
 			return response(parseErr.Error() + ". " + usage())
 		}
@@ -466,14 +461,10 @@ func (h *Handler) Handle(parent context.Context, command Command) Response {
 				return response(parseErr.Error())
 			}
 		}
-		if kind != dispatcherv1.OverrideKindDrain && options["confirm-fallback"] == "true" {
-			return response("--confirm-fallback is valid only for drain plans.")
-		}
 		request := coredispatcher.PlanRequest{
 			Kind: kind, Cluster: positionals[0], Capability: options["capability"], Capacity: capacity,
 			DurationSeconds: duration, Reason: options["reason"], IncidentURL: options["incident"],
 			UserID: command.UserID, ChannelID: command.ChannelID, IdempotencyKey: idempotencyKey(command, "plan"),
-			FallbackConfirmed: options["confirm-fallback"] == "true",
 		}
 		var plan coredispatcher.DispatchPlan
 		plan, err = h.client.Plan(ctx, request)
@@ -484,7 +475,7 @@ func (h *Handler) Handle(parent context.Context, command Command) Response {
 		if !h.options.EnableApply {
 			return response(fmt.Sprintf("Dispatcher %s is disabled while the command is in read-only shadow mode.", tokens[0]))
 		}
-		positionals, options, parseErr := parseOptions(tokens[1:], 1, "confirm-fallback")
+		positionals, _, parseErr := parseOptions(tokens[1:], 1)
 		if parseErr != nil {
 			return response(parseErr.Error() + ". " + usage())
 		}
@@ -499,7 +490,7 @@ func (h *Handler) Handle(parent context.Context, command Command) Response {
 		var override *dispatcherv1.DispatchOverride
 		override, err = h.client.Apply(ctx, positionals[0], coredispatcher.ApplyRequest{
 			UserID: command.UserID, ChannelID: command.ChannelID, IdempotencyKey: idempotencyKey(command, tokens[0]),
-			FallbackConfirmed: options["confirm-fallback"] == "true", SlackThreadTS: command.ThreadTS,
+			SlackThreadTS: command.ThreadTS,
 		})
 		if err == nil {
 			resultingOverride = override

--- a/pkg/slack/dispatcher/commands_test.go
+++ b/pkg/slack/dispatcher/commands_test.go
@@ -208,7 +208,7 @@ func TestMentionRetryIsIdempotentAndApplyUsesOriginatingThread(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	callback := mentionCallback("Ev-apply", "C-team", "U2", "<@B1> tp-dispatch apply plan-1 --confirm-fallback", "101.2", "100.1")
+	callback := mentionCallback("Ev-apply", "C-team", "U2", "<@B1> tp-dispatch apply plan-1", "101.2", "100.1")
 	logger := logrus.NewEntry(logrus.New())
 	for range 2 {
 		handled, err := handler.MentionHandler().Handle(callback, logger)
@@ -220,7 +220,7 @@ func TestMentionRetryIsIdempotentAndApplyUsesOriginatingThread(t *testing.T) {
 		t.Fatalf("Slack retry was not deduplicated: calls=%d apply=%d posts=%d", client.calls, len(client.applyRequests), len(messenger.posts))
 	}
 	request := client.applyRequests[0]
-	if request.IdempotencyKey != "apply:Ev-apply" || request.SlackThreadTS != "100.1" || !request.FallbackConfirmed {
+	if request.IdempotencyKey != "apply:Ev-apply" || request.SlackThreadTS != "100.1" {
 		t.Fatalf("apply identity or thread was not preserved: %#v", request)
 	}
 	if messenger.posts[0].channel != "C-team" || messenger.posts[0].threadTS != "100.1" || !strings.Contains(messenger.posts[0].text, "override-1") {
@@ -234,11 +234,11 @@ func TestMutatingCommandsUseEventIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	result := handler.Handle(context.Background(), Command{ChannelID: "C-team", UserID: "U2", RequestID: "Ev-apply", ThreadTS: "100.1", Text: "apply plan-1 --confirm-fallback"})
+	result := handler.Handle(context.Background(), Command{ChannelID: "C-team", UserID: "U2", RequestID: "Ev-apply", ThreadTS: "100.1", Text: "apply plan-1"})
 	if !strings.Contains(result.Text, "Active") {
 		t.Fatalf("apply failed: %#v", result)
 	}
-	result = handler.Handle(context.Background(), Command{ChannelID: "C-team", UserID: "U2", RequestID: "Ev-approve", ThreadTS: "100.1", Text: "approve plan-1 --confirm-fallback"})
+	result = handler.Handle(context.Background(), Command{ChannelID: "C-team", UserID: "U2", RequestID: "Ev-approve", ThreadTS: "100.1", Text: "approve plan-1"})
 	if !strings.Contains(result.Text, "Recorded approval") || !strings.Contains(result.Text, "1/1") || len(client.applyRequests) != 2 || client.applyRequests[1].IdempotencyKey != "approve:Ev-approve" {
 		t.Fatalf("approve failed: %#v, apply=%#v", result, client.applyRequests)
 	}
@@ -256,25 +256,20 @@ func TestFormatOverridesIncludesExpiry(t *testing.T) {
 			RequiredApprovals: 2, Approvals: []dispatcherv1.DispatchApproval{{UserID: "U9"}},
 			ExpiresAt: metav1.NewTime(time.Date(2026, 8, 20, 14, 0, 0, 0, time.UTC)),
 		},
-		Status: dispatcherv1.DispatchOverrideStatus{State: dispatcherv1.OverrideStatePending, PolicyGeneration: 7, FallbackProtected: true},
+		Status: dispatcherv1.DispatchOverrideStatus{State: dispatcherv1.OverrideStatePending, PolicyGeneration: 7},
 	}
 	formatted := formatOverrides([]dispatcherv1.DispatchOverride{override})
-	for _, want := range []string{"o1", "Pending", "2026-08-20T14:00:00Z", "INC-123 API outage", "U9", "1/2", "generation 7", "fallback protected: *true*", "https://issues.example/INC-123"} {
+	for _, want := range []string{"o1", "Pending", "2026-08-20T14:00:00Z", "INC-123 API outage", "U9", "1/2", "generation 7", "https://issues.example/INC-123"} {
 		if !strings.Contains(formatted, want) {
 			t.Fatalf("override presentation missing %q: %s", want, formatted)
 		}
 	}
 	withoutIncident := override
 	withoutIncident.Spec.IncidentURL = ""
-	withoutIncident.Spec.FallbackProtected = true
-	withoutIncident.Status.FallbackProtected = false
 	withoutIncident.Status.State = dispatcherv1.OverrideStatePending
 	formatted = formatOverrides([]dispatcherv1.DispatchOverride{withoutIncident})
 	if strings.Contains(formatted, "incident") {
 		t.Fatalf("empty incident URL was included: %s", formatted)
-	}
-	if !strings.Contains(formatted, "fallback protected: *false*") {
-		t.Fatalf("status fallback protection was not preferred: %s", formatted)
 	}
 }
 
@@ -430,5 +425,64 @@ func TestDisabledPlanKindFeatureFlagCombinations(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func threadOverride(id string, state dispatcherv1.OverrideState, generation uint64) dispatcherv1.DispatchOverride {
+	return dispatcherv1.DispatchOverride{
+		Spec:   dispatcherv1.DispatchOverrideSpec{ID: id, SourceChannelID: "C-team", SlackThreadTS: "100.1"},
+		Status: dispatcherv1.DispatchOverrideStatus{State: state, PolicyGeneration: generation},
+	}
+}
+
+func TestTransitionPollPostsStateChangesNotGenerationBumps(t *testing.T) {
+	override := threadOverride("o1", dispatcherv1.OverrideStateActive, 38)
+	client := &fakeControlClient{overrides: []dispatcherv1.DispatchOverride{override}}
+	messenger := &fakeMessenger{}
+	handler, err := NewHandler(client, Options{ChannelID: "C-team", Messenger: messenger})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	if err := handler.pollTransitions(ctx, false); err != nil {
+		t.Fatal(err)
+	}
+	if len(messenger.posts) != 0 {
+		t.Fatalf("startup seed posted a transition: %#v", messenger.posts)
+	}
+
+	override.Status.PolicyGeneration = 39
+	client.overrides = []dispatcherv1.DispatchOverride{override}
+	if err := handler.pollTransitions(ctx, true); err != nil {
+		t.Fatal(err)
+	}
+	if len(messenger.posts) != 0 {
+		t.Fatalf("policy generation bump posted a transition: %#v", messenger.posts)
+	}
+
+	override.Status.State = dispatcherv1.OverrideStateRevoked
+	client.overrides = []dispatcherv1.DispatchOverride{override}
+	if err := handler.pollTransitions(ctx, true); err != nil {
+		t.Fatal(err)
+	}
+	if len(messenger.posts) != 1 || !strings.Contains(messenger.posts[0].text, "Revoked") || messenger.posts[0].threadTS != "100.1" {
+		t.Fatalf("state change was not posted: %#v", messenger.posts)
+	}
+
+	override.Status.PolicyGeneration = 40
+	client.overrides = []dispatcherv1.DispatchOverride{override}
+	if err := handler.pollTransitions(ctx, true); err != nil {
+		t.Fatal(err)
+	}
+	if len(messenger.posts) != 1 {
+		t.Fatalf("revoked generation bump posted again: %#v", messenger.posts)
+	}
+
+	client.overrides = []dispatcherv1.DispatchOverride{override, threadOverride("o2", dispatcherv1.OverrideStatePending, 40)}
+	if err := handler.pollTransitions(ctx, true); err != nil {
+		t.Fatal(err)
+	}
+	if len(messenger.posts) != 2 || !strings.Contains(messenger.posts[1].text, "Pending") {
+		t.Fatalf("new override was not posted: %#v", messenger.posts)
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Removes fallback observer confirmation from the Prow job dispatcher.
- Requires one approval to activate capacity and drain plans.
- Removes fallback confirmation and protection fields from dispatcher APIs and `DispatchOverride` resources.
- Posts Slack transition notifications only when an override changes lifecycle state.
- Prevents duplicate revoked notifications and ignores policy-generation-only changes.
- Removes metrics and status reporting for unprotected drains.
- Updates dispatcher and Slack tests for single-approval activation and state-based notification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->