### PR TITLE
TRT-2927: jobrunaggregator: cut the memory the test case analyzer needs

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatorapi/gcs_jobrun.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/gcs_jobrun.go
@@ -217,7 +217,10 @@ func (j *gcsJobRun) GetCombinedJUnitTestSuites(ctx context.Context) (*junit.Test
 	testSuites := &junit.TestSuites{}
 	for _, junitFile := range j.GetGCSJunitPaths() {
 		logrus.Debug("getting junit file content content from GCS")
-		junitContent, err := j.GetContent(ctx, junitFile)
+		// deliberately not going through GetContent: a job run's junit files add up to hundreds
+		// of megabytes and their raw content is of no use once they are parsed, so it must not
+		// end up in the content cache
+		junitContent, err := j.getCurrentContent(ctx, junitFile)
 		if err != nil {
 			return nil, fmt.Errorf("error getting content for jobrun/%v/%v %q: %w", j.GetJobName(), j.GetJobRunID(), junitFile, err)
 		}

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/gcs_jobrun.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/gcs_jobrun.go
@@ -357,10 +357,10 @@ func (j *gcsJobRun) getCurrentContent(ctx context.Context, path string) ([]byte,
 }
 
 func (j *gcsJobRun) getAllContent(ctx context.Context) (map[string][]byte, error) {
-	if len(j.pathToContent) > 0 {
-		return j.pathToContent, nil
-	}
-
+	// deliberately no shortcut on a non-empty pathToContent: it is a cache of whatever anyone
+	// asked for, not of everything this job run has. IsFinished alone leaves finished.json in
+	// there, which would make a shortcut return a map with neither the prowjob nor the junits.
+	// GetContent below serves what is already cached anyway.
 	errs := []error{}
 	ret := map[string][]byte{}
 

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/util.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/util.go
@@ -11,16 +11,18 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/utils/clock"
 	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 	prowjobclientset "sigs.k8s.io/prow/pkg/client/clientset/versioned"
-	prowjobinformers "sigs.k8s.io/prow/pkg/client/informers/externalversions"
-	v1 "sigs.k8s.io/prow/pkg/client/informers/externalversions/prowjobs/v1"
+	prowjoblisters "sigs.k8s.io/prow/pkg/client/listers/prowjobs/v1"
 
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
 	"github.com/openshift/ci-tools/pkg/junit"
@@ -31,6 +33,13 @@ const (
 	JobStateQuerySourceCluster  = "cluster"
 	// prowJobJobRunIDLabel is the label in prowJob for the prow job run ID. It is a unique identifier for job runs across different jobs
 	prowJobJobRunIDLabel = "prow.k8s.io/build-id"
+	// prowJobNamespace is the namespace holding the ProwJobs of the CI cluster
+	prowJobNamespace = "ci"
+	// prowJobListPageSize bounds how many untrimmed ProwJobs are decoded at once when the
+	// prowjob informer does its initial list. The namespace holds tens of thousands of
+	// ProwJobs, so this trades a few hundred megabytes of peak usage against the number of
+	// requests the initial sync needs.
+	prowJobListPageSize = 5000
 )
 
 const (
@@ -222,6 +231,42 @@ type ClusterJobRunWaiter struct {
 	ProwJobMatcherFunc ProwJobMatcherFunc
 }
 
+// trimProwJob drops the parts of a ProwJob that no aggregator ever reads, so that the informer
+// cache holds job names, labels, annotations and completion state instead of whole pod specs.
+// The ProwJob is trimmed in place: the caller always owns the only reference to it.
+//
+// This is the same idea as pjutil.TrimCachedProwJob upstream (kubernetes-sigs/prow#904), which
+// several prow components share. Once that merges and we pick it up in a prow bump, most of the
+// body below can defer to it, but not all of it: that helper keeps ExtraRefs because the
+// exporter builds metric labels out of it, and keeps the status fields that deck and tide serve,
+// while nothing here reads any of them.
+func trimProwJob(prowJob *prowv1.ProwJob) {
+	prowJob.ManagedFields = nil
+	prowJob.OwnerReferences = nil
+	prowJob.Spec.PodSpec = nil
+	prowJob.Spec.PipelineRunSpec = nil
+	prowJob.Spec.TektonPipelineRunSpec = nil
+	prowJob.Spec.DecorationConfig = nil
+	prowJob.Spec.ExtraRefs = nil
+	prowJob.Spec.RerunAuthConfig = nil
+	prowJob.Spec.RerunCommand = ""
+	prowJob.Status.Description = ""
+	prowJob.Status.PrevReportStates = nil
+}
+
+// trimProwJobObject is the cache.TransformFunc form of trimProwJob
+func trimProwJobObject(obj interface{}) (interface{}, error) {
+	switch typed := obj.(type) {
+	case *prowv1.ProwJob:
+		trimProwJob(typed)
+	case cache.DeletedFinalStateUnknown:
+		if prowJob, ok := typed.Obj.(*prowv1.ProwJob); ok {
+			trimProwJob(prowJob)
+		}
+	}
+	return obj, nil
+}
+
 func (w *ClusterJobRunWaiter) allProwJobsFinished(allItems []*prowv1.ProwJob) (bool, map[string]*prowv1.ProwJob) {
 	uncompletedJobMap := map[string]*prowv1.ProwJob{}
 	matchedJobMap := map[string]*prowv1.ProwJob{}
@@ -246,8 +291,8 @@ func (w *ClusterJobRunWaiter) allProwJobsFinished(allItems []*prowv1.ProwJob) (b
 	return false, matchedJobMap
 }
 
-func (w *ClusterJobRunWaiter) checkMatchedJobsForCompletion(prowJobInformer v1.ProwJobInformer) (bool, map[string]*prowv1.ProwJob, error) {
-	allItems, err := prowJobInformer.Lister().List(labels.Everything())
+func (w *ClusterJobRunWaiter) checkMatchedJobsForCompletion(prowJobLister prowjoblisters.ProwJobLister) (bool, map[string]*prowv1.ProwJob, error) {
+	allItems, err := prowJobLister.List(labels.Everything())
 	if err != nil {
 		return false, nil, err
 	}
@@ -256,21 +301,92 @@ func (w *ClusterJobRunWaiter) checkMatchedJobsForCompletion(prowJobInformer v1.P
 	return allDone, matchedJobs, nil
 }
 
+// newProwJobInformer builds an informer over all ProwJobs in the CI cluster, tuned to keep the
+// aggregator's memory footprint down. A ProwJob embeds the full pod spec of the job it runs,
+// which for ci-operator jobs carries the unresolved ci-operator configuration and is by far the
+// largest part of the object, and the CI cluster holds tens of thousands of ProwJobs at any
+// time. Neither the list nor the cache can therefore hold whole ProwJobs:
+//   - the initial list is paged by hand and each page is trimmed before it is accumulated, so at
+//     most one page worth of untrimmed ProwJobs is ever decoded at once. The generated informers
+//     cannot do this: the reflector accumulates every page of its initial list into one slice
+//     before the transform below ever runs, which happens later, in the DeltaFIFO. It does ask
+//     the server to paginate, but a resourceVersion=0 list is served from the watch cache, which
+//     ignores the limit and returns the whole collection in one response anyway.
+//   - a transform trims the objects the watch delivers afterwards.
+//
+// The streaming watch-list initial sync (SendInitialEvents) would make the hand-rolled paging
+// unnecessary, because from client-go 1.34 the reflector trims the objects it streams into its
+// internal store. It is of no use to us yet: the client-side WatchListClient gate only defaults
+// to true in client-go 1.35 (we build against 1.33), and, more importantly, the server-side
+// WatchList gate is alpha and off in Kubernetes 1.31, which is what the CI cluster (OCP 4.18)
+// runs. Upstream also turned that gate back off by default in 1.33 after it was briefly on in
+// 1.32, so a newer cluster would not obviously help either. When the server honors
+// SendInitialEvents, the reflector uses WatchFunc below and ignores ListFunc, which can then go.
+func (w *ClusterJobRunWaiter) newProwJobInformer(ctx context.Context) (cache.SharedIndexInformer, error) {
+	prowJobs := w.ProwJobClient.ProwV1().ProwJobs(prowJobNamespace)
+	listWatch := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			// page ourselves, which requires a quorum read: the watch cache cannot paginate
+			options.ResourceVersion = ""
+			options.ResourceVersionMatch = ""
+			options.Continue = ""
+			options.Limit = prowJobListPageSize
+			trimmed := &prowv1.ProwJobList{}
+			for pageNumber := 1; ; pageNumber++ {
+				page, err := prowJobs.List(ctx, options)
+				if err != nil {
+					return nil, fmt.Errorf("failed to list prowjobs in namespace %q (page %d): %w", prowJobNamespace, pageNumber, err)
+				}
+				if pageNumber == 1 {
+					// every page of a paged list is served from the same snapshot, so the
+					// resourceVersion the watch resumes from is the one of the first page
+					trimmed.TypeMeta = page.TypeMeta
+					trimmed.ResourceVersion = page.ResourceVersion
+				}
+				for i := range page.Items {
+					trimProwJob(&page.Items[i])
+					trimmed.Items = append(trimmed.Items, page.Items[i])
+				}
+				if len(page.Continue) == 0 {
+					// no Continue on the returned list: the reflector's pager must not ask for more
+					return trimmed, nil
+				}
+				options.Continue = page.Continue
+			}
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return prowJobs.Watch(ctx, options)
+		},
+	}
+
+	informer := cache.NewSharedIndexInformer(listWatch, &prowv1.ProwJob{}, 24*time.Hour, cache.Indexers{})
+	if err := informer.SetTransform(trimProwJobObject); err != nil {
+		return nil, fmt.Errorf("failed to set prowjob informer transform: %w", err)
+	}
+	return informer, nil
+}
+
 func (w *ClusterJobRunWaiter) Wait(ctx context.Context) ([]JobRunIdentifier, error) {
 	if w.ProwJobClient == nil {
 		return nil, fmt.Errorf("prowjob client is missing")
 	}
 
-	prowJobInformerFactory := prowjobinformers.NewSharedInformerFactoryWithOptions(w.ProwJobClient, 24*time.Hour, prowjobinformers.WithNamespace("ci"))
-	prowJobInformer := prowJobInformerFactory.Prow().V1().ProwJobs()
+	// the cached prowjobs are only needed while we wait, so shut the informer down on the way out
+	// instead of keeping the cache around for the rest of the analysis
+	informerCtx, shutdownInformer := context.WithCancel(ctx)
+	defer shutdownInformer()
 
-	// done to be sure that the informer is shown as "active" so that start activates them
-	// start informers and wait for them to sync
-	hasSynced := prowJobInformer.Informer().HasSynced
-	go prowJobInformerFactory.Start(ctx.Done())
-	if !cache.WaitForCacheSync(ctx.Done(), hasSynced) {
+	prowJobInformer, err := w.newProwJobInformer(informerCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	// start the informer and wait for it to sync
+	go prowJobInformer.Run(informerCtx.Done())
+	if !cache.WaitForCacheSync(informerCtx.Done(), prowJobInformer.HasSynced) {
 		return nil, fmt.Errorf("prowjob informer sync error")
 	}
+	prowJobLister := prowjoblisters.NewProwJobLister(prowJobInformer.GetIndexer())
 	timeout := time.Until(w.TimeToStopWaiting)
 	if timeout < 0 {
 		timeout = 30 * time.Second
@@ -278,13 +394,13 @@ func (w *ClusterJobRunWaiter) Wait(ctx context.Context) ([]JobRunIdentifier, err
 	logrus.Infof("Going to wait until %+v with timeout value %+v", w.TimeToStopWaiting, timeout)
 
 	// wait for up to limit until we've finished
-	err := wait.PollUntilContextTimeout(
+	err = wait.PollUntilContextTimeout(
 		ctx,
 		5*time.Minute,
 		timeout,
 		true,
 		func(ctx context.Context) (bool, error) {
-			allDone, _, err := w.checkMatchedJobsForCompletion(prowJobInformer)
+			allDone, _, err := w.checkMatchedJobsForCompletion(prowJobLister)
 
 			if err != nil {
 				// log and suppress the error
@@ -300,7 +416,7 @@ func (w *ClusterJobRunWaiter) Wait(ctx context.Context) ([]JobRunIdentifier, err
 	}
 
 	// one more time to get the matched jobs
-	_, matchedJobs, err := w.checkMatchedJobsForCompletion(prowJobInformer)
+	_, matchedJobs, err := w.checkMatchedJobsForCompletion(prowJobLister)
 
 	if err != nil && err != context.DeadlineExceeded {
 		return nil, fmt.Errorf("failed waiting for prowjobs to complete: %w", err)

--- a/pkg/jobrunaggregator/jobruntestcaseanalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobruntestcaseanalyzer/analyzer.go
@@ -222,10 +222,15 @@ func (s *testCaseAnalyzerJobGetter) filterJobsByNames(jobNames sets.Set[string],
 	return ret
 }
 
-// TestCaseChecker checks if a test passes certain criteria across all job runs
+// TestCaseChecker checks if a test passes certain criteria across all job runs.
+// Job runs are folded in one at a time so that no more than a single job run's junit content
+// needs to be held in memory at once.
 type TestCaseChecker interface {
-	// CheckTestCase returns a test suite based on whether a test has passed certain criteria across job runs
-	CheckTestCase(ctx context.Context, jobRunJunits map[jobrunaggregatorapi.JobRunInfo]*junit.TestSuites) *junit.TestSuite
+	// AddJobRun folds the junit results of a single job run into the criteria being checked
+	AddJobRun(jobRun jobrunaggregatorapi.JobRunInfo, testSuites *junit.TestSuites)
+	// TestSuite returns a test suite based on whether a test has passed certain criteria across
+	// all the job runs added so far
+	TestSuite() *junit.TestSuite
 }
 
 type minimumRequiredPassesTestCaseChecker struct {
@@ -234,6 +239,24 @@ type minimumRequiredPassesTestCaseChecker struct {
 	// be created. This might include variant info like platform, network and infrastructure etc.
 	testNameSuffix         string
 	requiredNumberOfPasses int
+
+	// state accumulated by AddJobRun
+	details      *jobrunaggregatorlib.TestCaseDetails
+	jobRunCount  int
+	successCount int
+	duration     time.Duration
+}
+
+func newMinimumRequiredPassesTestCaseChecker(id testIdentifier, testNameSuffix string, requiredNumberOfPasses int) *minimumRequiredPassesTestCaseChecker {
+	return &minimumRequiredPassesTestCaseChecker{
+		id:                     id,
+		testNameSuffix:         testNameSuffix,
+		requiredNumberOfPasses: requiredNumberOfPasses,
+		details: &jobrunaggregatorlib.TestCaseDetails{
+			Name:          id.testName,
+			TestSuiteName: strings.Join(id.testSuites, jobrunaggregatorlib.TestSuitesSeparator),
+		},
+	}
 }
 
 type testStatus int
@@ -276,7 +299,7 @@ func getTestStatus(id testIdentifier, testSuite *junit.TestSuite) testStatus {
 	return testSkipped
 }
 
-func (r minimumRequiredPassesTestCaseChecker) addTestResultToDetails(currDetails *jobrunaggregatorlib.TestCaseDetails,
+func (r *minimumRequiredPassesTestCaseChecker) addTestResultToDetails(currDetails *jobrunaggregatorlib.TestCaseDetails,
 	jobRun jobrunaggregatorapi.JobRunInfo, status testStatus) {
 	switch status {
 	case testPassed:
@@ -338,8 +361,34 @@ func updateTestCountsInSuite(suite *junit.TestSuite) {
 	suite.NumFailed = numFailed
 }
 
-// CheckTestCase returns a test case based on whether a test has passed certain criteria across job runs
-func (r minimumRequiredPassesTestCaseChecker) CheckTestCase(ctx context.Context, jobRunJunits map[jobrunaggregatorapi.JobRunInfo]*junit.TestSuites) *junit.TestSuite {
+// AddJobRun records the result of the checked test case in a single job run
+func (r *minimumRequiredPassesTestCaseChecker) AddJobRun(jobRun jobrunaggregatorapi.JobRunInfo, testSuites *junit.TestSuites) {
+	start := time.Now()
+
+	status := testSkipped
+	// Now go through test suites check test result
+	for _, testSuite := range testSuites.Suites {
+		status = getTestStatus(r.id, testSuite)
+		found := false
+		switch status {
+		case testPassed:
+			found = true
+			r.successCount++
+		case testFailed:
+			found = true
+		}
+		if found {
+			break
+		}
+	}
+	r.addTestResultToDetails(r.details, jobRun, status)
+
+	r.jobRunCount++
+	r.duration += time.Since(start)
+}
+
+// TestSuite returns a test case based on whether a test has passed certain criteria across job runs
+func (r *minimumRequiredPassesTestCaseChecker) TestSuite() *junit.TestSuite {
 	topSuite := &junit.TestSuite{
 		Name:      "minimum-required-passes-checker",
 		TestCases: []*junit.TestCase{},
@@ -355,41 +404,16 @@ func (r minimumRequiredPassesTestCaseChecker) CheckTestCase(ctx context.Context,
 	}
 	bottomSuite.TestCases = append(bottomSuite.TestCases, testCase)
 
-	start := time.Now()
-	successCount := 0
-	currDetails := &jobrunaggregatorlib.TestCaseDetails{
-		Name:          r.id.testName,
-		TestSuiteName: strings.Join(r.id.testSuites, jobrunaggregatorlib.TestSuitesSeparator),
-	}
-	for jobRun, testSuites := range jobRunJunits {
-		status := testSkipped
-		// Now go through test suites check test result
-		for _, testSuite := range testSuites.Suites {
-			status = getTestStatus(r.id, testSuite)
-			found := false
-			switch status {
-			case testPassed:
-				found = true
-				successCount++
-			case testFailed:
-				found = true
-			}
-			if found {
-				break
-			}
-		}
-		r.addTestResultToDetails(currDetails, jobRun, status)
-	}
-	currDetails.Summary = fmt.Sprintf("Total job runs: %d, passes: %d, failures: %d, skips %d", len(jobRunJunits), len(currDetails.Passes), len(currDetails.Failures), len(currDetails.Skips))
-	detailsYaml, err := yaml.Marshal(currDetails)
+	r.details.Summary = fmt.Sprintf("Total job runs: %d, passes: %d, failures: %d, skips %d", r.jobRunCount, len(r.details.Passes), len(r.details.Failures), len(r.details.Skips))
+	detailsYaml, err := yaml.Marshal(r.details)
 	if err != nil {
 		return nil
 	}
-	testCase.Duration = time.Since(start).Seconds()
+	testCase.Duration = r.duration.Seconds()
 	testCase.SystemOut = string(detailsYaml)
-	if successCount < r.requiredNumberOfPasses {
+	if r.successCount < r.requiredNumberOfPasses {
 		testCase.FailureOutput = &junit.FailureOutput{
-			Message: fmt.Sprintf("required minimum successful count %d, got %d", r.requiredNumberOfPasses, successCount),
+			Message: fmt.Sprintf("required minimum successful count %d, got %d", r.requiredNumberOfPasses, r.successCount),
 		}
 	}
 	updateTestCountsInSuite(topSuite)
@@ -599,7 +623,6 @@ func (o *JobRunTestCaseAnalyzerOptions) runTestCaseCheckers(ctx context.Context,
 	}
 
 	allJobRuns := append(finishedJobRuns, unfinishedJobRuns...)
-	jobRunJunitMap := map[jobrunaggregatorapi.JobRunInfo]*junit.TestSuites{}
 	for i := range allJobRuns {
 		jobRun := allJobRuns[i]
 
@@ -607,10 +630,15 @@ func (o *JobRunTestCaseAnalyzerOptions) runTestCaseCheckers(ctx context.Context,
 		if err != nil {
 			continue
 		}
-		jobRunJunitMap[jobRun] = testSuites
+		for _, checker := range o.testCaseCheckers {
+			checker.AddJobRun(jobRun, testSuites)
+		}
+		// the junit content of a single job run runs into hundreds of megabytes, so release it
+		// before fetching the next job run instead of holding all of them until the end
+		jobRun.ClearAllContent()
 	}
 	for _, checker := range o.testCaseCheckers {
-		testSuite := checker.CheckTestCase(ctx, jobRunJunitMap)
+		testSuite := checker.TestSuite()
 		topSuite.Children = append(topSuite.Children, testSuite)
 		topSuite.NumTests += testSuite.NumTests
 		topSuite.NumFailed += testSuite.NumFailed

--- a/pkg/jobrunaggregator/jobruntestcaseanalyzer/cmd.go
+++ b/pkg/jobrunaggregator/jobruntestcaseanalyzer/cmd.go
@@ -371,7 +371,7 @@ func (f *JobRunsTestCaseAnalyzerFlags) ToOptions(ctx context.Context) (*JobRunTe
 		timeout:             f.Timeout,
 		ciDataClient:        ciDataClient,
 		ciGCSClient:         ciGCSClient,
-		testCaseCheckers:    []TestCaseChecker{minimumRequiredPassesTestCaseChecker{testIdentifierOpt, f.testNameSuffix(), f.MinimumSuccessfulTestCount}},
+		testCaseCheckers:    []TestCaseChecker{newMinimumRequiredPassesTestCaseChecker(testIdentifierOpt, f.testNameSuffix(), f.MinimumSuccessfulTestCount)},
 		testNameSuffix:      f.testNameSuffix(),
 		payloadInvocationID: f.PayloadInvocationID,
 		jobGCSPrefixes:      &f.JobGCSPrefixes,


### PR DESCRIPTION
The `release-payload-install-analysis` step gets its pod evicted because `job-run-aggregator analyze-test-case` grows past 16GiB against a 1000Mi request:

```
Evicted The node was low on resource: memory. [...] Container test was using 17222464Ki, request is 1000Mi
```

Three places account for the bulk of it:

* **The ProwJob informer.** With `--query-source=cluster` the waiter starts an informer over every ProwJob in the CI cluster's `ci` namespace. A ProwJob embeds the pod spec of the job it runs — for ci-operator jobs that carries the unresolved ci-operator configuration — so objects run into hundreds of kilobytes and there are tens of thousands of them. The whole collection is decoded at once during the initial sync and then kept in the cache for the rest of the run. This is the one that matches the observed failure: the pod dies at 11m30s, right around informer sync and long before any junit is fetched. The initial list is now paged and trimmed page by page, a transform trims what the watch delivers, and the informer is shut down once the wait is over.

  A `SetTransform` on its own does not fix the sync-time peak: on the list path the reflector's pager accumulates every page into one slice before returning, and the transform only runs afterwards, in `DeltaFIFO` during `Replace`. The reflector does ask for pagination, but a `resourceVersion=0` list is served from the watch cache, which ignores `Limit` and returns everything in one response (see the comment in `reflector.go`'s `list()`). Paging inside the `ListWatch` and trimming each page as it arrives is what bounds the peak. The streaming watch-list path would change this picture, but `WatchListClient` is `Default: false` in the client-go we build against (v0.33.11), and this version's `watchList` fills a plain `temporaryStore` with no transformer anyway.

* **Raw junit bytes.** `GetCombinedJUnitTestSuites` fetched through `GetContent`, which keeps every fetched file in the job run's content cache forever, so each job run held both the raw junit bytes and the parsed suites. It now fetches directly.

* **All job runs' junits at once.** The analyzer built a map of every job run's parsed junit and handed it to each checker, even though a checker only looks for one test case per job run — and a junit test case carries the output of the test it describes. `TestCaseChecker` now accumulates job runs one at a time, so each job run's content is released before the next is fetched.

Only the parts of a ProwJob that the matchers and the waiter actually read survive trimming: labels, annotations, `Spec.Job` and the completion state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Reduces memory usage in `jobrunaggregator analyze-test-case` to prevent pod eviction near the 16 GiB limit.

- Pages and trims ProwJob informer results before caching. The informer shuts down after the cluster wait completes.
- Fetches JUnit files directly instead of retaining large raw payloads in the job run content cache.
- Processes job runs one at a time and releases JUnit content after each run.
- Accumulates test case results through `AddJobRun` and generates the final result with `TestSuite()`.

These changes improve reliability for CI operators who analyze large job run sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->