### PR TITLE
Fix in prowgen to respect capabilities

### DIFF
--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -3,6 +3,7 @@ package prowgen
 import (
 	"fmt"
 	"hash/fnv"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
@@ -50,6 +51,7 @@ func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *cio
 			if err != nil {
 				return nil, fmt.Errorf("new prowjob builder: %w", err)
 			}
+			injectCapabilities(g.base.Labels, projectImageCapabilitiesForTest(configSpec, element))
 
 			name := element.As
 			if shardCount > 1 {
@@ -461,4 +463,137 @@ func injectCapabilitiesForImgJobs(g *prowJobBaseBuilder, imagesConfig []cioperat
 			g.WithLabel(fmt.Sprintf("capability/%s", c), c)
 		}
 	}
+}
+
+// projectImageCapabilitiesForTest returns capabilities declared by project
+// images selected through the common generated-test paths. Tests with a cluster
+// profile wait for [images], which contains every non-optional project image;
+// other tests can select a project image directly or through its From/Inputs.
+// Synthetic operator bundle and index image dependencies are not modeled here.
+func projectImageCapabilitiesForTest(config *cioperatorapi.ReleaseBuildConfiguration, test cioperatorapi.TestStepConfiguration) []string {
+	images := make(map[string]*cioperatorapi.ProjectDirectoryImageBuildStepConfiguration, len(config.Images.Items))
+	for i := range config.Images.Items {
+		image := &config.Images.Items[i]
+		images[string(image.To)] = image
+	}
+
+	requiredImages := sets.New[string]()
+	requireAllImages := false
+	var claimRelease *cioperatorapi.ClaimRelease
+	if test.ClusterClaim != nil {
+		claimRelease = test.ClusterClaim.ClaimRelease(test.As)
+	}
+
+	addDependency := func(dependency cioperatorapi.StepDependency, overrides cioperatorapi.DependencyOverrides) {
+		if dependency.PullSpec != "" || dependencyHasPullSpecOverride(dependency, overrides) {
+			return
+		}
+		stream, name, _ := config.DependencyParts(dependency, claimRelease)
+		switch {
+		case stream == cioperatorapi.PipelineImageStream:
+			if _, ok := images[name]; ok {
+				requiredImages.Insert(name)
+			}
+		case cioperatorapi.IsReleasePayloadStream(stream):
+			if releaseIncludesBuiltImages(config, name) {
+				requireAllImages = true
+			}
+		}
+	}
+
+	if container := test.ContainerTestConfiguration; container != nil {
+		addDependency(cioperatorapi.StepDependency{Name: string(container.From)}, nil)
+	}
+	if multiStage := test.MultiStageTestConfigurationLiteral; multiStage != nil {
+		// A cluster profile exposes IMAGE_FORMAT and RELEASE_IMAGE_LATEST. The
+		// former is provided by [images], so every non-optional image is built.
+		if multiStage.ClusterProfileLiteral != nil {
+			requireAllImages = true
+		}
+		for _, steps := range [][]cioperatorapi.LiteralTestStep{multiStage.Pre, multiStage.Test, multiStage.Post} {
+			for _, step := range steps {
+				if step.FromImage == nil {
+					addDependency(cioperatorapi.StepDependency{Name: step.From}, nil)
+				}
+				for _, dependency := range step.Dependencies {
+					addDependency(dependency, multiStage.DependencyOverrides)
+				}
+			}
+		}
+	}
+	if multiStage := test.MultiStageTestConfiguration; multiStage != nil {
+		// GenerateJobs normally receives registry-resolved literal steps, but
+		// preserve the same behavior for callers that pass inline steps.
+		if multiStage.ClusterProfile != "" {
+			requireAllImages = true
+		}
+		for env, dependency := range multiStage.Dependencies {
+			addDependency(cioperatorapi.StepDependency{Name: dependency, Env: env}, multiStage.DependencyOverrides)
+		}
+		for _, steps := range [][]cioperatorapi.TestStep{multiStage.Pre, multiStage.Test, multiStage.Post} {
+			for _, step := range steps {
+				if step.LiteralTestStep == nil {
+					continue
+				}
+				if step.FromImage == nil {
+					addDependency(cioperatorapi.StepDependency{Name: step.From}, nil)
+				}
+				for _, dependency := range step.Dependencies {
+					addDependency(dependency, multiStage.DependencyOverrides)
+				}
+			}
+		}
+	}
+
+	if requireAllImages {
+		for _, image := range config.Images.Items {
+			if !image.Optional {
+				requiredImages.Insert(string(image.To))
+			}
+		}
+	}
+
+	// Follow image-to-image dependencies. Every project image also depends on
+	// src, but src has no independent capability declaration.
+	for pending := requiredImages.UnsortedList(); len(pending) > 0; pending = pending[1:] {
+		image := images[pending[0]]
+		if image == nil {
+			continue
+		}
+		dependencies := sets.New[string](string(image.From))
+		for input := range image.Inputs {
+			dependencies.Insert(input)
+		}
+		for dependency := range dependencies {
+			if _, ok := images[dependency]; ok && !requiredImages.Has(dependency) {
+				requiredImages.Insert(dependency)
+				pending = append(pending, dependency)
+			}
+		}
+	}
+
+	capabilities := sets.New[string]()
+	for imageName := range requiredImages {
+		capabilities.Insert(images[imageName].AllCapabilities()...)
+	}
+	return sets.List(capabilities)
+}
+
+func dependencyHasPullSpecOverride(dependency cioperatorapi.StepDependency, overrides cioperatorapi.DependencyOverrides) bool {
+	for name, pullSpec := range overrides {
+		if pullSpec != "" && strings.EqualFold(dependency.Env, name) {
+			return true
+		}
+	}
+	return false
+}
+
+func releaseIncludesBuiltImages(config *cioperatorapi.ReleaseBuildConfiguration, name string) bool {
+	// With tag_specification, ci-operator assembles "latest" with all built
+	// images for backwards compatibility.
+	if name == cioperatorapi.LatestReleaseName && config.ReleaseTagConfiguration != nil {
+		return true
+	}
+	release, ok := config.Releases[name]
+	return ok && release.Integration != nil && release.Integration.IncludeBuiltImages
 }

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -1238,3 +1238,181 @@ func TestBundleWithCapabilities(t *testing.T) {
 		})
 	}
 }
+
+func TestProjectImageCapabilitiesForTest(t *testing.T) {
+	config := &ciop.ReleaseBuildConfiguration{
+		Images: ciop.ImageConfiguration{Items: []ciop.ProjectDirectoryImageBuildStepConfiguration{
+			{
+				To:                      "required-arm",
+				Capabilities:            []string{"intranet"},
+				AdditionalArchitectures: []string{"arm64"},
+			},
+			{To: "optional-kvm", Capabilities: []string{"nested-kvm"}, Optional: true},
+			{To: "optional-child", From: "optional-kvm", Optional: true},
+			{To: "independent"},
+		}},
+		InputConfiguration: ciop.InputConfiguration{Releases: map[string]ciop.UnresolvedRelease{
+			"with-built-images":    {Integration: &ciop.Integration{IncludeBuiltImages: true}},
+			"without-built-images": {Integration: &ciop.Integration{}},
+		}},
+	}
+
+	tests := []struct {
+		name     string
+		test     ciop.TestStepConfiguration
+		expected []string
+	}{
+		{
+			name:     "container inherits capabilities through image dependencies",
+			test:     ciop.TestStepConfiguration{ContainerTestConfiguration: &ciop.ContainerTestConfiguration{From: "optional-child"}},
+			expected: []string{"nested-kvm"},
+		},
+		{
+			name:     "unrelated container is not constrained by other image builds",
+			test:     ciop.TestStepConfiguration{ContainerTestConfiguration: &ciop.ContainerTestConfiguration{From: "independent"}},
+			expected: []string{},
+		},
+		{
+			name: "cluster profile requires all non-optional images",
+			test: ciop.TestStepConfiguration{MultiStageTestConfigurationLiteral: &ciop.MultiStageTestConfigurationLiteral{
+				ClusterProfileLiteral: &ciop.ClusterProfileLiteral{},
+			}},
+			expected: []string{"arm64", "intranet"},
+		},
+		{
+			name: "inline cluster profile requires all non-optional images",
+			test: ciop.TestStepConfiguration{MultiStageTestConfiguration: &ciop.MultiStageTestConfiguration{
+				ClusterProfile: "aws",
+			}},
+			expected: []string{"arm64", "intranet"},
+		},
+		{
+			name: "literal step dependency selects optional image chain",
+			test: ciop.TestStepConfiguration{MultiStageTestConfigurationLiteral: &ciop.MultiStageTestConfigurationLiteral{
+				Test: []ciop.LiteralTestStep{{Dependencies: []ciop.StepDependency{{Name: "optional-child"}}}},
+			}},
+			expected: []string{"nested-kvm"},
+		},
+		{
+			name: "literal dependency pullspec override is case insensitive",
+			test: ciop.TestStepConfiguration{MultiStageTestConfigurationLiteral: &ciop.MultiStageTestConfigurationLiteral{
+				Test:                []ciop.LiteralTestStep{{Dependencies: []ciop.StepDependency{{Name: "optional-child", Env: "OPTIONAL_IMAGE"}}}},
+				DependencyOverrides: ciop.DependencyOverrides{"optional_image": "quay.io/example/external:latest"},
+			}},
+			expected: []string{},
+		},
+		{
+			name: "unresolved dependency pullspec override is case insensitive",
+			test: ciop.TestStepConfiguration{MultiStageTestConfiguration: &ciop.MultiStageTestConfiguration{
+				Test:                []ciop.TestStep{{LiteralTestStep: &ciop.LiteralTestStep{Dependencies: []ciop.StepDependency{{Name: "optional-child", Env: "Optional_Image"}}}}},
+				Dependencies:        ciop.TestDependencies{"OPTIONAL_IMAGE": "optional-child"},
+				DependencyOverrides: ciop.DependencyOverrides{"optional_image": "quay.io/example/external:latest"},
+			}},
+			expected: []string{},
+		},
+		{
+			name: "release assembled with built images requires non-optional images",
+			test: ciop.TestStepConfiguration{MultiStageTestConfigurationLiteral: &ciop.MultiStageTestConfigurationLiteral{
+				Test: []ciop.LiteralTestStep{{From: "release:with-built-images"}},
+			}},
+			expected: []string{"arm64", "intranet"},
+		},
+		{
+			name: "release without built images does not select image builds",
+			test: ciop.TestStepConfiguration{MultiStageTestConfigurationLiteral: &ciop.MultiStageTestConfigurationLiteral{
+				Test: []ciop.LiteralTestStep{{From: "release:without-built-images"}},
+			}},
+			expected: []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			testhelper.Diff(t, "capabilities", projectImageCapabilitiesForTest(config, tc.test), tc.expected)
+		})
+	}
+}
+
+func TestGenerateJobsPropagatesDependentImageCapabilities(t *testing.T) {
+	config := &ciop.ReleaseBuildConfiguration{
+		Images: ciop.ImageConfiguration{Items: []ciop.ProjectDirectoryImageBuildStepConfiguration{
+			{To: "required-arm", Capabilities: []string{"arm64"}},
+			{To: "optional-kvm", Capabilities: []string{"nested-kvm"}, Optional: true},
+			{To: "optional-child", From: "optional-kvm", Optional: true},
+			{To: "independent"},
+		}},
+		Tests: []ciop.TestStepConfiguration{
+			{
+				As:                         "dependent",
+				Capabilities:               []string{"intranet"},
+				ContainerTestConfiguration: &ciop.ContainerTestConfiguration{From: "optional-child"},
+			},
+			{
+				As:                         "independent",
+				ContainerTestConfiguration: &ciop.ContainerTestConfiguration{From: "independent"},
+			},
+		},
+	}
+	jobConfig, err := GenerateJobs(config, &ciop.Metadata{Org: "org", Repo: "repo", Branch: "main"}, clusterProfileResolverFunc())
+	if err != nil {
+		t.Fatalf("generate jobs: %v", err)
+	}
+
+	var dependent, independent map[string]string
+	for _, job := range jobConfig.PresubmitsStatic["org/repo"] {
+		switch {
+		case strings.HasSuffix(job.Name, "-dependent"):
+			dependent = job.Labels
+		case strings.HasSuffix(job.Name, "-independent"):
+			independent = job.Labels
+		}
+	}
+	if dependent == nil || independent == nil {
+		t.Fatalf("failed to find generated test jobs: dependent=%v independent=%v", dependent != nil, independent != nil)
+	}
+	for key, value := range map[string]string{
+		"capability/intranet":   "intranet",
+		"capability/nested-kvm": "nested-kvm",
+	} {
+		if dependent[key] != value {
+			t.Errorf("dependent job label %s: got %q, want %q", key, dependent[key], value)
+		}
+	}
+	if _, ok := dependent["capability/arm64"]; ok {
+		t.Error("dependent job unexpectedly inherited capability from an unrelated image")
+	}
+	for key := range independent {
+		if strings.HasPrefix(key, "capability/") {
+			t.Errorf("independent job unexpectedly has capability label %s", key)
+		}
+	}
+}
+
+func TestGenerateJobsPropagatesArm64ImageCapabilityToClusterProfileTest(t *testing.T) {
+	config := &ciop.ReleaseBuildConfiguration{
+		Images: ciop.ImageConfiguration{Items: []ciop.ProjectDirectoryImageBuildStepConfiguration{{
+			To:                      "hypershift-operator",
+			AdditionalArchitectures: []string{"arm64"},
+		}}},
+		Tests: []ciop.TestStepConfiguration{{
+			As: "e2e-aks",
+			MultiStageTestConfigurationLiteral: &ciop.MultiStageTestConfigurationLiteral{
+				ClusterProfileLiteral: &ciop.ClusterProfileLiteral{Name: "hypershift-aks", ClusterType: "azure"},
+			},
+		}},
+	}
+	jobConfig, err := GenerateJobs(config, &ciop.Metadata{Org: "openshift", Repo: "hypershift", Branch: "main"}, clusterProfileResolverFunc())
+	if err != nil {
+		t.Fatalf("generate jobs: %v", err)
+	}
+
+	for _, job := range jobConfig.PresubmitsStatic["openshift/hypershift"] {
+		if strings.HasSuffix(job.Name, "-e2e-aks") {
+			if actual := job.Labels["capability/arm64"]; actual != "arm64" {
+				t.Fatalf("generated e2e-aks capability/arm64 label: got %q, want %q", actual, "arm64")
+			}
+			return
+		}
+	}
+	t.Fatal("failed to find generated e2e-aks ProwJob")
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

`prowgen` now respects image capabilities when it generates test jobs. It derives capabilities from required project images, including indirect image dependencies, cluster profiles, release payloads, and multi-stage test configurations.

The logic excludes pull-spec dependencies and overridden dependencies. It also handles optional images and built images in release configurations.

Generated presubmit jobs now receive the correct capability labels, including propagated capabilities such as `arm64`. Tests cover dependency propagation, exclusions, optional image chains, and cluster-profile and release-based tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->