### PR TITLE
Reject duplicate secret collections within a rover group

### DIFF
--- a/pkg/group/config.go
+++ b/pkg/group/config.go
@@ -76,10 +76,15 @@ func (c *Config) validate() error {
 		if k == OpenshiftPrivAdminsGroup || v.RenameTo == OpenshiftPrivAdminsGroup {
 			return fmt.Errorf("cannot use the group name %s in the configuration file", OpenshiftPrivAdminsGroup)
 		}
+		seen := sets.New[string]()
 		for _, collection := range v.SecretCollections {
 			if !validation.ValidateCollectionName(collection) {
 				return fmt.Errorf("invalid collection name '%s' in the configuration file: must be at most %d characters, contain only lowercase letters, numbers, hyphens, and underscores (no double underscores), and end with a lowercase letter or number", collection, validation.MaxCollectionLength)
 			}
+			if seen.Has(collection) {
+				return fmt.Errorf("secret collection '%s' is listed more than once for group '%s' in the configuration file", collection, k)
+			}
+			seen.Insert(collection)
 		}
 	}
 	return nil

--- a/pkg/group/config_test.go
+++ b/pkg/group/config_test.go
@@ -33,6 +33,11 @@ func TestLoadConfig(t *testing.T) {
 			file:        filepath.Join("testdata", "TestLoadConfig", "openshift_priv_admins.yaml"),
 			expectedErr: fmt.Errorf("failed to validate config file: cannot use the group name openshift-priv-admins in the configuration file"),
 		},
+		{
+			name:        "a secret collection cannot be listed twice for the same group",
+			file:        filepath.Join("testdata", "TestLoadConfig", "duplicate_secret_collection.yaml"),
+			expectedErr: fmt.Errorf("failed to validate config file: secret collection 'wildfly-charts-secrets' is listed more than once for group 'test-platform-gsm-secrets-owners' in the configuration file"),
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/group/testdata/TestLoadConfig/duplicate_secret_collection.yaml
+++ b/pkg/group/testdata/TestLoadConfig/duplicate_secret_collection.yaml
@@ -1,0 +1,11 @@
+cluster_groups:
+  dp-managed:
+    - build01
+    - build02
+groups:
+  test-platform-gsm-secrets-owners:
+    secret_collections:
+      - test-platform-infra
+      - psalajova-first-secret
+      - wildfly-charts-secrets
+      - wildfly-charts-secrets


### PR DESCRIPTION
## What

Adds validation to `group.Config.validate()` that rejects a secret collection listed more than once for the same group in `core-services/sync-rover-groups/_config.yaml`.

Example that is now rejected:

```yaml
groups:
  test-platform-gsm-secrets-owners:
    secret_collections:
    - test-platform-infra
    - psalajova-first-secret
    - wildfly-charts-secrets
    - wildfly-charts-secrets   # duplicate -> error
```

## Why

A collection listed twice for the same group causes `gsm-secret-sync` (`pkg/gsm-secrets/config.go`) to append that group's email to `GroupsWithAccess` twice, producing a duplicate `group:<name>` IAM member on the collection's bindings. This is silently accepted today.

The check lives in `Config.validate()`, the single chokepoint reached via `group.LoadConfig` by both `sync-rover-groups` presubmits (`ci/prow/sync-rover-groups` and `ci/prow/rover-groups-config-validation`) and the `gsm-secret-sync` tool, so it's enforced everywhere without duplicating logic.

A collection shared across *different* groups remains valid (intended "a collection can belong to multiple groups" behavior).

## Testing

- Added a case to `TestLoadConfig` with fixture `duplicate_secret_collection.yaml`.
- `go test ./pkg/group/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

`group.LoadConfig` now rejects duplicate secret collections within the same rover group. This prevents `gsm-secret-sync` from generating duplicate IAM members while allowing collections shared across different groups.

The validation covers rover-groups presubmits and `gsm-secret-sync`. Tests add duplicate-collection coverage, and `go test ./pkg/group/...` passes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->