### PR TITLE
DPTP-5236: use gcs.ci.openshift.org for public gcsweb URLs in ci-tools

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -219,7 +219,7 @@ func gatherOptions() (options, error) {
 
 	fs.StringVar(&o.gcsBucket, "gcs-bucket", "test-platform-results", "GCS Bucket to upload affected jobs list")
 	fs.StringVar(&o.gcsCredentialsFile, "gcs-credentials-file", "/etc/gcs/service-account.json", "GCS Credentials file to upload affected jobs list")
-	fs.StringVar(&o.gcsBrowserPrefix, "gcs-browser-prefix", "https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/", "Prefix for the GCS Browser for viewing the affected jobs list")
+	fs.StringVar(&o.gcsBrowserPrefix, "gcs-browser-prefix", "https://gcs.ci.openshift.org/gcs/test-platform-results/", "Prefix for the GCS Browser for viewing the affected jobs list")
 
 	o.github.AddFlags(fs)
 	o.githubEventServerOptions.Bind(fs)

--- a/pkg/api/domain.go
+++ b/pkg/api/domain.go
@@ -16,7 +16,10 @@ const (
 	// routed for the current service cluster.
 	ServiceDomainCI    = "ci.openshift.org"
 	ServiceDomainAPPCI = "apps.ci.l2s4.p1.openshiftapps.com"
-	ServiceDomainGCS   = "googleapis.com"
+
+	// GCSWebPublicHost is the vanity hostname for the public gcsweb browser on core-ci.
+	GCSWebPublicHost = "gcs.ci.openshift.org"
+	ServiceDomainGCS = "googleapis.com"
 
 	ServiceDomainAPPCIRegistry     = "registry.ci.openshift.org"
 	ServiceDomainVSphere02Registry = "registry.apps.build02.vmc.ci.openshift.org"

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/gcs_jobrun.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/gcs_jobrun.go
@@ -18,6 +18,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	prowjobv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 
+	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/junit"
 )
 
@@ -150,7 +151,7 @@ func (j *gcsJobRun) writeCache(ctx context.Context, parentDir string) error {
 func (j *gcsJobRun) GetJobRunFromGCS(ctx context.Context) error {
 	query := &storage.Query{
 		// This ends up being the equivalent of:
-		// https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-upgrade-from-stable-4.8-e2e-metal-ipi-upgrade/1671747590984568832
+		// https://gcs.ci.openshift.org/gcs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-upgrade-from-stable-4.8-e2e-metal-ipi-upgrade/1671747590984568832
 		// the next directory step is based on some bit of metadata I don't recognize
 		Prefix: j.jobRunGCSBucketRoot,
 
@@ -413,6 +414,6 @@ func GetHumanURLForLocation(jobRunGCSBucketRoot, jobRunGCSBucket string) string 
 }
 
 func GetGCSArtifactURLForLocation(jobRunGCSBucketRoot, jobRunGCSBucket string) string {
-	// https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.9-e2e-gcp-upgrade/1420676206029705216/artifacts/e2e-gcp-upgrade/
-	return fmt.Sprintf("https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/%s/%s/artifacts", jobRunGCSBucket, jobRunGCSBucketRoot)
+	// https://gcs.ci.openshift.org/gcs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.9-e2e-gcp-upgrade/1420676206029705216/artifacts/e2e-gcp-upgrade/
+	return fmt.Sprintf("https://%s/gcs/%s/%s/artifacts", api.GCSWebPublicHost, jobRunGCSBucket, jobRunGCSBucketRoot)
 }

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/gcs_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/gcs_client.go
@@ -48,7 +48,7 @@ func (o *ciGCSClient) ReadRelatedJobRuns(ctx context.Context,
 	logrus.Debugf("searching GCS for related job runs in %s between %s and %s", gcsPrefix, startingJobRunID, endingJobRunID)
 	query := &storage.Query{
 		// This ends up being the equivalent of:
-		// https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-upgrade-from-stable-4.8-e2e-metal-ipi-upgrade/
+		// https://gcs.ci.openshift.org/gcs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-upgrade-from-stable-4.8-e2e-metal-ipi-upgrade/
 		Prefix: fmt.Sprintf("%s/", gcsPrefix),
 
 		// TODO this field is apparently missing from this level of go/storage

--- a/pkg/slack/events/joblink/link.go
+++ b/pkg/slack/events/joblink/link.go
@@ -359,7 +359,7 @@ func infoFromUrl(url *url.URL) *jobInfo {
 		case "view":
 			return infoForJobView(url)
 		}
-	case api.DomainForService(api.ServiceGCSWeb), api.DomainForService(api.ServiceGCSStorage):
+	case api.GCSWebPublicHost, api.DomainForService(api.ServiceGCSWeb), api.DomainForService(api.ServiceGCSStorage):
 		return infoForArtifact(url)
 	}
 	return nil
@@ -408,7 +408,7 @@ func infoForJobView(url *url.URL) *jobInfo {
 }
 
 // infoForArtifact handles URLs like:
-// https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/25585/pull-ci-openshift-origin-master-e2e-aws-disruptive/1319310480841379840/build-log.txt
+// https://gcs.ci.openshift.org/gcs/test-platform-results/pr-logs/pull/25585/pull-ci-openshift-origin-master-e2e-aws-disruptive/1319310480841379840/build-log.txt
 // https://storage.googleapis.com/test-platform-results/pr-logs/pull/openshift_cluster-ingress-operator/836/pull-ci-openshift-cluster-ingress-operator-master-e2e-aws-operator/1583384716713660416/build-log.txt
 func infoForArtifact(url *url.URL) *jobInfo {
 	parts := strings.Split(url.Path, "/")

--- a/pkg/slack/events/joblink/link_test.go
+++ b/pkg/slack/events/joblink/link_test.go
@@ -21,6 +21,10 @@ func TestExtractInfo(t *testing.T) {
 			expected: &jobInfo{Name: "pull-ci-openshift-installer-release-4.6-e2e-metal-ipi", Id: "1319125780608847872"},
 		},
 		{
+			link:     "https://gcs.ci.openshift.org/gcs/test-platform-results/pr-logs/pull/25585/pull-ci-openshift-origin-master-e2e-aws-disruptive/1319310480841379840/build-log.txt",
+			expected: &jobInfo{Name: "pull-ci-openshift-origin-master-e2e-aws-disruptive", Id: "1319310480841379840"},
+		},
+		{
 			link:     "https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/25585/pull-ci-openshift-origin-master-e2e-aws-disruptive/1319310480841379840/build-log.txt",
 			expected: &jobInfo{Name: "pull-ci-openshift-origin-master-e2e-aws-disruptive", Id: "1319310480841379840"},
 		},


### PR DESCRIPTION
Point pj-rehearse, jobrunaggregator, and slack-bot gcsweb links at gcs.ci.openshift.org; keep legacy openshiftapps host parsing for old URLs.

https://redhat.atlassian.net/browse/DPTP-5236
/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Use `gcs.ci.openshift.org` for public GCS web links in `pj-rehearse` and `jobrunaggregator`.
- Keep `slack-bot` support for GCS service, storage, and legacy `openshiftapps` URLs.
- Add test coverage for extracting job details from direct GCS build-log URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->