### PR TITLE
Ephemeral Cluster Controller: Name ProwJob after EphemeralCluster name

### DIFF
--- a/pkg/api/ephemeralcluster/v1/types.go
+++ b/pkg/api/ephemeralcluster/v1/types.go
@@ -37,10 +37,8 @@ const (
 	EventReasonProwJobSucceeded      = "ProwJobSucceeded"
 	EventReasonProwJobAborted        = "ProwJobAborted"
 
-	KonfluxClusterAnnotation  = "ephemeralcluster.ci.openshift.io/konflux-cluster"
-	KonfluxTenantAnnotation   = "ephemeralcluster.ci.openshift.io/konflux-tenant"
-	PipelineRunNameAnnotation = "ephemeralcluster.ci.openshift.io/pipeline-run-name"
-	TaskRunNameAnnotation     = "ephemeralcluster.ci.openshift.io/task-run-name"
+	KonfluxClusterAnnotation = "ephemeralcluster.ci.openshift.io/konflux-cluster"
+	KonfluxTenantAnnotation  = "ephemeralcluster.ci.openshift.io/konflux-tenant"
 )
 
 // Conditions
@@ -95,20 +93,6 @@ func (ec *EphemeralCluster) KonfluxCluster() string {
 
 func (ec *EphemeralCluster) KonfluxTenant() string {
 	if value, ok := ec.Annotations[KonfluxTenantAnnotation]; ok {
-		return value
-	}
-	return ""
-}
-
-func (ec *EphemeralCluster) PipelineRunName() string {
-	if value, ok := ec.Annotations[PipelineRunNameAnnotation]; ok {
-		return value
-	}
-	return ""
-}
-
-func (ec *EphemeralCluster) TaskRunName() string {
-	if value, ok := ec.Annotations[TaskRunNameAnnotation]; ok {
 		return value
 	}
 	return ""

--- a/pkg/controller/ephemeralcluster/reconciler.go
+++ b/pkg/controller/ephemeralcluster/reconciler.go
@@ -39,7 +39,6 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	ephemeralclusterv1 "github.com/openshift/ci-tools/pkg/api/ephemeralcluster/v1"
-	"github.com/openshift/ci-tools/pkg/jobconfig"
 	"github.com/openshift/ci-tools/pkg/load/agents"
 	"github.com/openshift/ci-tools/pkg/prowgen"
 	"github.com/openshift/ci-tools/pkg/steps"
@@ -601,21 +600,8 @@ func (r *reconciler) createProwJob(ctx context.Context, log *logrus.Entry, ec *e
 	return nil
 }
 
-func (r *reconciler) prowJobName(periodic *prowconfig.Periodic, ec *ephemeralclusterv1.EphemeralCluster) (string, error) {
-	if pipelineRunName := ec.PipelineRunName(); pipelineRunName != "" {
-		return ProwJobNamePrefix + "-ci-" + pipelineRunName, nil
-	}
-
-	if taskRunName := ec.TaskRunName(); taskRunName != "" {
-		return ProwJobNamePrefix + "-ci-" + taskRunName, nil
-	}
-
-	jobNameWithoutPrefix, prefixCut := strings.CutPrefix(periodic.JobBase.Name, jobconfig.PeriodicPrefix)
-	if !prefixCut {
-		return "", fmt.Errorf("failed to strip %s prefix from %s", jobconfig.PeriodicPrefix, periodic.JobBase.Name)
-	}
-
-	return ProwJobNamePrefix + jobNameWithoutPrefix, nil
+func (r *reconciler) prowJobName(periodic *prowconfig.Periodic, ec *ephemeralclusterv1.EphemeralCluster) string {
+	return ProwJobNamePrefix + "-ci-" + ec.Name
 }
 
 func (r *reconciler) makeProwJob(ciOperatorConfig *api.ReleaseBuildConfiguration, ec *ephemeralclusterv1.EphemeralCluster) (*prowv1.ProwJob, error) {
@@ -637,12 +623,7 @@ func (r *reconciler) makeProwJob(ciOperatorConfig *api.ReleaseBuildConfiguration
 		return nil, fmt.Errorf("default periodic: %w", err)
 	}
 
-	pjName, err := r.prowJobName(periodic, ec)
-	if err != nil {
-		return nil, fmt.Errorf("generate prowjob name: %w", err)
-	}
-
-	periodic.JobBase.Name = pjName
+	periodic.JobBase.Name = r.prowJobName(periodic, ec)
 	periodic.UtilityConfig.ExtraRefs = []prowv1.Refs{}
 
 	labels := make(map[string]string)

--- a/pkg/controller/ephemeralcluster/reconciler.go
+++ b/pkg/controller/ephemeralcluster/reconciler.go
@@ -600,7 +600,7 @@ func (r *reconciler) createProwJob(ctx context.Context, log *logrus.Entry, ec *e
 	return nil
 }
 
-func (r *reconciler) prowJobName(periodic *prowconfig.Periodic, ec *ephemeralclusterv1.EphemeralCluster) string {
+func (r *reconciler) prowJobName(ec *ephemeralclusterv1.EphemeralCluster) string {
 	return ProwJobNamePrefix + "-ci-" + ec.Name
 }
 
@@ -623,7 +623,7 @@ func (r *reconciler) makeProwJob(ciOperatorConfig *api.ReleaseBuildConfiguration
 		return nil, fmt.Errorf("default periodic: %w", err)
 	}
 
-	periodic.JobBase.Name = r.prowJobName(periodic, ec)
+	periodic.JobBase.Name = r.prowJobName(ec)
 	periodic.UtilityConfig.ExtraRefs = []prowv1.Refs{}
 
 	labels := make(map[string]string)

--- a/pkg/controller/ephemeralcluster/reconciler_test.go
+++ b/pkg/controller/ephemeralcluster/reconciler_test.go
@@ -181,9 +181,8 @@ func TestReconcileCreateProwJob(t *testing.T) {
 			ec: ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						ephemeralclusterv1.KonfluxClusterAnnotation:  "kcluster",
-						ephemeralclusterv1.KonfluxTenantAnnotation:   "ktenant",
-						ephemeralclusterv1.PipelineRunNameAnnotation: "pipeline-run-name",
+						ephemeralclusterv1.KonfluxClusterAnnotation: "kcluster",
+						ephemeralclusterv1.KonfluxTenantAnnotation:  "ktenant",
 					},
 					Namespace: "ns",
 					Name:      "ec",
@@ -331,9 +330,6 @@ func TestReconcileCreateProwJob(t *testing.T) {
 			name: "Hive cluster request creates a ProwJob",
 			ec: ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						ephemeralclusterv1.TaskRunNameAnnotation: "task-run-name",
-					},
 					Namespace: "ns",
 					Name:      "ec",
 				},

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestReconcileCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestReconcileCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
@@ -2,7 +2,6 @@ metadata:
   annotations:
     ephemeralcluster.ci.openshift.io/konflux-cluster: kcluster
     ephemeralcluster.ci.openshift.io/konflux-tenant: ktenant
-    ephemeralcluster.ci.openshift.io/pipeline-run-name: pipeline-run-name
   finalizers:
   - ephemeralcluster.ci.openshift.io/dependent-prowjob
   name: ec

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestReconcileCreateProwJob_Hive_cluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestReconcileCreateProwJob_Hive_cluster_request_creates_a_ProwJob.yaml
@@ -1,6 +1,4 @@
 metadata:
-  annotations:
-    ephemeralcluster.ci.openshift.io/task-run-name: task-run-name
   finalizers:
   - ephemeralcluster.ci.openshift.io/dependent-prowjob
   name: ec

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestReconcileCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestReconcileCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
@@ -2,7 +2,7 @@ items:
 - metadata:
     annotations:
       prow.k8s.io/context: ""
-      prow.k8s.io/job: ephemeralcluster-ci-pipeline-run-name
+      prow.k8s.io/job: ephemeralcluster-ci-ec
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: aws
@@ -10,7 +10,7 @@ items:
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       prow.k8s.io/context: ""
-      prow.k8s.io/job: ephemeralcluster-ci-pipeline-run-name
+      prow.k8s.io/job: ephemeralcluster-ci-ec
       prow.k8s.io/type: periodic
     name: foobar
     namespace: ci
@@ -29,7 +29,7 @@ items:
         entrypoint: entrypoint
         initupload: initupload
         sidecar: sidecar
-    job: ephemeralcluster-ci-pipeline-run-name
+    job: ephemeralcluster-ci-ec
     namespace: ci
     pod_spec:
       containers:

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestReconcileCreateProwJob_Hive_cluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestReconcileCreateProwJob_Hive_cluster_request_creates_a_ProwJob.yaml
@@ -2,13 +2,13 @@ items:
 - metadata:
     annotations:
       prow.k8s.io/context: ""
-      prow.k8s.io/job: ephemeralcluster-ci-task-run-name
+      prow.k8s.io/job: ephemeralcluster-ci-ec
     labels:
       ci.openshift.io/ephemeral-cluster: ec
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       prow.k8s.io/context: ""
-      prow.k8s.io/job: ephemeralcluster-ci-task-run-name
+      prow.k8s.io/job: ephemeralcluster-ci-ec
       prow.k8s.io/type: periodic
     name: foobar
     namespace: ci
@@ -27,7 +27,7 @@ items:
         entrypoint: entrypoint
         initupload: initupload
         sidecar: sidecar
-    job: ephemeralcluster-ci-task-run-name
+    job: ephemeralcluster-ci-ec
     namespace: ci
     pod_spec:
       containers:

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestReconcileCreateProwJob_Privileged_tenant.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestReconcileCreateProwJob_Privileged_tenant.yaml
@@ -2,7 +2,7 @@ items:
 - metadata:
     annotations:
       prow.k8s.io/context: ""
-      prow.k8s.io/job: ephemeralcluster-ci-org-repo-branch-cluster-provisioning
+      prow.k8s.io/job: ephemeralcluster-ci-ec
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: aws
@@ -10,7 +10,7 @@ items:
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       prow.k8s.io/context: ""
-      prow.k8s.io/job: ephemeralcluster-ci-org-repo-branch-cluster-provisioning
+      prow.k8s.io/job: ephemeralcluster-ci-ec
       prow.k8s.io/type: periodic
     name: foobar
     namespace: ci
@@ -29,7 +29,7 @@ items:
         entrypoint: entrypoint
         initupload: initupload
         sidecar: sidecar
-    job: ephemeralcluster-ci-org-repo-branch-cluster-provisioning
+    job: ephemeralcluster-ci-ec
     namespace: ci
     pod_spec:
       containers:


### PR DESCRIPTION
As of today, the ProwJob name is fixed to `ephemeralcluster-ci-org-repo-branch-cluster-provisioning`, with this PR it matches the following pattern:
```
ephemeralcluster-ci-${EPHEMERAL_CLUSTER_NAME}
```
In this way we can leverage `prow-job-dispatcher` to properly dispatch PJs across the cluster fleet.

By keeping the name fixed to `ephemeralcluster-ci-org-repo-branch-cluster-provisioning`, every PJ would end up being scheduled on a fixed cluster for the entire `prow-job-dispatcher` cache TTL (24h see [here](https://github.com/openshift/ci-tools/blob/89470df172f0167b30053077d9a94a66d1200107/pkg/dispatcher/ephemeralcluster.go#L41-L69)), even it belongs to different Konflux test/pipeline/whatever.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

The Ephemeral Cluster Controller now names ProwJobs with `ephemeralcluster-ci-${EPHEMERAL_CLUSTER_NAME}`.

This allows `prow-job-dispatcher` to route jobs to the correct cluster across the fleet. It also prevents different tests or pipelines from sharing a cluster because of the dispatcher cache.

The change removes obsolete PipelineRun and TaskRun naming annotations and accessors. Reconciliation fixtures now use the EphemeralCluster name in ProwJob metadata and specifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->