### PR TITLE
gsm-secret-sync: fix IAM binding limits and support unclaimed collections

### DIFF
--- a/pkg/group/config.go
+++ b/pkg/group/config.go
@@ -34,6 +34,10 @@ type Target struct {
 	ClusterGroups []string `json:"cluster_groups,omitempty" yaml:"cluster_groups,omitempty"`
 	// SecretCollections are the secret collections the group has access to.
 	SecretCollections []string `json:"secret_collections,omitempty" yaml:"secret_collections,omitempty"`
+	// Unclaimed marks a group as a holding area for secret collections that no team owns yet.
+	// The gsm-secret-sync reconciler keeps these collections' secrets alive but creates no
+	// updater service account and no IAM bindings for them until they are moved under a normal group.
+	Unclaimed bool `json:"unclaimed,omitempty" yaml:"unclaimed,omitempty"`
 }
 
 func (t Target) ResolveClusters(cg map[string][]string) sets.Set[string] {

--- a/pkg/gsm-secrets/config.go
+++ b/pkg/gsm-secrets/config.go
@@ -14,11 +14,15 @@ import (
 
 // GetDesiredState parses the configuration file and builds the desired state specifications.
 //
-// Each collection referenced by a group gets an updater service account, its SA secret, an index
-// secret, and service-account-scoped viewer/updater bindings limited to that single collection.
-// Each owning group additionally gets its own viewer/updater bindings; a group's collections are
-// chunked (at most MaxCollectionsPerGroupBinding per binding) so no single binding exceeds GCP's
-// IAM limits on operators per condition and bindings per role+member.
+// Collections owned by a normal ("claimed") group each get an updater service account, its SA
+// secret, an index secret, and service-account-scoped viewer/updater bindings limited to that
+// single collection. Each owning group additionally gets its own viewer/updater bindings; a
+// group's collections are chunked (at most MaxCollectionsPerGroupBinding per binding) so no
+// single binding exceeds GCP's IAM limits on operators per condition and bindings per role+member.
+//
+// Collections owned only by an "unclaimed" group (see group.Target.Unclaimed) are kept in the
+// active-collection set so their migrated data secrets are not deleted, but they get no service
+// account, no SA/index secrets, and no bindings until they are moved under a normal group.
 //
 // Returns desired service account specs, secret specs, IAM binding specs, and the set of active collections.
 func GetDesiredState(configFile string, config Config) ([]ServiceAccountInfo, map[string]GCPSecret, []*iampb.Binding, map[string]bool, error) {
@@ -33,9 +37,15 @@ func GetDesiredState(configFile string, config Config) ([]ServiceAccountInfo, ma
 	}
 	sort.Strings(groupNames)
 
-	collections := sets.New[string]()
+	claimedCollections := sets.New[string]()
+	unclaimedCollections := sets.New[string]()
 	for _, name := range groupNames {
-		collections.Insert(groupConfig.Groups[name].SecretCollections...)
+		groupCfg := groupConfig.Groups[name]
+		if groupCfg.Unclaimed {
+			unclaimedCollections.Insert(groupCfg.SecretCollections...)
+			continue
+		}
+		claimedCollections.Insert(groupCfg.SecretCollections...)
 	}
 
 	var desiredSAs []ServiceAccountInfo
@@ -43,15 +53,17 @@ func GetDesiredState(configFile string, config Config) ([]ServiceAccountInfo, ma
 	desiredCollections := make(map[string]bool)
 	var desiredIAMBindings []*iampb.Binding
 
-	for _, collection := range collections.UnsortedList() {
+	// Keep every referenced collection alive so its migrated data secrets are not deleted,
+	// including unclaimed collections that have no service account or bindings yet.
+	for _, collection := range claimedCollections.Union(unclaimedCollections).UnsortedList() {
 		desiredCollections[collection] = true
 	}
 
-	// Per collection: an updater service account, its SA secret, an index secret, and
+	// Per claimed collection: an updater service account, its SA secret, an index secret, and
 	// service-account-scoped viewer/updater bindings limited to that single collection. The
 	// service account is given its own bindings rather than being grouped with the owning group,
 	// so its access stays scoped to exactly one collection.
-	for _, collection := range sets.List(collections) {
+	for _, collection := range sets.List(claimedCollections) {
 		desiredSAs = append(desiredSAs, ServiceAccountInfo{
 			Email:       GetUpdaterSAEmail(collection, config),
 			DisplayName: GetUpdaterSADisplayName(collection),
@@ -96,7 +108,7 @@ func GetDesiredState(configFile string, config Config) ([]ServiceAccountInfo, ma
 	// binding condition stays within GCP's IAM limits.
 	for _, name := range groupNames {
 		groupCfg := groupConfig.Groups[name]
-		if len(groupCfg.SecretCollections) == 0 {
+		if groupCfg.Unclaimed || len(groupCfg.SecretCollections) == 0 {
 			continue
 		}
 		email := fmt.Sprintf("%s@redhat.com", name)

--- a/pkg/gsm-secrets/config.go
+++ b/pkg/gsm-secrets/config.go
@@ -7,34 +7,35 @@ import (
 	"cloud.google.com/go/iam/apiv1/iampb"
 	"google.golang.org/genproto/googleapis/type/expr"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/openshift/ci-tools/pkg/group"
 )
 
 // GetDesiredState parses the configuration file and builds the desired state specifications.
-// For each unique secret collection referenced by groups, it generates the required resource definitions.
+//
+// Each collection referenced by a group gets an updater service account, its SA secret, an index
+// secret, and service-account-scoped viewer/updater bindings limited to that single collection.
+// Each owning group additionally gets its own viewer/updater bindings; a group's collections are
+// chunked (at most MaxCollectionsPerGroupBinding per binding) so no single binding exceeds GCP's
+// IAM limits on operators per condition and bindings per role+member.
+//
 // Returns desired service account specs, secret specs, IAM binding specs, and the set of active collections.
 func GetDesiredState(configFile string, config Config) ([]ServiceAccountInfo, map[string]GCPSecret, []*iampb.Binding, map[string]bool, error) {
 	groupConfig, err := group.LoadConfig(configFile)
 	if err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("failed to load file: %w", err)
 	}
-	collectionsMap := make(map[string]DesiredCollection)
 
-	for name, groupCfg := range groupConfig.Groups {
-		email := fmt.Sprintf("%s@redhat.com", name)
+	var groupNames []string
+	for name := range groupConfig.Groups {
+		groupNames = append(groupNames, name)
+	}
+	sort.Strings(groupNames)
 
-		for _, collection := range groupCfg.SecretCollections {
-			if _, found := collectionsMap[collection]; !found {
-				collectionsMap[collection] = DesiredCollection{
-					Name:             collection,
-					GroupsWithAccess: []string{email},
-				}
-			} else {
-				col := collectionsMap[collection]
-				col.GroupsWithAccess = append(col.GroupsWithAccess, email)
-				collectionsMap[collection] = col
-			}
-		}
+	collections := sets.New[string]()
+	for _, name := range groupNames {
+		collections.Insert(groupConfig.Groups[name].SecretCollections...)
 	}
 
 	var desiredSAs []ServiceAccountInfo
@@ -42,61 +43,89 @@ func GetDesiredState(configFile string, config Config) ([]ServiceAccountInfo, ma
 	desiredCollections := make(map[string]bool)
 	var desiredIAMBindings []*iampb.Binding
 
-	var collectionNames []string
-	for name := range collectionsMap {
-		collectionNames = append(collectionNames, name)
+	for _, collection := range collections.UnsortedList() {
+		desiredCollections[collection] = true
 	}
-	sort.Strings(collectionNames)
 
-	for _, collectionName := range collectionNames {
-		collection := collectionsMap[collectionName]
-		desiredCollections[collection.Name] = true
-
+	// Per collection: an updater service account, its SA secret, an index secret, and
+	// service-account-scoped viewer/updater bindings limited to that single collection. The
+	// service account is given its own bindings rather than being grouped with the owning group,
+	// so its access stays scoped to exactly one collection.
+	for _, collection := range sets.List(collections) {
 		desiredSAs = append(desiredSAs, ServiceAccountInfo{
-			Email:       GetUpdaterSAEmail(collection.Name, config),
-			DisplayName: GetUpdaterSADisplayName(collection.Name),
-			ID:          GetUpdaterSAId(collection.Name),
-			Collection:  collection.Name,
-			Description: GetUpdaterSADescription(collection.Name),
+			Email:       GetUpdaterSAEmail(collection, config),
+			DisplayName: GetUpdaterSADisplayName(collection),
+			ID:          GetUpdaterSAId(collection),
+			Collection:  collection,
+			Description: GetUpdaterSADescription(collection),
 		})
 
-		desiredSecrets[GetUpdaterSASecretName(collection.Name)] = GCPSecret{
-			Name:       GetUpdaterSASecretName(collection.Name),
+		desiredSecrets[GetUpdaterSASecretName(collection)] = GCPSecret{
+			Name:       GetUpdaterSASecretName(collection),
 			Type:       SecretTypeSA,
-			Collection: collection.Name,
+			Collection: collection,
 		}
-
-		desiredSecrets[GetIndexSecretName(collection.Name)] = GCPSecret{
-			Name:       GetIndexSecretName(collection.Name),
+		desiredSecrets[GetIndexSecretName(collection)] = GCPSecret{
+			Name:       GetIndexSecretName(collection),
 			Type:       SecretTypeIndex,
-			Collection: collection.Name,
+			Collection: collection,
 		}
 
-		var members []string
-		for _, groupWithAccess := range collection.GroupsWithAccess {
-			members = append(members, fmt.Sprintf("group:%s", groupWithAccess))
-		}
-		members = append(members, fmt.Sprintf("serviceAccount:%s", GetUpdaterSAEmail(collection.Name, config)))
-		sort.Strings(members)
-
+		saMembers := []string{fmt.Sprintf("serviceAccount:%s", GetUpdaterSAEmail(collection, config))}
 		desiredIAMBindings = append(desiredIAMBindings, &iampb.Binding{
 			Role:    config.GetSecretAccessorRole(),
-			Members: members,
+			Members: saMembers,
 			Condition: &expr.Expr{
-				Expression:  BuildSecretAccessorRoleConditionExpression(collection.Name),
-				Title:       GetSecretsViewerConditionTitle(collection.Name),
-				Description: GetSecretsViewerConditionDescription(collection.Name),
+				Expression:  BuildSecretAccessorRoleConditionExpression(collection),
+				Title:       GetSecretsViewerConditionTitle(collection),
+				Description: GetSecretsViewerConditionDescription(collection),
 			},
 		})
 		desiredIAMBindings = append(desiredIAMBindings, &iampb.Binding{
 			Role:    config.GetSecretUpdaterRole(),
-			Members: members,
+			Members: saMembers,
 			Condition: &expr.Expr{
-				Expression:  BuildSecretUpdaterRoleConditionExpression(collection.Name),
-				Title:       GetSecretsUpdaterConditionTitle(collection.Name),
-				Description: GetSecretsUpdaterConditionDescription(collection.Name),
+				Expression:  BuildSecretUpdaterRoleConditionExpression(collection),
+				Title:       GetSecretsUpdaterConditionTitle(collection),
+				Description: GetSecretsUpdaterConditionDescription(collection),
 			},
 		})
+	}
+
+	// Per claimed group: viewer/updater bindings for the group principal, chunked so each
+	// binding condition stays within GCP's IAM limits.
+	for _, name := range groupNames {
+		groupCfg := groupConfig.Groups[name]
+		if len(groupCfg.SecretCollections) == 0 {
+			continue
+		}
+		email := fmt.Sprintf("%s@redhat.com", name)
+		groupMembers := []string{fmt.Sprintf("group:%s", email)}
+
+		collections := make([]string, len(groupCfg.SecretCollections))
+		copy(collections, groupCfg.SecretCollections)
+		sort.Strings(collections)
+
+		for chunkIdx, chunk := range chunkCollections(collections, MaxCollectionsPerGroupBinding) {
+			desiredIAMBindings = append(desiredIAMBindings, &iampb.Binding{
+				Role:    config.GetSecretAccessorRole(),
+				Members: groupMembers,
+				Condition: &expr.Expr{
+					Expression:  BuildSecretAccessorRoleConditionExpressionForCollections(chunk),
+					Title:       GetSecretsViewerGroupConditionTitle(name, chunkIdx),
+					Description: GetSecretsViewerGroupConditionDescription(name, chunkIdx),
+				},
+			})
+			desiredIAMBindings = append(desiredIAMBindings, &iampb.Binding{
+				Role:    config.GetSecretUpdaterRole(),
+				Members: groupMembers,
+				Condition: &expr.Expr{
+					Expression:  BuildSecretUpdaterRoleConditionExpressionForCollections(chunk),
+					Title:       GetSecretsUpdaterGroupConditionTitle(name, chunkIdx),
+					Description: GetSecretsUpdaterGroupConditionDescription(name, chunkIdx),
+				},
+			})
+		}
 	}
 
 	return desiredSAs, desiredSecrets, desiredIAMBindings, desiredCollections, nil

--- a/pkg/gsm-secrets/config_test.go
+++ b/pkg/gsm-secrets/config_test.go
@@ -31,6 +31,10 @@ func TestGetDesiredState(t *testing.T) {
 			name:       "complex config",
 			configFile: "testdata/complex-config.yaml",
 		},
+		{
+			name:       "chunked config",
+			configFile: "testdata/chunked-config.yaml",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/gsm-secrets/config_test.go
+++ b/pkg/gsm-secrets/config_test.go
@@ -35,6 +35,10 @@ func TestGetDesiredState(t *testing.T) {
 			name:       "chunked config",
 			configFile: "testdata/chunked-config.yaml",
 		},
+		{
+			name:       "unclaimed config",
+			configFile: "testdata/unclaimed-config.yaml",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/gsm-secrets/iam.go
+++ b/pkg/gsm-secrets/iam.go
@@ -36,9 +36,75 @@ func BuildSecretUpdaterRoleConditionExpression(collection string) string {
   resource.name.extract("secrets/{secret}").startsWith("%s__")`, collection)
 }
 
+// BuildSecretAccessorRoleConditionExpressionForCollections builds the viewer IAM condition
+// expression covering multiple collections. It is used for group bindings, where a group's
+// collections are chunked to keep the number of logical operators within GCP's limits.
+func BuildSecretAccessorRoleConditionExpressionForCollections(collections []string) string {
+	var terms []string
+	for _, collection := range collections {
+		terms = append(terms,
+			fmt.Sprintf(`  resource.name.extract("secrets/{secret}") == "%s%s"`, collection, UpdaterSASecretSuffix),
+			fmt.Sprintf(`  resource.name.extract("secrets/{secret}") == "%s%s"`, collection, IndexSecretSuffix),
+		)
+	}
+	return fmt.Sprintf(`(
+  resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+  resource.type == "secretmanager.googleapis.com/Secret"
+) && (
+%s
+)`, strings.Join(terms, " ||\n"))
+}
+
+// BuildSecretUpdaterRoleConditionExpressionForCollections builds the updater IAM condition
+// expression covering multiple collections. It is used for group bindings, where a group's
+// collections are chunked to keep the number of logical operators within GCP's limits.
+func BuildSecretUpdaterRoleConditionExpressionForCollections(collections []string) string {
+	var terms []string
+	for _, collection := range collections {
+		terms = append(terms, fmt.Sprintf(`  resource.name.extract("secrets/{secret}").startsWith("%s__")`, collection))
+	}
+	return fmt.Sprintf(`(
+  resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+  resource.type == "secretmanager.googleapis.com/Secret"
+) && (
+%s
+)`, strings.Join(terms, " ||\n"))
+}
+
+// chunkCollections splits a sorted slice of collections into consecutive chunks of at most
+// size. Chunking is deterministic so binding conditions stay stable across reconciler runs.
+func chunkCollections(collections []string, size int) [][]string {
+	var chunks [][]string
+	for i := 0; i < len(collections); i += size {
+		end := min(i+size, len(collections))
+		chunks = append(chunks, collections[i:end])
+	}
+	return chunks
+}
+
 // GetSecretsViewerConditionTitle returns the condition title for secrets viewer role
 func GetSecretsViewerConditionTitle(collection string) string {
 	return fmt.Sprintf("%s%s", SecretsViewerConditionTitlePrefix, collection)
+}
+
+// GetSecretsViewerGroupConditionTitle returns the viewer condition title for a group binding chunk.
+func GetSecretsViewerGroupConditionTitle(group string, chunkIdx int) string {
+	return fmt.Sprintf("%sgroup %s (set %d)", SecretsViewerConditionTitlePrefix, group, chunkIdx+1)
+}
+
+// GetSecretsUpdaterGroupConditionTitle returns the updater condition title for a group binding chunk.
+func GetSecretsUpdaterGroupConditionTitle(group string, chunkIdx int) string {
+	return fmt.Sprintf("%sgroup %s (set %d)", SecretsUpdaterConditionTitlePrefix, group, chunkIdx+1)
+}
+
+// GetSecretsViewerGroupConditionDescription returns the viewer condition description for a group binding chunk.
+func GetSecretsViewerGroupConditionDescription(group string, chunkIdx int) string {
+	return fmt.Sprintf("Managed by %s: Read access to secrets for group %s (set %d)", TestPlatform, group, chunkIdx+1)
+}
+
+// GetSecretsUpdaterGroupConditionDescription returns the updater condition description for a group binding chunk.
+func GetSecretsUpdaterGroupConditionDescription(group string, chunkIdx int) string {
+	return fmt.Sprintf("Managed by %s: Create, update, and delete access to secrets for group %s (set %d)", TestPlatform, group, chunkIdx+1)
 }
 
 // GetSecretsUpdaterConditionTitle returns the condition title for secrets updater role

--- a/pkg/gsm-secrets/iam_test.go
+++ b/pkg/gsm-secrets/iam_test.go
@@ -168,6 +168,47 @@ func TestToCanonicalIAMBinding(t *testing.T) {
 	}
 }
 
+func TestChunkCollections(t *testing.T) {
+	testCases := []struct {
+		name        string
+		collections []string
+		size        int
+		expected    [][]string
+	}{
+		{
+			name:        "empty",
+			collections: nil,
+			size:        5,
+			expected:    nil,
+		},
+		{
+			name:        "fewer than size",
+			collections: []string{"a", "b"},
+			size:        5,
+			expected:    [][]string{{"a", "b"}},
+		},
+		{
+			name:        "exact multiple of size",
+			collections: []string{"a", "b", "c", "d"},
+			size:        2,
+			expected:    [][]string{{"a", "b"}, {"c", "d"}},
+		},
+		{
+			name:        "size with remainder",
+			collections: []string{"a", "b", "c", "d", "e"},
+			size:        2,
+			expected:    [][]string{{"a", "b"}, {"c", "d"}, {"e"}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := chunkCollections(tc.collections, tc.size)
+			testhelper.Diff(t, "chunks", actual, tc.expected)
+		})
+	}
+}
+
 func TestIsManagedBinding(t *testing.T) {
 	config := Config{
 		ProjectIdString: "test-project",
@@ -245,6 +286,32 @@ func TestIsManagedBinding(t *testing.T) {
 				},
 			},
 			expected: false,
+		},
+		{
+			name: "group viewer binding chunk",
+			binding: &iampb.Binding{
+				Role:    config.GetSecretAccessorRole(),
+				Members: []string{"group:team-x@redhat.com"},
+				Condition: &expr.Expr{
+					Title:       GetSecretsViewerGroupConditionTitle("team-x", 0),
+					Description: GetSecretsViewerGroupConditionDescription("team-x", 0),
+					Expression:  BuildSecretAccessorRoleConditionExpressionForCollections([]string{"a", "b"}),
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "group updater binding chunk",
+			binding: &iampb.Binding{
+				Role:    config.GetSecretUpdaterRole(),
+				Members: []string{"group:team-x@redhat.com"},
+				Condition: &expr.Expr{
+					Title:       GetSecretsUpdaterGroupConditionTitle("team-x", 1),
+					Description: GetSecretsUpdaterGroupConditionDescription("team-x", 1),
+					Expression:  BuildSecretUpdaterRoleConditionExpressionForCollections([]string{"a", "b"}),
+				},
+			},
+			expected: true,
 		},
 	}
 

--- a/pkg/gsm-secrets/testdata/chunked-config.yaml
+++ b/pkg/gsm-secrets/testdata/chunked-config.yaml
@@ -1,0 +1,22 @@
+groups:
+  big-team:
+    secret_collections:
+    - bt-01
+    - bt-02
+    - bt-03
+    - bt-04
+    - bt-05
+    - bt-06
+    - bt-07
+    - bt-08
+    - bt-09
+    - bt-10
+    - bt-11
+    - bt-12
+  small-team:
+    secret_collections:
+    - st-01
+  another-team:
+    secret_collections:
+    - bt-01
+    - at-01

--- a/pkg/gsm-secrets/testdata/unclaimed-config.yaml
+++ b/pkg/gsm-secrets/testdata/unclaimed-config.yaml
@@ -1,0 +1,11 @@
+groups:
+  owner-team:
+    secret_collections:
+    - claimed-a
+    - claimed-b
+  test-platform-gsm-unclaimed-secrets:
+    unclaimed: true
+    secret_collections:
+    - unclaimed-x
+    - unclaimed-y
+    - claimed-a

--- a/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_basic_config.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_basic_config.yaml
@@ -11,7 +11,6 @@
       )
     title: Read access to secrets for collection-alpha
   members:
-  - group:team-alpha@redhat.com
   - serviceAccount:collection-alpha-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_viewer
 - condition:
@@ -21,7 +20,6 @@
       ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"collection-alpha__\")"
     title: Create, update, and delete access for collection-alpha
   members:
-  - group:team-alpha@redhat.com
   - serviceAccount:collection-alpha-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
@@ -37,8 +35,6 @@
       )
     title: Read access to secrets for shared-collection
   members:
-  - group:team-alpha@redhat.com
-  - group:team-beta@redhat.com
   - serviceAccount:shared-collection-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_viewer
 - condition:
@@ -48,8 +44,6 @@
       ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"shared-collection__\")"
     title: Create, update, and delete access for shared-collection
   members:
-  - group:team-alpha@redhat.com
-  - group:team-beta@redhat.com
   - serviceAccount:shared-collection-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
@@ -65,7 +59,6 @@
       )
     title: Read access to secrets for some-collection-with-a-very-long-name
   members:
-  - group:team-beta@redhat.com
   - serviceAccount:ynbbgzp1q3u3iwp8edyqix-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_viewer
 - condition:
@@ -75,6 +68,69 @@
       ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"some-collection-with-a-very-long-name__\")"
     title: Create, update, and delete access for some-collection-with-a-very-long-name
   members:
-  - group:team-beta@redhat.com
   - serviceAccount:ynbbgzp1q3u3iwp8edyqix-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater
+- condition:
+    description: 'Managed by test platform: Read access to secrets for group team-alpha
+      (set 1)'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "collection-alpha__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "collection-alpha____index" ||
+        resource.name.extract("secrets/{secret}") == "shared-collection__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "shared-collection____index"
+      )
+    title: Read access to secrets for group team-alpha (set 1)
+  members:
+  - group:team-alpha@redhat.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      for group team-alpha (set 1)'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}").startsWith("collection-alpha__") ||
+        resource.name.extract("secrets/{secret}").startsWith("shared-collection__")
+      )
+    title: Create, update, and delete access for group team-alpha (set 1)
+  members:
+  - group:team-alpha@redhat.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater
+- condition:
+    description: 'Managed by test platform: Read access to secrets for group team-beta
+      (set 1)'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "shared-collection__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "shared-collection____index" ||
+        resource.name.extract("secrets/{secret}") == "some-collection-with-a-very-long-name__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "some-collection-with-a-very-long-name____index"
+      )
+    title: Read access to secrets for group team-beta (set 1)
+  members:
+  - group:team-beta@redhat.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      for group team-beta (set 1)'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}").startsWith("shared-collection__") ||
+        resource.name.extract("secrets/{secret}").startsWith("some-collection-with-a-very-long-name__")
+      )
+    title: Create, update, and delete access for group team-beta (set 1)
+  members:
+  - group:team-beta@redhat.com
   role: projects/test-project/roles/openshift_ci_secrets_updater

--- a/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_chunked_config.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_chunked_config.yaml
@@ -1,0 +1,497 @@
+- condition:
+    description: 'Managed by test platform: Read access to secrets in at-01 collection'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "at-01__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "at-01____index"
+      )
+    title: Read access to secrets for at-01
+  members:
+  - serviceAccount:at-01-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      in at-01 collection'
+    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
+      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"at-01__\")"
+    title: Create, update, and delete access for at-01
+  members:
+  - serviceAccount:at-01-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater
+- condition:
+    description: 'Managed by test platform: Read access to secrets in bt-01 collection'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "bt-01__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "bt-01____index"
+      )
+    title: Read access to secrets for bt-01
+  members:
+  - serviceAccount:bt-01-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      in bt-01 collection'
+    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
+      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"bt-01__\")"
+    title: Create, update, and delete access for bt-01
+  members:
+  - serviceAccount:bt-01-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater
+- condition:
+    description: 'Managed by test platform: Read access to secrets in bt-02 collection'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "bt-02__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "bt-02____index"
+      )
+    title: Read access to secrets for bt-02
+  members:
+  - serviceAccount:bt-02-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      in bt-02 collection'
+    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
+      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"bt-02__\")"
+    title: Create, update, and delete access for bt-02
+  members:
+  - serviceAccount:bt-02-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater
+- condition:
+    description: 'Managed by test platform: Read access to secrets in bt-03 collection'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "bt-03__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "bt-03____index"
+      )
+    title: Read access to secrets for bt-03
+  members:
+  - serviceAccount:bt-03-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      in bt-03 collection'
+    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
+      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"bt-03__\")"
+    title: Create, update, and delete access for bt-03
+  members:
+  - serviceAccount:bt-03-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater
+- condition:
+    description: 'Managed by test platform: Read access to secrets in bt-04 collection'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "bt-04__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "bt-04____index"
+      )
+    title: Read access to secrets for bt-04
+  members:
+  - serviceAccount:bt-04-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      in bt-04 collection'
+    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
+      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"bt-04__\")"
+    title: Create, update, and delete access for bt-04
+  members:
+  - serviceAccount:bt-04-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater
+- condition:
+    description: 'Managed by test platform: Read access to secrets in bt-05 collection'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "bt-05__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "bt-05____index"
+      )
+    title: Read access to secrets for bt-05
+  members:
+  - serviceAccount:bt-05-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      in bt-05 collection'
+    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
+      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"bt-05__\")"
+    title: Create, update, and delete access for bt-05
+  members:
+  - serviceAccount:bt-05-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater
+- condition:
+    description: 'Managed by test platform: Read access to secrets in bt-06 collection'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "bt-06__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "bt-06____index"
+      )
+    title: Read access to secrets for bt-06
+  members:
+  - serviceAccount:bt-06-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      in bt-06 collection'
+    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
+      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"bt-06__\")"
+    title: Create, update, and delete access for bt-06
+  members:
+  - serviceAccount:bt-06-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater
+- condition:
+    description: 'Managed by test platform: Read access to secrets in bt-07 collection'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "bt-07__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "bt-07____index"
+      )
+    title: Read access to secrets for bt-07
+  members:
+  - serviceAccount:bt-07-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      in bt-07 collection'
+    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
+      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"bt-07__\")"
+    title: Create, update, and delete access for bt-07
+  members:
+  - serviceAccount:bt-07-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater
+- condition:
+    description: 'Managed by test platform: Read access to secrets in bt-08 collection'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "bt-08__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "bt-08____index"
+      )
+    title: Read access to secrets for bt-08
+  members:
+  - serviceAccount:bt-08-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      in bt-08 collection'
+    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
+      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"bt-08__\")"
+    title: Create, update, and delete access for bt-08
+  members:
+  - serviceAccount:bt-08-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater
+- condition:
+    description: 'Managed by test platform: Read access to secrets in bt-09 collection'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "bt-09__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "bt-09____index"
+      )
+    title: Read access to secrets for bt-09
+  members:
+  - serviceAccount:bt-09-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      in bt-09 collection'
+    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
+      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"bt-09__\")"
+    title: Create, update, and delete access for bt-09
+  members:
+  - serviceAccount:bt-09-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater
+- condition:
+    description: 'Managed by test platform: Read access to secrets in bt-10 collection'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "bt-10__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "bt-10____index"
+      )
+    title: Read access to secrets for bt-10
+  members:
+  - serviceAccount:bt-10-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      in bt-10 collection'
+    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
+      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"bt-10__\")"
+    title: Create, update, and delete access for bt-10
+  members:
+  - serviceAccount:bt-10-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater
+- condition:
+    description: 'Managed by test platform: Read access to secrets in bt-11 collection'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "bt-11__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "bt-11____index"
+      )
+    title: Read access to secrets for bt-11
+  members:
+  - serviceAccount:bt-11-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      in bt-11 collection'
+    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
+      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"bt-11__\")"
+    title: Create, update, and delete access for bt-11
+  members:
+  - serviceAccount:bt-11-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater
+- condition:
+    description: 'Managed by test platform: Read access to secrets in bt-12 collection'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "bt-12__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "bt-12____index"
+      )
+    title: Read access to secrets for bt-12
+  members:
+  - serviceAccount:bt-12-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      in bt-12 collection'
+    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
+      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"bt-12__\")"
+    title: Create, update, and delete access for bt-12
+  members:
+  - serviceAccount:bt-12-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater
+- condition:
+    description: 'Managed by test platform: Read access to secrets in st-01 collection'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "st-01__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "st-01____index"
+      )
+    title: Read access to secrets for st-01
+  members:
+  - serviceAccount:st-01-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      in st-01 collection'
+    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
+      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"st-01__\")"
+    title: Create, update, and delete access for st-01
+  members:
+  - serviceAccount:st-01-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater
+- condition:
+    description: 'Managed by test platform: Read access to secrets for group another-team
+      (set 1)'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "at-01__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "at-01____index" ||
+        resource.name.extract("secrets/{secret}") == "bt-01__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "bt-01____index"
+      )
+    title: Read access to secrets for group another-team (set 1)
+  members:
+  - group:another-team@redhat.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      for group another-team (set 1)'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}").startsWith("at-01__") ||
+        resource.name.extract("secrets/{secret}").startsWith("bt-01__")
+      )
+    title: Create, update, and delete access for group another-team (set 1)
+  members:
+  - group:another-team@redhat.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater
+- condition:
+    description: 'Managed by test platform: Read access to secrets for group big-team
+      (set 1)'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "bt-01__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "bt-01____index" ||
+        resource.name.extract("secrets/{secret}") == "bt-02__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "bt-02____index" ||
+        resource.name.extract("secrets/{secret}") == "bt-03__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "bt-03____index" ||
+        resource.name.extract("secrets/{secret}") == "bt-04__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "bt-04____index" ||
+        resource.name.extract("secrets/{secret}") == "bt-05__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "bt-05____index"
+      )
+    title: Read access to secrets for group big-team (set 1)
+  members:
+  - group:big-team@redhat.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      for group big-team (set 1)'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}").startsWith("bt-01__") ||
+        resource.name.extract("secrets/{secret}").startsWith("bt-02__") ||
+        resource.name.extract("secrets/{secret}").startsWith("bt-03__") ||
+        resource.name.extract("secrets/{secret}").startsWith("bt-04__") ||
+        resource.name.extract("secrets/{secret}").startsWith("bt-05__")
+      )
+    title: Create, update, and delete access for group big-team (set 1)
+  members:
+  - group:big-team@redhat.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater
+- condition:
+    description: 'Managed by test platform: Read access to secrets for group big-team
+      (set 2)'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "bt-06__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "bt-06____index" ||
+        resource.name.extract("secrets/{secret}") == "bt-07__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "bt-07____index" ||
+        resource.name.extract("secrets/{secret}") == "bt-08__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "bt-08____index" ||
+        resource.name.extract("secrets/{secret}") == "bt-09__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "bt-09____index" ||
+        resource.name.extract("secrets/{secret}") == "bt-10__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "bt-10____index"
+      )
+    title: Read access to secrets for group big-team (set 2)
+  members:
+  - group:big-team@redhat.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      for group big-team (set 2)'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}").startsWith("bt-06__") ||
+        resource.name.extract("secrets/{secret}").startsWith("bt-07__") ||
+        resource.name.extract("secrets/{secret}").startsWith("bt-08__") ||
+        resource.name.extract("secrets/{secret}").startsWith("bt-09__") ||
+        resource.name.extract("secrets/{secret}").startsWith("bt-10__")
+      )
+    title: Create, update, and delete access for group big-team (set 2)
+  members:
+  - group:big-team@redhat.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater
+- condition:
+    description: 'Managed by test platform: Read access to secrets for group big-team
+      (set 3)'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "bt-11__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "bt-11____index" ||
+        resource.name.extract("secrets/{secret}") == "bt-12__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "bt-12____index"
+      )
+    title: Read access to secrets for group big-team (set 3)
+  members:
+  - group:big-team@redhat.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      for group big-team (set 3)'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}").startsWith("bt-11__") ||
+        resource.name.extract("secrets/{secret}").startsWith("bt-12__")
+      )
+    title: Create, update, and delete access for group big-team (set 3)
+  members:
+  - group:big-team@redhat.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater
+- condition:
+    description: 'Managed by test platform: Read access to secrets for group small-team
+      (set 1)'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "st-01__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "st-01____index"
+      )
+    title: Read access to secrets for group small-team (set 1)
+  members:
+  - group:small-team@redhat.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      for group small-team (set 1)'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}").startsWith("st-01__")
+      )
+    title: Create, update, and delete access for group small-team (set 1)
+  members:
+  - group:small-team@redhat.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater

--- a/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_complex_config.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_complex_config.yaml
@@ -11,7 +11,6 @@
       )
     title: Read access to secrets for alpha-secrets
   members:
-  - group:team-alpha@redhat.com
   - serviceAccount:alpha-secrets-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_viewer
 - condition:
@@ -21,7 +20,6 @@
       ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"alpha-secrets__\")"
     title: Create, update, and delete access for alpha-secrets
   members:
-  - group:team-alpha@redhat.com
   - serviceAccount:alpha-secrets-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
@@ -37,8 +35,6 @@
       )
     title: Read access to secrets for beta-delta-secrets
   members:
-  - group:team-beta@redhat.com
-  - group:team-delta@redhat.com
   - serviceAccount:beta-delta-secrets-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_viewer
 - condition:
@@ -48,8 +44,6 @@
       ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"beta-delta-secrets__\")"
     title: Create, update, and delete access for beta-delta-secrets
   members:
-  - group:team-beta@redhat.com
-  - group:team-delta@redhat.com
   - serviceAccount:beta-delta-secrets-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
@@ -65,7 +59,6 @@
       )
     title: Read access to secrets for epsilon-secrets
   members:
-  - group:team-epsilon@redhat.com
   - serviceAccount:epsilon-secrets-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_viewer
 - condition:
@@ -75,6 +68,121 @@
       ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"epsilon-secrets__\")"
     title: Create, update, and delete access for epsilon-secrets
   members:
-  - group:team-epsilon@redhat.com
   - serviceAccount:epsilon-secrets-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater
+- condition:
+    description: 'Managed by test platform: Read access to secrets for group team-alpha
+      (set 1)'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "alpha-secrets__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "alpha-secrets____index"
+      )
+    title: Read access to secrets for group team-alpha (set 1)
+  members:
+  - group:team-alpha@redhat.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      for group team-alpha (set 1)'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}").startsWith("alpha-secrets__")
+      )
+    title: Create, update, and delete access for group team-alpha (set 1)
+  members:
+  - group:team-alpha@redhat.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater
+- condition:
+    description: 'Managed by test platform: Read access to secrets for group team-beta
+      (set 1)'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "beta-delta-secrets__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "beta-delta-secrets____index"
+      )
+    title: Read access to secrets for group team-beta (set 1)
+  members:
+  - group:team-beta@redhat.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      for group team-beta (set 1)'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}").startsWith("beta-delta-secrets__")
+      )
+    title: Create, update, and delete access for group team-beta (set 1)
+  members:
+  - group:team-beta@redhat.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater
+- condition:
+    description: 'Managed by test platform: Read access to secrets for group team-delta
+      (set 1)'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "beta-delta-secrets__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "beta-delta-secrets____index"
+      )
+    title: Read access to secrets for group team-delta (set 1)
+  members:
+  - group:team-delta@redhat.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      for group team-delta (set 1)'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}").startsWith("beta-delta-secrets__")
+      )
+    title: Create, update, and delete access for group team-delta (set 1)
+  members:
+  - group:team-delta@redhat.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater
+- condition:
+    description: 'Managed by test platform: Read access to secrets for group team-epsilon
+      (set 1)'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "epsilon-secrets__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "epsilon-secrets____index"
+      )
+    title: Read access to secrets for group team-epsilon (set 1)
+  members:
+  - group:team-epsilon@redhat.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      for group team-epsilon (set 1)'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}").startsWith("epsilon-secrets__")
+      )
+    title: Create, update, and delete access for group team-epsilon (set 1)
+  members:
+  - group:team-epsilon@redhat.com
   role: projects/test-project/roles/openshift_ci_secrets_updater

--- a/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_one_secret_collection.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_one_secret_collection.yaml
@@ -11,8 +11,6 @@
       )
     title: Read access to secrets for collection-alpha
   members:
-  - group:team-alpha@redhat.com
-  - group:team-beta@redhat.com
   - serviceAccount:collection-alpha-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_viewer
 - condition:
@@ -22,7 +20,63 @@
       ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"collection-alpha__\")"
     title: Create, update, and delete access for collection-alpha
   members:
-  - group:team-alpha@redhat.com
-  - group:team-beta@redhat.com
   - serviceAccount:collection-alpha-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater
+- condition:
+    description: 'Managed by test platform: Read access to secrets for group team-alpha
+      (set 1)'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "collection-alpha__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "collection-alpha____index"
+      )
+    title: Read access to secrets for group team-alpha (set 1)
+  members:
+  - group:team-alpha@redhat.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      for group team-alpha (set 1)'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}").startsWith("collection-alpha__")
+      )
+    title: Create, update, and delete access for group team-alpha (set 1)
+  members:
+  - group:team-alpha@redhat.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater
+- condition:
+    description: 'Managed by test platform: Read access to secrets for group team-beta
+      (set 1)'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "collection-alpha__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "collection-alpha____index"
+      )
+    title: Read access to secrets for group team-beta (set 1)
+  members:
+  - group:team-beta@redhat.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      for group team-beta (set 1)'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}").startsWith("collection-alpha__")
+      )
+    title: Create, update, and delete access for group team-beta (set 1)
+  members:
+  - group:team-beta@redhat.com
   role: projects/test-project/roles/openshift_ci_secrets_updater

--- a/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_unclaimed_config.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_unclaimed_config.yaml
@@ -1,0 +1,78 @@
+- condition:
+    description: 'Managed by test platform: Read access to secrets in claimed-a collection'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "claimed-a__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "claimed-a____index"
+      )
+    title: Read access to secrets for claimed-a
+  members:
+  - serviceAccount:claimed-a-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      in claimed-a collection'
+    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
+      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"claimed-a__\")"
+    title: Create, update, and delete access for claimed-a
+  members:
+  - serviceAccount:claimed-a-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater
+- condition:
+    description: 'Managed by test platform: Read access to secrets in claimed-b collection'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "claimed-b__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "claimed-b____index"
+      )
+    title: Read access to secrets for claimed-b
+  members:
+  - serviceAccount:claimed-b-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      in claimed-b collection'
+    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
+      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"claimed-b__\")"
+    title: Create, update, and delete access for claimed-b
+  members:
+  - serviceAccount:claimed-b-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater
+- condition:
+    description: 'Managed by test platform: Read access to secrets for group owner-team
+      (set 1)'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "claimed-a__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "claimed-a____index" ||
+        resource.name.extract("secrets/{secret}") == "claimed-b__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "claimed-b____index"
+      )
+    title: Read access to secrets for group owner-team (set 1)
+  members:
+  - group:owner-team@redhat.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      for group owner-team (set 1)'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}").startsWith("claimed-a__") ||
+        resource.name.extract("secrets/{secret}").startsWith("claimed-b__")
+      )
+    title: Create, update, and delete access for group owner-team (set 1)
+  members:
+  - group:owner-team@redhat.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater

--- a/pkg/gsm-secrets/testdata/zz_fixture_collections_TestGetDesiredState_chunked_config.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_collections_TestGetDesiredState_chunked_config.yaml
@@ -1,0 +1,14 @@
+at-01: true
+bt-01: true
+bt-02: true
+bt-03: true
+bt-04: true
+bt-05: true
+bt-06: true
+bt-07: true
+bt-08: true
+bt-09: true
+bt-10: true
+bt-11: true
+bt-12: true
+st-01: true

--- a/pkg/gsm-secrets/testdata/zz_fixture_collections_TestGetDesiredState_unclaimed_config.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_collections_TestGetDesiredState_unclaimed_config.yaml
@@ -1,0 +1,4 @@
+claimed-a: true
+claimed-b: true
+unclaimed-x: true
+unclaimed-y: true

--- a/pkg/gsm-secrets/testdata/zz_fixture_sa_TestGetDesiredState_chunked_config.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_sa_TestGetDesiredState_chunked_config.yaml
@@ -1,0 +1,70 @@
+- Collection: at-01
+  Description: 'Updater service account for secret collection: at-01'
+  DisplayName: at-01
+  Email: at-01-updater@test-project.iam.gserviceaccount.com
+  ID: at-01-updater
+- Collection: bt-01
+  Description: 'Updater service account for secret collection: bt-01'
+  DisplayName: bt-01
+  Email: bt-01-updater@test-project.iam.gserviceaccount.com
+  ID: bt-01-updater
+- Collection: bt-02
+  Description: 'Updater service account for secret collection: bt-02'
+  DisplayName: bt-02
+  Email: bt-02-updater@test-project.iam.gserviceaccount.com
+  ID: bt-02-updater
+- Collection: bt-03
+  Description: 'Updater service account for secret collection: bt-03'
+  DisplayName: bt-03
+  Email: bt-03-updater@test-project.iam.gserviceaccount.com
+  ID: bt-03-updater
+- Collection: bt-04
+  Description: 'Updater service account for secret collection: bt-04'
+  DisplayName: bt-04
+  Email: bt-04-updater@test-project.iam.gserviceaccount.com
+  ID: bt-04-updater
+- Collection: bt-05
+  Description: 'Updater service account for secret collection: bt-05'
+  DisplayName: bt-05
+  Email: bt-05-updater@test-project.iam.gserviceaccount.com
+  ID: bt-05-updater
+- Collection: bt-06
+  Description: 'Updater service account for secret collection: bt-06'
+  DisplayName: bt-06
+  Email: bt-06-updater@test-project.iam.gserviceaccount.com
+  ID: bt-06-updater
+- Collection: bt-07
+  Description: 'Updater service account for secret collection: bt-07'
+  DisplayName: bt-07
+  Email: bt-07-updater@test-project.iam.gserviceaccount.com
+  ID: bt-07-updater
+- Collection: bt-08
+  Description: 'Updater service account for secret collection: bt-08'
+  DisplayName: bt-08
+  Email: bt-08-updater@test-project.iam.gserviceaccount.com
+  ID: bt-08-updater
+- Collection: bt-09
+  Description: 'Updater service account for secret collection: bt-09'
+  DisplayName: bt-09
+  Email: bt-09-updater@test-project.iam.gserviceaccount.com
+  ID: bt-09-updater
+- Collection: bt-10
+  Description: 'Updater service account for secret collection: bt-10'
+  DisplayName: bt-10
+  Email: bt-10-updater@test-project.iam.gserviceaccount.com
+  ID: bt-10-updater
+- Collection: bt-11
+  Description: 'Updater service account for secret collection: bt-11'
+  DisplayName: bt-11
+  Email: bt-11-updater@test-project.iam.gserviceaccount.com
+  ID: bt-11-updater
+- Collection: bt-12
+  Description: 'Updater service account for secret collection: bt-12'
+  DisplayName: bt-12
+  Email: bt-12-updater@test-project.iam.gserviceaccount.com
+  ID: bt-12-updater
+- Collection: st-01
+  Description: 'Updater service account for secret collection: st-01'
+  DisplayName: st-01
+  Email: st-01-updater@test-project.iam.gserviceaccount.com
+  ID: st-01-updater

--- a/pkg/gsm-secrets/testdata/zz_fixture_sa_TestGetDesiredState_unclaimed_config.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_sa_TestGetDesiredState_unclaimed_config.yaml
@@ -1,0 +1,10 @@
+- Collection: claimed-a
+  Description: 'Updater service account for secret collection: claimed-a'
+  DisplayName: claimed-a
+  Email: claimed-a-updater@test-project.iam.gserviceaccount.com
+  ID: claimed-a-updater
+- Collection: claimed-b
+  Description: 'Updater service account for secret collection: claimed-b'
+  DisplayName: claimed-b
+  Email: claimed-b-updater@test-project.iam.gserviceaccount.com
+  ID: claimed-b-updater

--- a/pkg/gsm-secrets/testdata/zz_fixture_secrets_TestGetDesiredState_chunked_config.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_secrets_TestGetDesiredState_chunked_config.yaml
@@ -1,0 +1,224 @@
+at-01____index:
+  Annotations: null
+  Collection: at-01
+  Labels: null
+  Name: at-01____index
+  Payload: null
+  ResourceName: ""
+  Type: 2
+at-01__updater-service-account:
+  Annotations: null
+  Collection: at-01
+  Labels: null
+  Name: at-01__updater-service-account
+  Payload: null
+  ResourceName: ""
+  Type: 1
+bt-01____index:
+  Annotations: null
+  Collection: bt-01
+  Labels: null
+  Name: bt-01____index
+  Payload: null
+  ResourceName: ""
+  Type: 2
+bt-01__updater-service-account:
+  Annotations: null
+  Collection: bt-01
+  Labels: null
+  Name: bt-01__updater-service-account
+  Payload: null
+  ResourceName: ""
+  Type: 1
+bt-02____index:
+  Annotations: null
+  Collection: bt-02
+  Labels: null
+  Name: bt-02____index
+  Payload: null
+  ResourceName: ""
+  Type: 2
+bt-02__updater-service-account:
+  Annotations: null
+  Collection: bt-02
+  Labels: null
+  Name: bt-02__updater-service-account
+  Payload: null
+  ResourceName: ""
+  Type: 1
+bt-03____index:
+  Annotations: null
+  Collection: bt-03
+  Labels: null
+  Name: bt-03____index
+  Payload: null
+  ResourceName: ""
+  Type: 2
+bt-03__updater-service-account:
+  Annotations: null
+  Collection: bt-03
+  Labels: null
+  Name: bt-03__updater-service-account
+  Payload: null
+  ResourceName: ""
+  Type: 1
+bt-04____index:
+  Annotations: null
+  Collection: bt-04
+  Labels: null
+  Name: bt-04____index
+  Payload: null
+  ResourceName: ""
+  Type: 2
+bt-04__updater-service-account:
+  Annotations: null
+  Collection: bt-04
+  Labels: null
+  Name: bt-04__updater-service-account
+  Payload: null
+  ResourceName: ""
+  Type: 1
+bt-05____index:
+  Annotations: null
+  Collection: bt-05
+  Labels: null
+  Name: bt-05____index
+  Payload: null
+  ResourceName: ""
+  Type: 2
+bt-05__updater-service-account:
+  Annotations: null
+  Collection: bt-05
+  Labels: null
+  Name: bt-05__updater-service-account
+  Payload: null
+  ResourceName: ""
+  Type: 1
+bt-06____index:
+  Annotations: null
+  Collection: bt-06
+  Labels: null
+  Name: bt-06____index
+  Payload: null
+  ResourceName: ""
+  Type: 2
+bt-06__updater-service-account:
+  Annotations: null
+  Collection: bt-06
+  Labels: null
+  Name: bt-06__updater-service-account
+  Payload: null
+  ResourceName: ""
+  Type: 1
+bt-07____index:
+  Annotations: null
+  Collection: bt-07
+  Labels: null
+  Name: bt-07____index
+  Payload: null
+  ResourceName: ""
+  Type: 2
+bt-07__updater-service-account:
+  Annotations: null
+  Collection: bt-07
+  Labels: null
+  Name: bt-07__updater-service-account
+  Payload: null
+  ResourceName: ""
+  Type: 1
+bt-08____index:
+  Annotations: null
+  Collection: bt-08
+  Labels: null
+  Name: bt-08____index
+  Payload: null
+  ResourceName: ""
+  Type: 2
+bt-08__updater-service-account:
+  Annotations: null
+  Collection: bt-08
+  Labels: null
+  Name: bt-08__updater-service-account
+  Payload: null
+  ResourceName: ""
+  Type: 1
+bt-09____index:
+  Annotations: null
+  Collection: bt-09
+  Labels: null
+  Name: bt-09____index
+  Payload: null
+  ResourceName: ""
+  Type: 2
+bt-09__updater-service-account:
+  Annotations: null
+  Collection: bt-09
+  Labels: null
+  Name: bt-09__updater-service-account
+  Payload: null
+  ResourceName: ""
+  Type: 1
+bt-10____index:
+  Annotations: null
+  Collection: bt-10
+  Labels: null
+  Name: bt-10____index
+  Payload: null
+  ResourceName: ""
+  Type: 2
+bt-10__updater-service-account:
+  Annotations: null
+  Collection: bt-10
+  Labels: null
+  Name: bt-10__updater-service-account
+  Payload: null
+  ResourceName: ""
+  Type: 1
+bt-11____index:
+  Annotations: null
+  Collection: bt-11
+  Labels: null
+  Name: bt-11____index
+  Payload: null
+  ResourceName: ""
+  Type: 2
+bt-11__updater-service-account:
+  Annotations: null
+  Collection: bt-11
+  Labels: null
+  Name: bt-11__updater-service-account
+  Payload: null
+  ResourceName: ""
+  Type: 1
+bt-12____index:
+  Annotations: null
+  Collection: bt-12
+  Labels: null
+  Name: bt-12____index
+  Payload: null
+  ResourceName: ""
+  Type: 2
+bt-12__updater-service-account:
+  Annotations: null
+  Collection: bt-12
+  Labels: null
+  Name: bt-12__updater-service-account
+  Payload: null
+  ResourceName: ""
+  Type: 1
+st-01____index:
+  Annotations: null
+  Collection: st-01
+  Labels: null
+  Name: st-01____index
+  Payload: null
+  ResourceName: ""
+  Type: 2
+st-01__updater-service-account:
+  Annotations: null
+  Collection: st-01
+  Labels: null
+  Name: st-01__updater-service-account
+  Payload: null
+  ResourceName: ""
+  Type: 1

--- a/pkg/gsm-secrets/testdata/zz_fixture_secrets_TestGetDesiredState_unclaimed_config.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_secrets_TestGetDesiredState_unclaimed_config.yaml
@@ -1,0 +1,32 @@
+claimed-a____index:
+  Annotations: null
+  Collection: claimed-a
+  Labels: null
+  Name: claimed-a____index
+  Payload: null
+  ResourceName: ""
+  Type: 2
+claimed-a__updater-service-account:
+  Annotations: null
+  Collection: claimed-a
+  Labels: null
+  Name: claimed-a__updater-service-account
+  Payload: null
+  ResourceName: ""
+  Type: 1
+claimed-b____index:
+  Annotations: null
+  Collection: claimed-b
+  Labels: null
+  Name: claimed-b____index
+  Payload: null
+  ResourceName: ""
+  Type: 2
+claimed-b__updater-service-account:
+  Annotations: null
+  Collection: claimed-b
+  Labels: null
+  Name: claimed-b__updater-service-account
+  Payload: null
+  ResourceName: ""
+  Type: 1

--- a/pkg/gsm-secrets/types.go
+++ b/pkg/gsm-secrets/types.go
@@ -31,6 +31,12 @@ const (
 	// IAM binding condition description templates
 	SecretsViewerConditionDescriptionTemplate  = "Managed by %s: Read access to secrets in %s collection"
 	SecretsUpdaterConditionDescriptionTemplate = "Managed by %s: Create, update, and delete access to secrets in %s collection"
+
+	// MaxCollectionsPerGroupBinding is the maximum number of collections referenced by a
+	// single group IAM binding condition. GCP allows at most 12 logical operators (&&, ||, !)
+	// per condition expression. The viewer condition uses 2N+1 operators for N collections,
+	// so N=5 (11 operators) is the largest chunk that stays within the limit.
+	MaxCollectionsPerGroupBinding = 5
 )
 
 type Config struct {

--- a/test/e2e/gsm-secret-sync/gsm-e2e_test.go
+++ b/test/e2e/gsm-secret-sync/gsm-e2e_test.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -469,6 +470,70 @@ func TestDeletion(t *testing.T) {
 
 	if !tr.compareStates(actualState, expectedState) {
 		t.Fatal("deletion test failed")
+	}
+}
+
+// TestUnclaimedCollectionPreserved verifies that a collection owned only by an unclaimed group
+// keeps its migrated data secrets but gets no service account, no SA/index secrets, and no IAM
+// bindings, while a normally-owned collection in the same config is reconciled as usual.
+func TestUnclaimedCollectionPreserved(t *testing.T) {
+	const (
+		claimedCollection   = "owned-secrets"
+		unclaimedCollection = "orphan-secrets"
+	)
+	dataSecretName := fmt.Sprintf("%s__someteam__token", unclaimedCollection)
+
+	// Seed a data secret in the unclaimed collection, simulating a migrated credential
+	// that the reconciler must preserve.
+	if err := gsm.CreateOrUpdateSecret(tr.ctx, tr.secretsClient, tr.config.ProjectIdNumber, dataSecretName, []byte("secret-value"), nil, nil); err != nil {
+		t.Fatalf("failed to seed data secret %s: %v", dataSecretName, err)
+	}
+
+	if err := tr.runReconcilerTool("testdata/config-unclaimed.yaml"); err != nil {
+		t.Fatalf("failed to run reconciler tool: %v", err)
+	}
+
+	// The reconciler creates a service account for the claimed collection. Wait for it to
+	// appear so we know reconciliation has propagated before making assertions.
+	var state GCPState
+	err := retry.OnError(gcpStateCheckBackoff, func(error) bool { return true }, func() error {
+		state = tr.getActualGCPState()
+		for _, sa := range state.ServiceAccounts {
+			if sa.Collection == claimedCollection {
+				return nil
+			}
+		}
+		return fmt.Errorf("service account for claimed collection %q not found yet", claimedCollection)
+	})
+	if err != nil {
+		t.Fatalf("claimed collection service account never appeared: %v", err)
+	}
+
+	// The seeded data secret in the unclaimed collection must still exist.
+	dataSecretPath := fmt.Sprintf("%s/secrets/%s", gsm.GetProjectResourceIdNumber(tr.config.ProjectIdNumber), dataSecretName)
+	if _, err := tr.secretsClient.GetSecret(tr.ctx, &secretmanagerpb.GetSecretRequest{Name: dataSecretPath}); err != nil {
+		t.Errorf("seeded data secret %s was not preserved: %v", dataSecretName, err)
+	}
+
+	// No service account may be created for the unclaimed collection.
+	for _, sa := range state.ServiceAccounts {
+		if sa.Collection == unclaimedCollection {
+			t.Errorf("unexpected service account for unclaimed collection: %s", sa.Email)
+		}
+	}
+
+	// No managed SA/index secret may be created for the unclaimed collection.
+	for name, s := range state.Secrets {
+		if s.Collection == unclaimedCollection && (s.Type == gsm.SecretTypeSA || s.Type == gsm.SecretTypeIndex) {
+			t.Errorf("unexpected managed secret for unclaimed collection: %s (type %v)", name, s.Type)
+		}
+	}
+
+	// No managed IAM binding may reference the unclaimed collection.
+	for _, binding := range state.IAMBindings {
+		if binding.Condition != nil && strings.Contains(binding.Condition.Expression, unclaimedCollection+"__") {
+			t.Errorf("unexpected managed IAM binding referencing unclaimed collection: %s", binding.Condition.Title)
+		}
 	}
 }
 

--- a/test/e2e/gsm-secret-sync/gsm-e2e_test.go
+++ b/test/e2e/gsm-secret-sync/gsm-e2e_test.go
@@ -129,7 +129,11 @@ func setupLogger(censor *secrets.DynamicCensor) error {
 
 func (tr *testRunner) cleanup() {
 	ctx := context.Background()
-	currentState := tr.getActualGCPState()
+	currentState, err := tr.getActualGCPState()
+	if err != nil {
+		logrus.Errorf("Failed to fetch GCP state for cleanup; leftover resources may remain: %v", err)
+		return
+	}
 
 	if len(currentState.Secrets) > 0 {
 		logrus.Infof("Deleting %d secrets...", len(currentState.Secrets))
@@ -495,9 +499,16 @@ func TestUnclaimedCollectionPreserved(t *testing.T) {
 
 	// The reconciler creates a service account for the claimed collection. Wait for it to
 	// appear so we know reconciliation has propagated before making assertions.
+	// Retry until the claimed collection's service account appears, so the negative
+	// assertions below run only against a complete, successfully retrieved state. A
+	// retrieval error keeps retrying rather than being treated as an absence.
 	var state GCPState
 	err := retry.OnError(gcpStateCheckBackoff, func(error) bool { return true }, func() error {
-		state = tr.getActualGCPState()
+		var err error
+		state, err = tr.getActualGCPState()
+		if err != nil {
+			return fmt.Errorf("failed to fetch GCP state: %w", err)
+		}
 		for _, sa := range state.ServiceAccounts {
 			if sa.Collection == claimedCollection {
 				return nil
@@ -562,29 +573,29 @@ func (tr *testRunner) runReconcilerTool(configPath string) error {
 	return nil
 }
 
-// getActualGCPState returns the current state of resources in the GCP project
-func (tr *testRunner) getActualGCPState() GCPState {
+// getActualGCPState returns the current state of resources in the GCP project.
+// Any retrieval failure is returned as an error rather than being masked as an
+// empty result, so callers never mistake a transient API failure for an absence
+// of resources (which would make negative assertions pass spuriously).
+func (tr *testRunner) getActualGCPState() (GCPState, error) {
 	gcpSecrets, err := gsm.GetAllSecrets(tr.ctx, tr.secretsClient, tr.config)
 	if err != nil {
-		logrus.Errorf("Error while fetching secrets: %v", err)
-		gcpSecrets = make(map[string]gsm.GCPSecret)
+		return GCPState{}, fmt.Errorf("failed to fetch secrets: %w", err)
 	}
 
 	serviceAccounts, err := gsm.GetUpdaterServiceAccounts(tr.ctx, tr.iamAdminClient, tr.config)
 	if err != nil {
-		logrus.Errorf("Failed to fetch service accounts: %v", err)
-		serviceAccounts = []gsm.ServiceAccountInfo{}
+		return GCPState{}, fmt.Errorf("failed to fetch service accounts: %w", err)
 	}
 
-	var iamBindings []*iampb.Binding
 	policy, err := gsm.GetProjectIAMPolicy(tr.ctx, tr.resourceManagerClient, tr.config.ProjectIdNumber)
 	if err != nil {
-		logrus.Errorf("Failed to fetch IAM policy: %v", err)
-	} else {
-		for _, binding := range policy.Bindings {
-			if gsm.IsManagedBinding(binding) {
-				iamBindings = append(iamBindings, binding)
-			}
+		return GCPState{}, fmt.Errorf("failed to fetch IAM policy: %w", err)
+	}
+	var iamBindings []*iampb.Binding
+	for _, binding := range policy.Bindings {
+		if gsm.IsManagedBinding(binding) {
+			iamBindings = append(iamBindings, binding)
 		}
 	}
 
@@ -592,7 +603,7 @@ func (tr *testRunner) getActualGCPState() GCPState {
 		Secrets:         gcpSecrets,
 		IAMBindings:     iamBindings,
 		ServiceAccounts: serviceAccounts,
-	}
+	}, nil
 }
 
 // getActualGCPStateWithRetry gets the actual state with retry for eventual consistency
@@ -607,7 +618,12 @@ func (tr *testRunner) getActualGCPStateWithRetry(expectedState GCPState) GCPStat
 	err := retry.OnError(gcpStateCheckBackoff, func(err error) bool {
 		return true
 	}, func() error {
-		state = tr.getActualGCPState()
+		var err error
+		state, err = tr.getActualGCPState()
+		if err != nil {
+			logrus.Infof("Failed to fetch GCP state, retrying: %v", err)
+			return err
+		}
 		actualSACount := len(state.ServiceAccounts)
 		actualSecretCount := len(state.Secrets)
 

--- a/test/e2e/gsm-secret-sync/testdata/config-create.yaml
+++ b/test/e2e/gsm-secret-sync/testdata/config-create.yaml
@@ -15,4 +15,15 @@ groups:
   team-noop:
     cluster_groups:
     - dp-managed
+  # Owns more than MaxCollectionsPerGroupBinding collections, so its bindings are
+  # chunked. The first chunk has 5 collections and exercises the largest viewer
+  # condition (11 logical operators) GCP will accept.
+  test-platform-large:
+    secret_collections:
+    - large-secrets-01
+    - large-secrets-02
+    - large-secrets-03
+    - large-secrets-04
+    - large-secrets-05
+    - large-secrets-06
 

--- a/test/e2e/gsm-secret-sync/testdata/config-create.yaml
+++ b/test/e2e/gsm-secret-sync/testdata/config-create.yaml
@@ -16,9 +16,11 @@ groups:
     cluster_groups:
     - dp-managed
   # Owns more than MaxCollectionsPerGroupBinding collections, so its bindings are
-  # chunked. The first chunk has 5 collections and exercises the largest viewer
-  # condition (11 logical operators) GCP will accept.
-  test-platform-large:
+  # chunked. The first chunk holds 5 collections and exercises the largest viewer
+  # condition (11 logical operators) GCP will accept. This must be a group that
+  # actually exists in the directory, otherwise SetIamPolicy rejects its bindings
+  # with "Group ... does not exist".
+  test-platform-gsm-secrets-owners:
     secret_collections:
     - large-secrets-01
     - large-secrets-02

--- a/test/e2e/gsm-secret-sync/testdata/config-unclaimed.yaml
+++ b/test/e2e/gsm-secret-sync/testdata/config-unclaimed.yaml
@@ -1,0 +1,10 @@
+groups:
+  test-platform-ci-admins:
+    secret_collections:
+    - owned-secrets
+  # Holding area for collections no team owns yet. The reconciler must keep these
+  # collections' data secrets alive while creating no service account and no bindings.
+  test-platform-gsm-unclaimed-secrets:
+    unclaimed: true
+    secret_collections:
+    - orphan-secrets


### PR DESCRIPTION
## What

Two related fixes to `gsm-secret-sync`, in separate commits:

### 1. Chunk group IAM bindings and scope service accounts per collection
The reconciler emitted one combined viewer/updater binding per collection whose members were the owning groups **plus** the collection's updater service account. A group owning many collections thus appeared in that many bindings sharing the same `(role, member)`, hitting GCP's limit of **20 bindings per role+member** (`multiarch-devel`, 23 collections, failed to apply).

Now the desired bindings are split into:
- **Per-collection, service-account-only** bindings scoped to exactly one collection, so a service account never gains access to another collection's secrets.
- **Per-group** bindings whose condition covers the group's collections, chunked to at most `MaxCollectionsPerGroupBinding` (5). The viewer condition uses `2N+1` logical operators for N collections, so 5 stays within GCP's cap of **12 operators per condition**; chunking also keeps a group under the 20-bindings cap for up to 100 collections.

Conditions still use exact `==` (viewer) and `startsWith("<collection>__")` (updater), which are safe against collection-name prefix collisions because collection names cannot contain `__`.

### 2. Support unclaimed secret collections
Adds an `unclaimed` flag to `group.Target` for a holding-area rover group (`test-platform-gsm-unclaimed-secrets`) that owns Vault collections no team has claimed yet. For an `unclaimed: true` group, `GetDesiredState` keeps its collections in the active-collection set (so migrated data secrets are **not deleted**) but emits no service account, no SA/index secrets, and no IAM bindings. Claiming a collection later is just moving it under a normal group; the collection stays active throughout, so its data secrets are never deleted in the process. A collection listed under both a normal and the unclaimed group is treated as claimed.

## Testing
- Unit: new `chunked-config` and `unclaimed-config` fixtures for `TestGetDesiredState`; added `TestChunkCollections` and group-binding cases to `TestIsManagedBinding`.
- e2e: `config-create.yaml` now includes a 6-collection group (forces a 5-collection / 11-operator condition through real `SetIamPolicy`); new `config-unclaimed.yaml` + `TestUnclaimedCollectionPreserved` seeds a data secret and asserts it survives while no SA/binding/managed-secret is created for the unclaimed collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated `gsm-secret-sync` to generate separate service-account and group IAM bindings.
- Limited each group binding to five collections to avoid GCP binding limits.
- Added `unclaimed` collections that retain data secrets but receive no service accounts, managed secrets, or IAM bindings.
- Added unit fixtures, tests, and end-to-end coverage for IAM chunking, large groups, and unclaimed collection preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->