### PR TITLE
gsm-secrets: ensure updater service account IDs are always valid

### DIFF
--- a/pkg/gsm-secrets/types.go
+++ b/pkg/gsm-secrets/types.go
@@ -3,8 +3,10 @@ package gsmsecrets
 import (
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 
 	"cloud.google.com/go/iam/apiv1/iampb"
@@ -16,6 +18,8 @@ const (
 	TestPlatform = "test platform"
 
 	GCPMaxServiceAccountIDLength = 30
+	// GCPMinServiceAccountIDLength is the minimum length GCP allows for a service account ID.
+	GCPMinServiceAccountIDLength = 6
 
 	UpdaterSASecretName   = "updater-service-account"
 	UpdaterSASecretSuffix = "__updater-service-account"
@@ -147,10 +151,32 @@ func GetUpdaterSAEmail(collection string, config Config) string {
 	return fmt.Sprintf("%s@%s.iam.gserviceaccount.com", GetUpdaterSAId(collection), config.ProjectIdString)
 }
 
+var gcpServiceAccountIDRegex = regexp.MustCompile(`^[a-z][a-z0-9-]*[a-z0-9]$`)
+
+func isValidGCPServiceAccountID(id string) bool {
+	if len(id) < GCPMinServiceAccountIDLength || len(id) > GCPMaxServiceAccountIDLength {
+		return false
+	}
+	return gcpServiceAccountIDRegex.MatchString(id)
+}
+
 // GetUpdaterSAId returns the updater service account ID for a given collection name.
-// Uses the collection name directly if it fits within GCP's 30-character limit,
-// otherwise uses a hash-based approach.
+// It first tries the collection-derived ID (rawUpdaterSAId); if that ID is a valid GCP
+// service account ID it is returned unchanged. Otherwise, it falls back
+// to a guaranteed-valid hash-based ID.
 func GetUpdaterSAId(collection string) string {
+	id := rawUpdaterSAId(collection)
+	if isValidGCPServiceAccountID(id) {
+		return id
+	}
+	return fallbackUpdaterSAId(collection)
+}
+
+// rawUpdaterSAId derives the service account ID directly from the collection name:
+// the collection name itself if it fits within GCP's length limit, otherwise a
+// truncated base64url-encoded hash. The result may be invalid per GCP's rules (e.g. a
+// leading digit, or a '_' from the base64url alphabet); callers must validate it.
+func rawUpdaterSAId(collection string) string {
 	suffixLen := len(ServiceAccountIDSuffix)
 	directId := fmt.Sprintf("%s%s", collection, ServiceAccountIDSuffix)
 
@@ -167,6 +193,23 @@ func GetUpdaterSAId(collection string) string {
 	}
 
 	return fmt.Sprintf("%s%s", strings.ToLower(encodedHash), ServiceAccountIDSuffix)
+}
+
+// fallbackUpdaterSAId returns a deterministic, always-valid GCP service account ID for a
+// collection whose rawUpdaterSAId is invalid. It hex-encodes a sha256 of the collection
+// (so no '_'), prefixes a fixed letter (so no leading digit), and appends the standard
+// suffix. The collection remains recoverable from the SA description and secret name, so
+// the ID does not need to be reversible.
+func fallbackUpdaterSAId(collection string) string {
+	hash := sha256.Sum256([]byte(collection))
+	encodedHash := hex.EncodeToString(hash[:])
+
+	maxHashLen := GCPMaxServiceAccountIDLength - len("s") - len(ServiceAccountIDSuffix)
+	if len(encodedHash) > maxHashLen {
+		encodedHash = encodedHash[:maxHashLen]
+	}
+
+	return fmt.Sprintf("s%s%s", encodedHash, ServiceAccountIDSuffix)
 }
 
 // GetUpdaterSADisplayName returns the display name for the service account,

--- a/pkg/gsm-secrets/types_test.go
+++ b/pkg/gsm-secrets/types_test.go
@@ -55,57 +55,128 @@ func TestGetUpdaterSAEmail(t *testing.T) {
 }
 
 func TestGetUpdaterSAId(t *testing.T) {
+	// path describes which branch of GetUpdaterSAId a collection is expected to hit.
+	type path string
+	const (
+		direct   path = "direct"   // raw ID is the collection name plus suffix and is valid
+		hash     path = "hash"     // raw ID is the base64 hash and is valid
+		fallback path = "fallback" // raw ID is invalid, so the hex fallback is used
+	)
+
 	testCases := []struct {
 		name           string
 		collection     string
 		expectedLength int
-		shouldUseHash  bool
+		path           path
 	}{
 		{
 			name:           "short collection - direct use",
 			collection:     "alpha",
 			expectedLength: 13, // "alpha-updater" = 13 chars
-			shouldUseHash:  false,
+			path:           direct,
 		},
 		{
 			name:           "medium collection - direct use",
 			collection:     "test-collection",
 			expectedLength: 23, // "test-collection-updater" = 23 chars
-			shouldUseHash:  false,
+			path:           direct,
 		},
 		{
 			name:           "collection at limit - direct use",
 			collection:     "collection-at-limit-22",
 			expectedLength: 30, // "collection-at-limit-22-updater" = 30 chars
-			shouldUseHash:  false,
+			path:           direct,
 		},
 		{
-			name:           "very long collection - hash use",
+			name:           "very long collection - valid hash use",
 			collection:     "this-is-a-very-long-collection-name-that-exceeds-normal-limits",
 			expectedLength: 30,
-			shouldUseHash:  true,
+			path:           hash,
+		},
+		{
+			// Leading digit makes the direct ID invalid (GCP IDs must start with a letter).
+			name:           "collection with leading digit - fallback",
+			collection:     "3scale-test-image",
+			expectedLength: 30,
+			path:           fallback,
+		},
+		{
+			// Long collection whose base64url hash contains '_' (invalid in a GCP ID).
+			name:           "long collection with underscore in hash - fallback",
+			collection:     "cluster-secrets-osl-gcp",
+			expectedLength: 30,
+			path:           fallback,
+		},
+		{
+			// Long collection whose lowercased hash starts with a digit (invalid).
+			name:           "long collection with leading digit in hash - fallback",
+			collection:     "vsphere-assisted-installer-ci",
+			expectedLength: 30,
+			path:           fallback,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			actual := GetUpdaterSAId(tc.collection)
+
 			if len(actual) != tc.expectedLength {
 				t.Errorf("Expected length %d, got %d for ID %q", tc.expectedLength, len(actual), actual)
 			}
 			if !strings.HasSuffix(actual, ServiceAccountIDSuffix) {
 				t.Errorf("Expected ID %q to end with %q", actual, ServiceAccountIDSuffix)
 			}
+			// Every returned ID must satisfy GCP's rules and be deterministic.
+			if !isValidGCPServiceAccountID(actual) {
+				t.Errorf("ID %q is not a valid GCP service account ID", actual)
+			}
+			if again := GetUpdaterSAId(tc.collection); again != actual {
+				t.Errorf("GetUpdaterSAId is not deterministic: got %q then %q", actual, again)
+			}
 
 			directId := fmt.Sprintf("%s%s", tc.collection, ServiceAccountIDSuffix)
-			if tc.shouldUseHash {
+			switch tc.path {
+			case direct:
+				if actual != directId {
+					t.Errorf("Expected direct ID %q, but got %q", directId, actual)
+				}
+			case hash:
 				if actual == directId {
 					t.Errorf("Expected hash to be used for long collection %q, but got direct ID", tc.collection)
 				}
-			} else {
-				if actual != directId {
-					t.Errorf("Expected direct ID %q for short collection, but got %q", directId, actual)
+			case fallback:
+				if raw := rawUpdaterSAId(tc.collection); isValidGCPServiceAccountID(raw) {
+					t.Errorf("Expected raw ID %q to be invalid so the fallback is exercised", raw)
 				}
+				if want := fallbackUpdaterSAId(tc.collection); actual != want {
+					t.Errorf("Expected fallback ID %q, but got %q", want, actual)
+				}
+			}
+		})
+	}
+}
+
+func TestIsValidGCPServiceAccountID(t *testing.T) {
+	testCases := []struct {
+		name  string
+		id    string
+		valid bool
+	}{
+		{name: "valid direct id", id: "alpha-updater", valid: true},
+		{name: "valid hex fallback id", id: "s64f7ba388325bd0dafee3-updater", valid: true},
+		{name: "valid with double hyphen", id: "vfxj0ci--zubgj8gdeo4ec-updater", valid: true},
+		{name: "leading digit", id: "3scale-test-image-updater", valid: false},
+		{name: "contains underscore", id: "vbapy_ashggzdty6ydupia-updater", valid: false},
+		{name: "leading hyphen", id: "-alpha-updater", valid: false},
+		{name: "uppercase", id: "Alpha-updater", valid: false},
+		{name: "too short", id: "a-b", valid: false},
+		{name: "too long", id: strings.Repeat("a", GCPMaxServiceAccountIDLength+1), valid: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isValidGCPServiceAccountID(tc.id); got != tc.valid {
+				t.Errorf("isValidGCPServiceAccountID(%q) = %v, want %v", tc.id, got, tc.valid)
 			}
 		})
 	}


### PR DESCRIPTION
## What

`GetUpdaterSAId` could return service account IDs that GCP rejects, so the updater service account for the affected collections could never be created.

## Why

Collection names may legally contain underscores or start with a digit/hyphen (per `CollectionRegex = ^([a-z0-9_-]*[a-z0-9])?$`), but a GCP service account ID must match `^[a-z][a-z0-9-]*[a-z0-9]$` (6-30 chars). The previous logic fed the collection name directly into the ID, or for long names a base64url-encoded hash whose alphabet includes `_` — both can violate GCP's rules.

## How

- Split the derivation into `rawUpdaterSAId` (the original, possibly-invalid logic).
- `GetUpdaterSAId` returns the raw ID when it passes `isValidGCPServiceAccountID`, otherwise falls back to a deterministic, always-valid `fallbackUpdaterSAId` (hex-encoded sha256, letter-prefixed, standard suffix, 30 chars).
- Existing valid IDs are unchanged, so already-created service accounts remain stable; only previously-invalid (uncreatable) IDs are replaced.

## Testing

- Reworked `TestGetUpdaterSAId` with a direct/hash/fallback path enum; fallback cases self-verify the raw ID is invalid, and every returned ID is asserted valid and deterministic.
- Added `TestIsValidGCPServiceAccountID`.
- `go test ./pkg/gsm-secrets/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updates `gsm-secrets` to generate GCP-compliant updater service account IDs.

- Preserves valid IDs derived from collection names.
- Uses deterministic, letter-prefixed SHA-256 fallback IDs when derived IDs are invalid.
- Covers invalid characters, leading digits or hyphens, length limits, and determinism.
- Adds validation tests for GCP service account IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->