### PR TITLE
gsm-secrets: drop resource.type preamble and fix the viewer condition

### DIFF
--- a/pkg/gsm-secrets/iam.go
+++ b/pkg/gsm-secrets/iam.go
@@ -12,28 +12,28 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// The two roles need different templates because GCP checks their permissions on different
+// resources. The viewer only holds versions.access, checked on "projects/P/secrets/S/versions/V",
+// so anchoring on "/versions/" makes {s} stop at the secret name and match by equality. The
+// updater also holds secrets.get/update/delete, checked on the bare "projects/P/secrets/S",
+// where that anchor finds nothing and returns ""; the greedy template yields the secret name
+// there and "S/versions/V" on a version, both of which satisfy the prefix match.
+//
+// Dropping the "resource.type" guard is safe: an unmatched template returns "" and the
+// condition is false, so access fails closed.
+const (
+	viewerSecretNameTemplate  = `resource.name.extract("secrets/{s}/versions/")`
+	updaterSecretNameTemplate = `resource.name.extract("secrets/{secret}")`
+)
+
 // BuildSecretAccessorRoleConditionExpression builds the IAM condition expression for secret accessor role
 func BuildSecretAccessorRoleConditionExpression(collection string) string {
-	// Define the two specific secrets this role can access
-	updaterSecret := fmt.Sprintf("%s%s", collection, UpdaterSASecretSuffix)
-	indexSecret := fmt.Sprintf("%s%s", collection, IndexSecretSuffix)
-
-	return fmt.Sprintf(`(
-  resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-  resource.type == "secretmanager.googleapis.com/Secret"
-) && (
-  resource.name.extract("secrets/{secret}") == "%s" ||
-  resource.name.extract("secrets/{secret}") == "%s"
-)`, updaterSecret, indexSecret)
+	return BuildSecretAccessorRoleConditionExpressionForCollections([]string{collection})
 }
 
 // BuildSecretUpdaterRoleConditionExpression builds the IAM condition expression for secret updater role
 func BuildSecretUpdaterRoleConditionExpression(collection string) string {
-	return fmt.Sprintf(`(
-  resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-  resource.type == "secretmanager.googleapis.com/Secret"
-) && 
-  resource.name.extract("secrets/{secret}").startsWith("%s__")`, collection)
+	return BuildSecretUpdaterRoleConditionExpressionForCollections([]string{collection})
 }
 
 // BuildSecretAccessorRoleConditionExpressionForCollections builds the viewer IAM condition
@@ -43,16 +43,11 @@ func BuildSecretAccessorRoleConditionExpressionForCollections(collections []stri
 	var terms []string
 	for _, collection := range collections {
 		terms = append(terms,
-			fmt.Sprintf(`  resource.name.extract("secrets/{secret}") == "%s%s"`, collection, UpdaterSASecretSuffix),
-			fmt.Sprintf(`  resource.name.extract("secrets/{secret}") == "%s%s"`, collection, IndexSecretSuffix),
+			fmt.Sprintf(`%s == "%s%s"`, viewerSecretNameTemplate, collection, UpdaterSASecretSuffix),
+			fmt.Sprintf(`%s == "%s%s"`, viewerSecretNameTemplate, collection, IndexSecretSuffix),
 		)
 	}
-	return fmt.Sprintf(`(
-  resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-  resource.type == "secretmanager.googleapis.com/Secret"
-) && (
-%s
-)`, strings.Join(terms, " ||\n"))
+	return strings.Join(terms, " || ")
 }
 
 // BuildSecretUpdaterRoleConditionExpressionForCollections builds the updater IAM condition
@@ -61,14 +56,9 @@ func BuildSecretAccessorRoleConditionExpressionForCollections(collections []stri
 func BuildSecretUpdaterRoleConditionExpressionForCollections(collections []string) string {
 	var terms []string
 	for _, collection := range collections {
-		terms = append(terms, fmt.Sprintf(`  resource.name.extract("secrets/{secret}").startsWith("%s__")`, collection))
+		terms = append(terms, fmt.Sprintf(`%s.startsWith("%s__")`, updaterSecretNameTemplate, collection))
 	}
-	return fmt.Sprintf(`(
-  resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-  resource.type == "secretmanager.googleapis.com/Secret"
-) && (
-%s
-)`, strings.Join(terms, " ||\n"))
+	return strings.Join(terms, " || ")
 }
 
 // chunkCollections splits a sorted slice of collections into consecutive chunks of at most
@@ -133,23 +123,19 @@ func IsManagedBinding(b *iampb.Binding) bool {
 		return false
 	}
 
+	// The title prefix is what separates our bindings from hand-made ones on the same roles,
+	// such as the "EXCEPTION: ..." grants, which must be left untouched.
 	title := b.Condition.GetTitle()
-	description := b.Condition.GetDescription()
-
-	titleMatches := strings.HasPrefix(title, SecretsViewerConditionTitlePrefix) ||
-		strings.HasPrefix(title, SecretsUpdaterConditionTitlePrefix)
-	descriptionMatches := strings.HasPrefix(description, fmt.Sprintf("Managed by %s:", TestPlatform))
-
-	if !titleMatches || !descriptionMatches {
+	if !strings.HasPrefix(title, SecretsViewerConditionTitlePrefix) &&
+		!strings.HasPrefix(title, SecretsUpdaterConditionTitlePrefix) {
 		return false
 	}
 
 	expr := b.Condition.Expression
-	hasSecretManagerResource := strings.Contains(expr, "secretmanager.googleapis.com")
-	hasSecretExtract := strings.Contains(expr, `resource.name.extract("secrets/{secret}")`)
+	hasSecretExtract := strings.Contains(expr, "resource.name.extract(")
 	hasExpectedPattern := strings.Contains(expr, "startsWith(") || strings.Contains(expr, "==")
 
-	return hasSecretManagerResource && hasSecretExtract && hasExpectedPattern
+	return hasSecretExtract && hasExpectedPattern
 }
 
 // ToCanonicalIAMBinding converts an iampb.Binding into our canonical form.

--- a/pkg/gsm-secrets/iam_test.go
+++ b/pkg/gsm-secrets/iam_test.go
@@ -263,7 +263,7 @@ func TestIsManagedBinding(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "correct binding with different description",
+			name: "description is not part of the detection",
 			binding: &iampb.Binding{
 				Role:    config.GetSecretUpdaterRole(),
 				Members: []string{"serviceAccount:test@example.com"},
@@ -271,6 +271,19 @@ func TestIsManagedBinding(t *testing.T) {
 					Title:       GetSecretsUpdaterConditionTitle("test-collection"),
 					Description: "some wrong description",
 					Expression:  BuildSecretUpdaterRoleConditionExpression("test-collection"),
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "hand-made exception binding on a managed role",
+			binding: &iampb.Binding{
+				Role:    config.GetSecretAccessorRole(),
+				Members: []string{"group:team-x@redhat.com"},
+				Condition: &expr.Expr{
+					Title:       "EXCEPTION: read secrets for team-x",
+					Description: "MANUAL EXCEPTION: permission to read secret values in team-x collection",
+					Expression:  `resource.name.extract("secrets/{secret}").startsWith("team-x__")`,
 				},
 			},
 			expected: false,

--- a/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_basic_config.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_basic_config.yaml
@@ -1,14 +1,8 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets in collection-alpha
       collection'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "collection-alpha__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "collection-alpha____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "collection-alpha__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "collection-alpha____index"
     title: Read access to secrets for collection-alpha
   members:
   - serviceAccount:collection-alpha-updater@test-project.iam.gserviceaccount.com
@@ -16,8 +10,7 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in collection-alpha collection'
-    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
-      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"collection-alpha__\")"
+    expression: resource.name.extract("secrets/{secret}").startsWith("collection-alpha__")
     title: Create, update, and delete access for collection-alpha
   members:
   - serviceAccount:collection-alpha-updater@test-project.iam.gserviceaccount.com
@@ -25,14 +18,8 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets in shared-collection
       collection'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "shared-collection__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "shared-collection____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "shared-collection__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "shared-collection____index"
     title: Read access to secrets for shared-collection
   members:
   - serviceAccount:shared-collection-updater@test-project.iam.gserviceaccount.com
@@ -40,8 +27,7 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in shared-collection collection'
-    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
-      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"shared-collection__\")"
+    expression: resource.name.extract("secrets/{secret}").startsWith("shared-collection__")
     title: Create, update, and delete access for shared-collection
   members:
   - serviceAccount:shared-collection-updater@test-project.iam.gserviceaccount.com
@@ -49,14 +35,8 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets in some-collection-with-a-very-long-name
       collection'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "some-collection-with-a-very-long-name__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "some-collection-with-a-very-long-name____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "some-collection-with-a-very-long-name__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "some-collection-with-a-very-long-name____index"
     title: Read access to secrets for some-collection-with-a-very-long-name
   members:
   - serviceAccount:ynbbgzp1q3u3iwp8edyqix-updater@test-project.iam.gserviceaccount.com
@@ -64,8 +44,7 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in some-collection-with-a-very-long-name collection'
-    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
-      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"some-collection-with-a-very-long-name__\")"
+    expression: resource.name.extract("secrets/{secret}").startsWith("some-collection-with-a-very-long-name__")
     title: Create, update, and delete access for some-collection-with-a-very-long-name
   members:
   - serviceAccount:ynbbgzp1q3u3iwp8edyqix-updater@test-project.iam.gserviceaccount.com
@@ -73,16 +52,10 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets for group team-alpha
       (set 1)'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "collection-alpha__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "collection-alpha____index" ||
-        resource.name.extract("secrets/{secret}") == "shared-collection__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "shared-collection____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "collection-alpha__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "collection-alpha____index"
+      || resource.name.extract("secrets/{s}/versions/") == "shared-collection__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "shared-collection____index"
     title: Read access to secrets for group team-alpha (set 1)
   members:
   - group:team-alpha@redhat.com
@@ -90,14 +63,8 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       for group team-alpha (set 1)'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}").startsWith("collection-alpha__") ||
-        resource.name.extract("secrets/{secret}").startsWith("shared-collection__")
-      )
+    expression: resource.name.extract("secrets/{secret}").startsWith("collection-alpha__")
+      || resource.name.extract("secrets/{secret}").startsWith("shared-collection__")
     title: Create, update, and delete access for group team-alpha (set 1)
   members:
   - group:team-alpha@redhat.com
@@ -105,16 +72,10 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets for group team-beta
       (set 1)'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "shared-collection__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "shared-collection____index" ||
-        resource.name.extract("secrets/{secret}") == "some-collection-with-a-very-long-name__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "some-collection-with-a-very-long-name____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "shared-collection__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "shared-collection____index"
+      || resource.name.extract("secrets/{s}/versions/") == "some-collection-with-a-very-long-name__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "some-collection-with-a-very-long-name____index"
     title: Read access to secrets for group team-beta (set 1)
   members:
   - group:team-beta@redhat.com
@@ -122,14 +83,8 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       for group team-beta (set 1)'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}").startsWith("shared-collection__") ||
-        resource.name.extract("secrets/{secret}").startsWith("some-collection-with-a-very-long-name__")
-      )
+    expression: resource.name.extract("secrets/{secret}").startsWith("shared-collection__")
+      || resource.name.extract("secrets/{secret}").startsWith("some-collection-with-a-very-long-name__")
     title: Create, update, and delete access for group team-beta (set 1)
   members:
   - group:team-beta@redhat.com

--- a/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_chunked_config.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_chunked_config.yaml
@@ -1,13 +1,7 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets in at-01 collection'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "at-01__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "at-01____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "at-01__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "at-01____index"
     title: Read access to secrets for at-01
   members:
   - serviceAccount:at-01-updater@test-project.iam.gserviceaccount.com
@@ -15,22 +9,15 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in at-01 collection'
-    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
-      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"at-01__\")"
+    expression: resource.name.extract("secrets/{secret}").startsWith("at-01__")
     title: Create, update, and delete access for at-01
   members:
   - serviceAccount:at-01-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in bt-01 collection'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "bt-01__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "bt-01____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "bt-01__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "bt-01____index"
     title: Read access to secrets for bt-01
   members:
   - serviceAccount:bt-01-updater@test-project.iam.gserviceaccount.com
@@ -38,22 +25,15 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in bt-01 collection'
-    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
-      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"bt-01__\")"
+    expression: resource.name.extract("secrets/{secret}").startsWith("bt-01__")
     title: Create, update, and delete access for bt-01
   members:
   - serviceAccount:bt-01-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in bt-02 collection'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "bt-02__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "bt-02____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "bt-02__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "bt-02____index"
     title: Read access to secrets for bt-02
   members:
   - serviceAccount:bt-02-updater@test-project.iam.gserviceaccount.com
@@ -61,22 +41,15 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in bt-02 collection'
-    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
-      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"bt-02__\")"
+    expression: resource.name.extract("secrets/{secret}").startsWith("bt-02__")
     title: Create, update, and delete access for bt-02
   members:
   - serviceAccount:bt-02-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in bt-03 collection'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "bt-03__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "bt-03____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "bt-03__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "bt-03____index"
     title: Read access to secrets for bt-03
   members:
   - serviceAccount:bt-03-updater@test-project.iam.gserviceaccount.com
@@ -84,22 +57,15 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in bt-03 collection'
-    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
-      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"bt-03__\")"
+    expression: resource.name.extract("secrets/{secret}").startsWith("bt-03__")
     title: Create, update, and delete access for bt-03
   members:
   - serviceAccount:bt-03-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in bt-04 collection'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "bt-04__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "bt-04____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "bt-04__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "bt-04____index"
     title: Read access to secrets for bt-04
   members:
   - serviceAccount:bt-04-updater@test-project.iam.gserviceaccount.com
@@ -107,22 +73,15 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in bt-04 collection'
-    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
-      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"bt-04__\")"
+    expression: resource.name.extract("secrets/{secret}").startsWith("bt-04__")
     title: Create, update, and delete access for bt-04
   members:
   - serviceAccount:bt-04-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in bt-05 collection'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "bt-05__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "bt-05____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "bt-05__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "bt-05____index"
     title: Read access to secrets for bt-05
   members:
   - serviceAccount:bt-05-updater@test-project.iam.gserviceaccount.com
@@ -130,22 +89,15 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in bt-05 collection'
-    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
-      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"bt-05__\")"
+    expression: resource.name.extract("secrets/{secret}").startsWith("bt-05__")
     title: Create, update, and delete access for bt-05
   members:
   - serviceAccount:bt-05-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in bt-06 collection'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "bt-06__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "bt-06____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "bt-06__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "bt-06____index"
     title: Read access to secrets for bt-06
   members:
   - serviceAccount:bt-06-updater@test-project.iam.gserviceaccount.com
@@ -153,22 +105,15 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in bt-06 collection'
-    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
-      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"bt-06__\")"
+    expression: resource.name.extract("secrets/{secret}").startsWith("bt-06__")
     title: Create, update, and delete access for bt-06
   members:
   - serviceAccount:bt-06-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in bt-07 collection'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "bt-07__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "bt-07____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "bt-07__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "bt-07____index"
     title: Read access to secrets for bt-07
   members:
   - serviceAccount:bt-07-updater@test-project.iam.gserviceaccount.com
@@ -176,22 +121,15 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in bt-07 collection'
-    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
-      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"bt-07__\")"
+    expression: resource.name.extract("secrets/{secret}").startsWith("bt-07__")
     title: Create, update, and delete access for bt-07
   members:
   - serviceAccount:bt-07-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in bt-08 collection'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "bt-08__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "bt-08____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "bt-08__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "bt-08____index"
     title: Read access to secrets for bt-08
   members:
   - serviceAccount:bt-08-updater@test-project.iam.gserviceaccount.com
@@ -199,22 +137,15 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in bt-08 collection'
-    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
-      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"bt-08__\")"
+    expression: resource.name.extract("secrets/{secret}").startsWith("bt-08__")
     title: Create, update, and delete access for bt-08
   members:
   - serviceAccount:bt-08-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in bt-09 collection'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "bt-09__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "bt-09____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "bt-09__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "bt-09____index"
     title: Read access to secrets for bt-09
   members:
   - serviceAccount:bt-09-updater@test-project.iam.gserviceaccount.com
@@ -222,22 +153,15 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in bt-09 collection'
-    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
-      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"bt-09__\")"
+    expression: resource.name.extract("secrets/{secret}").startsWith("bt-09__")
     title: Create, update, and delete access for bt-09
   members:
   - serviceAccount:bt-09-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in bt-10 collection'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "bt-10__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "bt-10____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "bt-10__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "bt-10____index"
     title: Read access to secrets for bt-10
   members:
   - serviceAccount:bt-10-updater@test-project.iam.gserviceaccount.com
@@ -245,22 +169,15 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in bt-10 collection'
-    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
-      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"bt-10__\")"
+    expression: resource.name.extract("secrets/{secret}").startsWith("bt-10__")
     title: Create, update, and delete access for bt-10
   members:
   - serviceAccount:bt-10-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in bt-11 collection'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "bt-11__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "bt-11____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "bt-11__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "bt-11____index"
     title: Read access to secrets for bt-11
   members:
   - serviceAccount:bt-11-updater@test-project.iam.gserviceaccount.com
@@ -268,22 +185,15 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in bt-11 collection'
-    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
-      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"bt-11__\")"
+    expression: resource.name.extract("secrets/{secret}").startsWith("bt-11__")
     title: Create, update, and delete access for bt-11
   members:
   - serviceAccount:bt-11-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in bt-12 collection'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "bt-12__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "bt-12____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "bt-12__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "bt-12____index"
     title: Read access to secrets for bt-12
   members:
   - serviceAccount:bt-12-updater@test-project.iam.gserviceaccount.com
@@ -291,22 +201,15 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in bt-12 collection'
-    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
-      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"bt-12__\")"
+    expression: resource.name.extract("secrets/{secret}").startsWith("bt-12__")
     title: Create, update, and delete access for bt-12
   members:
   - serviceAccount:bt-12-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in st-01 collection'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "st-01__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "st-01____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "st-01__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "st-01____index"
     title: Read access to secrets for st-01
   members:
   - serviceAccount:st-01-updater@test-project.iam.gserviceaccount.com
@@ -314,8 +217,7 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in st-01 collection'
-    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
-      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"st-01__\")"
+    expression: resource.name.extract("secrets/{secret}").startsWith("st-01__")
     title: Create, update, and delete access for st-01
   members:
   - serviceAccount:st-01-updater@test-project.iam.gserviceaccount.com
@@ -323,16 +225,10 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets for group another-team
       (set 1)'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "at-01__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "at-01____index" ||
-        resource.name.extract("secrets/{secret}") == "bt-01__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "bt-01____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "at-01__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "at-01____index" || resource.name.extract("secrets/{s}/versions/")
+      == "bt-01__updater-service-account" || resource.name.extract("secrets/{s}/versions/")
+      == "bt-01____index"
     title: Read access to secrets for group another-team (set 1)
   members:
   - group:another-team@redhat.com
@@ -340,14 +236,8 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       for group another-team (set 1)'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}").startsWith("at-01__") ||
-        resource.name.extract("secrets/{secret}").startsWith("bt-01__")
-      )
+    expression: resource.name.extract("secrets/{secret}").startsWith("at-01__") ||
+      resource.name.extract("secrets/{secret}").startsWith("bt-01__")
     title: Create, update, and delete access for group another-team (set 1)
   members:
   - group:another-team@redhat.com
@@ -355,22 +245,14 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets for group big-team
       (set 1)'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "bt-01__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "bt-01____index" ||
-        resource.name.extract("secrets/{secret}") == "bt-02__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "bt-02____index" ||
-        resource.name.extract("secrets/{secret}") == "bt-03__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "bt-03____index" ||
-        resource.name.extract("secrets/{secret}") == "bt-04__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "bt-04____index" ||
-        resource.name.extract("secrets/{secret}") == "bt-05__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "bt-05____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "bt-01__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "bt-01____index" || resource.name.extract("secrets/{s}/versions/")
+      == "bt-02__updater-service-account" || resource.name.extract("secrets/{s}/versions/")
+      == "bt-02____index" || resource.name.extract("secrets/{s}/versions/") == "bt-03__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "bt-03____index" || resource.name.extract("secrets/{s}/versions/")
+      == "bt-04__updater-service-account" || resource.name.extract("secrets/{s}/versions/")
+      == "bt-04____index" || resource.name.extract("secrets/{s}/versions/") == "bt-05__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "bt-05____index"
     title: Read access to secrets for group big-team (set 1)
   members:
   - group:big-team@redhat.com
@@ -378,17 +260,9 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       for group big-team (set 1)'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}").startsWith("bt-01__") ||
-        resource.name.extract("secrets/{secret}").startsWith("bt-02__") ||
-        resource.name.extract("secrets/{secret}").startsWith("bt-03__") ||
-        resource.name.extract("secrets/{secret}").startsWith("bt-04__") ||
-        resource.name.extract("secrets/{secret}").startsWith("bt-05__")
-      )
+    expression: resource.name.extract("secrets/{secret}").startsWith("bt-01__") ||
+      resource.name.extract("secrets/{secret}").startsWith("bt-02__") || resource.name.extract("secrets/{secret}").startsWith("bt-03__")
+      || resource.name.extract("secrets/{secret}").startsWith("bt-04__") || resource.name.extract("secrets/{secret}").startsWith("bt-05__")
     title: Create, update, and delete access for group big-team (set 1)
   members:
   - group:big-team@redhat.com
@@ -396,22 +270,14 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets for group big-team
       (set 2)'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "bt-06__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "bt-06____index" ||
-        resource.name.extract("secrets/{secret}") == "bt-07__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "bt-07____index" ||
-        resource.name.extract("secrets/{secret}") == "bt-08__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "bt-08____index" ||
-        resource.name.extract("secrets/{secret}") == "bt-09__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "bt-09____index" ||
-        resource.name.extract("secrets/{secret}") == "bt-10__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "bt-10____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "bt-06__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "bt-06____index" || resource.name.extract("secrets/{s}/versions/")
+      == "bt-07__updater-service-account" || resource.name.extract("secrets/{s}/versions/")
+      == "bt-07____index" || resource.name.extract("secrets/{s}/versions/") == "bt-08__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "bt-08____index" || resource.name.extract("secrets/{s}/versions/")
+      == "bt-09__updater-service-account" || resource.name.extract("secrets/{s}/versions/")
+      == "bt-09____index" || resource.name.extract("secrets/{s}/versions/") == "bt-10__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "bt-10____index"
     title: Read access to secrets for group big-team (set 2)
   members:
   - group:big-team@redhat.com
@@ -419,17 +285,9 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       for group big-team (set 2)'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}").startsWith("bt-06__") ||
-        resource.name.extract("secrets/{secret}").startsWith("bt-07__") ||
-        resource.name.extract("secrets/{secret}").startsWith("bt-08__") ||
-        resource.name.extract("secrets/{secret}").startsWith("bt-09__") ||
-        resource.name.extract("secrets/{secret}").startsWith("bt-10__")
-      )
+    expression: resource.name.extract("secrets/{secret}").startsWith("bt-06__") ||
+      resource.name.extract("secrets/{secret}").startsWith("bt-07__") || resource.name.extract("secrets/{secret}").startsWith("bt-08__")
+      || resource.name.extract("secrets/{secret}").startsWith("bt-09__") || resource.name.extract("secrets/{secret}").startsWith("bt-10__")
     title: Create, update, and delete access for group big-team (set 2)
   members:
   - group:big-team@redhat.com
@@ -437,16 +295,10 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets for group big-team
       (set 3)'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "bt-11__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "bt-11____index" ||
-        resource.name.extract("secrets/{secret}") == "bt-12__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "bt-12____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "bt-11__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "bt-11____index" || resource.name.extract("secrets/{s}/versions/")
+      == "bt-12__updater-service-account" || resource.name.extract("secrets/{s}/versions/")
+      == "bt-12____index"
     title: Read access to secrets for group big-team (set 3)
   members:
   - group:big-team@redhat.com
@@ -454,14 +306,8 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       for group big-team (set 3)'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}").startsWith("bt-11__") ||
-        resource.name.extract("secrets/{secret}").startsWith("bt-12__")
-      )
+    expression: resource.name.extract("secrets/{secret}").startsWith("bt-11__") ||
+      resource.name.extract("secrets/{secret}").startsWith("bt-12__")
     title: Create, update, and delete access for group big-team (set 3)
   members:
   - group:big-team@redhat.com
@@ -469,14 +315,8 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets for group small-team
       (set 1)'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "st-01__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "st-01____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "st-01__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "st-01____index"
     title: Read access to secrets for group small-team (set 1)
   members:
   - group:small-team@redhat.com
@@ -484,13 +324,7 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       for group small-team (set 1)'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}").startsWith("st-01__")
-      )
+    expression: resource.name.extract("secrets/{secret}").startsWith("st-01__")
     title: Create, update, and delete access for group small-team (set 1)
   members:
   - group:small-team@redhat.com

--- a/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_complex_config.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_complex_config.yaml
@@ -1,14 +1,8 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets in alpha-secrets
       collection'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "alpha-secrets__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "alpha-secrets____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "alpha-secrets__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "alpha-secrets____index"
     title: Read access to secrets for alpha-secrets
   members:
   - serviceAccount:alpha-secrets-updater@test-project.iam.gserviceaccount.com
@@ -16,8 +10,7 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in alpha-secrets collection'
-    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
-      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"alpha-secrets__\")"
+    expression: resource.name.extract("secrets/{secret}").startsWith("alpha-secrets__")
     title: Create, update, and delete access for alpha-secrets
   members:
   - serviceAccount:alpha-secrets-updater@test-project.iam.gserviceaccount.com
@@ -25,14 +18,8 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets in beta-delta-secrets
       collection'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "beta-delta-secrets__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "beta-delta-secrets____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "beta-delta-secrets__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "beta-delta-secrets____index"
     title: Read access to secrets for beta-delta-secrets
   members:
   - serviceAccount:beta-delta-secrets-updater@test-project.iam.gserviceaccount.com
@@ -40,8 +27,7 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in beta-delta-secrets collection'
-    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
-      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"beta-delta-secrets__\")"
+    expression: resource.name.extract("secrets/{secret}").startsWith("beta-delta-secrets__")
     title: Create, update, and delete access for beta-delta-secrets
   members:
   - serviceAccount:beta-delta-secrets-updater@test-project.iam.gserviceaccount.com
@@ -49,14 +35,8 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets in epsilon-secrets
       collection'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "epsilon-secrets__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "epsilon-secrets____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "epsilon-secrets__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "epsilon-secrets____index"
     title: Read access to secrets for epsilon-secrets
   members:
   - serviceAccount:epsilon-secrets-updater@test-project.iam.gserviceaccount.com
@@ -64,8 +44,7 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in epsilon-secrets collection'
-    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
-      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"epsilon-secrets__\")"
+    expression: resource.name.extract("secrets/{secret}").startsWith("epsilon-secrets__")
     title: Create, update, and delete access for epsilon-secrets
   members:
   - serviceAccount:epsilon-secrets-updater@test-project.iam.gserviceaccount.com
@@ -73,14 +52,8 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets for group team-alpha
       (set 1)'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "alpha-secrets__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "alpha-secrets____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "alpha-secrets__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "alpha-secrets____index"
     title: Read access to secrets for group team-alpha (set 1)
   members:
   - group:team-alpha@redhat.com
@@ -88,13 +61,7 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       for group team-alpha (set 1)'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}").startsWith("alpha-secrets__")
-      )
+    expression: resource.name.extract("secrets/{secret}").startsWith("alpha-secrets__")
     title: Create, update, and delete access for group team-alpha (set 1)
   members:
   - group:team-alpha@redhat.com
@@ -102,14 +69,8 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets for group team-beta
       (set 1)'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "beta-delta-secrets__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "beta-delta-secrets____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "beta-delta-secrets__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "beta-delta-secrets____index"
     title: Read access to secrets for group team-beta (set 1)
   members:
   - group:team-beta@redhat.com
@@ -117,13 +78,7 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       for group team-beta (set 1)'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}").startsWith("beta-delta-secrets__")
-      )
+    expression: resource.name.extract("secrets/{secret}").startsWith("beta-delta-secrets__")
     title: Create, update, and delete access for group team-beta (set 1)
   members:
   - group:team-beta@redhat.com
@@ -131,14 +86,8 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets for group team-delta
       (set 1)'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "beta-delta-secrets__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "beta-delta-secrets____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "beta-delta-secrets__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "beta-delta-secrets____index"
     title: Read access to secrets for group team-delta (set 1)
   members:
   - group:team-delta@redhat.com
@@ -146,13 +95,7 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       for group team-delta (set 1)'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}").startsWith("beta-delta-secrets__")
-      )
+    expression: resource.name.extract("secrets/{secret}").startsWith("beta-delta-secrets__")
     title: Create, update, and delete access for group team-delta (set 1)
   members:
   - group:team-delta@redhat.com
@@ -160,14 +103,8 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets for group team-epsilon
       (set 1)'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "epsilon-secrets__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "epsilon-secrets____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "epsilon-secrets__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "epsilon-secrets____index"
     title: Read access to secrets for group team-epsilon (set 1)
   members:
   - group:team-epsilon@redhat.com
@@ -175,13 +112,7 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       for group team-epsilon (set 1)'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}").startsWith("epsilon-secrets__")
-      )
+    expression: resource.name.extract("secrets/{secret}").startsWith("epsilon-secrets__")
     title: Create, update, and delete access for group team-epsilon (set 1)
   members:
   - group:team-epsilon@redhat.com

--- a/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_one_secret_collection.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_one_secret_collection.yaml
@@ -1,14 +1,8 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets in collection-alpha
       collection'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "collection-alpha__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "collection-alpha____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "collection-alpha__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "collection-alpha____index"
     title: Read access to secrets for collection-alpha
   members:
   - serviceAccount:collection-alpha-updater@test-project.iam.gserviceaccount.com
@@ -16,8 +10,7 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in collection-alpha collection'
-    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
-      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"collection-alpha__\")"
+    expression: resource.name.extract("secrets/{secret}").startsWith("collection-alpha__")
     title: Create, update, and delete access for collection-alpha
   members:
   - serviceAccount:collection-alpha-updater@test-project.iam.gserviceaccount.com
@@ -25,14 +18,8 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets for group team-alpha
       (set 1)'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "collection-alpha__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "collection-alpha____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "collection-alpha__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "collection-alpha____index"
     title: Read access to secrets for group team-alpha (set 1)
   members:
   - group:team-alpha@redhat.com
@@ -40,13 +27,7 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       for group team-alpha (set 1)'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}").startsWith("collection-alpha__")
-      )
+    expression: resource.name.extract("secrets/{secret}").startsWith("collection-alpha__")
     title: Create, update, and delete access for group team-alpha (set 1)
   members:
   - group:team-alpha@redhat.com
@@ -54,14 +35,8 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets for group team-beta
       (set 1)'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "collection-alpha__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "collection-alpha____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "collection-alpha__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "collection-alpha____index"
     title: Read access to secrets for group team-beta (set 1)
   members:
   - group:team-beta@redhat.com
@@ -69,13 +44,7 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       for group team-beta (set 1)'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}").startsWith("collection-alpha__")
-      )
+    expression: resource.name.extract("secrets/{secret}").startsWith("collection-alpha__")
     title: Create, update, and delete access for group team-beta (set 1)
   members:
   - group:team-beta@redhat.com

--- a/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_unclaimed_config.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_unclaimed_config.yaml
@@ -1,13 +1,7 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets in claimed-a collection'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "claimed-a__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "claimed-a____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "claimed-a__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "claimed-a____index"
     title: Read access to secrets for claimed-a
   members:
   - serviceAccount:claimed-a-updater@test-project.iam.gserviceaccount.com
@@ -15,22 +9,15 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in claimed-a collection'
-    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
-      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"claimed-a__\")"
+    expression: resource.name.extract("secrets/{secret}").startsWith("claimed-a__")
     title: Create, update, and delete access for claimed-a
   members:
   - serviceAccount:claimed-a-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in claimed-b collection'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "claimed-b__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "claimed-b____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "claimed-b__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "claimed-b____index"
     title: Read access to secrets for claimed-b
   members:
   - serviceAccount:claimed-b-updater@test-project.iam.gserviceaccount.com
@@ -38,8 +25,7 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in claimed-b collection'
-    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
-      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"claimed-b__\")"
+    expression: resource.name.extract("secrets/{secret}").startsWith("claimed-b__")
     title: Create, update, and delete access for claimed-b
   members:
   - serviceAccount:claimed-b-updater@test-project.iam.gserviceaccount.com
@@ -47,16 +33,10 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets for group owner-team
       (set 1)'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "claimed-a__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "claimed-a____index" ||
-        resource.name.extract("secrets/{secret}") == "claimed-b__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "claimed-b____index"
-      )
+    expression: resource.name.extract("secrets/{s}/versions/") == "claimed-a__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "claimed-a____index" ||
+      resource.name.extract("secrets/{s}/versions/") == "claimed-b__updater-service-account"
+      || resource.name.extract("secrets/{s}/versions/") == "claimed-b____index"
     title: Read access to secrets for group owner-team (set 1)
   members:
   - group:owner-team@redhat.com
@@ -64,14 +44,8 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       for group owner-team (set 1)'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}").startsWith("claimed-a__") ||
-        resource.name.extract("secrets/{secret}").startsWith("claimed-b__")
-      )
+    expression: resource.name.extract("secrets/{secret}").startsWith("claimed-a__")
+      || resource.name.extract("secrets/{secret}").startsWith("claimed-b__")
     title: Create, update, and delete access for group owner-team (set 1)
   members:
   - group:owner-team@redhat.com

--- a/pkg/gsm-secrets/types.go
+++ b/pkg/gsm-secrets/types.go
@@ -38,8 +38,8 @@ const (
 
 	// MaxCollectionsPerGroupBinding is the maximum number of collections referenced by a
 	// single group IAM binding condition. GCP allows at most 12 logical operators (&&, ||, !)
-	// per condition expression. The viewer condition uses 2N+1 operators for N collections,
-	// so N=5 (11 operators) is the largest chunk that stays within the limit.
+	// per condition expression. The viewer condition uses 2N-1 operators for N collections,
+	// so N=5 (9 operators) stays within the limit.
 	MaxCollectionsPerGroupBinding = 5
 )
 


### PR DESCRIPTION
`gsm-secret-sync` tool, that runs as the reconciler postsubmit, attaches an IAM condition to each secret collection's viewer and updater role-binding in the `openshift-ci-secrets` project. This PR makes the expression condition in each role binding shorter, because it's not needed and we can save much needed space. (The `resource.type` preamble is redundant.** If the name doesn't match the template, `extract` returns `""` and the condition is false anyway. It costs ~120 bytes per binding, and the project policy has an undocumented ~67KB cap that we are currently over — which is what blocks the secrets migration.)

## Before / after examples, collection `my-team`

```
# VIEWER, before
(
  resource.type == "secretmanager.googleapis.com/SecretVersion" ||
  resource.type == "secretmanager.googleapis.com/Secret"
) && (
  resource.name.extract("secrets/{secret}") == "my-team__updater-service-account" ||
  resource.name.extract("secrets/{secret}") == "my-team____index"
)

# VIEWER, after
resource.name.extract("secrets/{s}/versions/") == "my-team__updater-service-account" || resource.name.extract("secrets/{s}/versions/") == "my-team____index"
```

```
# UPDATER, before
(
  resource.type == "secretmanager.googleapis.com/SecretVersion" ||
  resource.type == "secretmanager.googleapis.com/Secret"
) && 
  resource.name.extract("secrets/{secret}").startsWith("my-team__")

# UPDATER, after
resource.name.extract("secrets/{secret}").startsWith("my-team__")
```

## Reviewer notes

- `IsManagedBinding` (which decides what the reconciler may delete) used to search the expression for `secretmanager.googleapis.com`, removed here. It now keys on the role plus the condition title prefix. That prefix is what keeps the two hand-made `EXCEPTION: ...` bindings in prod from being seen as ours and pruned — new test covers it.
- `correct binding with different description` now expects `true` and is renamed; it asserted the description check this removes.
- Verified against real GCP, not just unit tests: A/B tested on `openshift-ci-secrets-dev` (both variants bound to a test SA in turn, same probes), then confirmed on prod by impersonating a real updater SA — `versions access` on `<collection>____index` now allowed, on a data secret still denied.
- Most of the diff is regenerated test fixtures.
