### PR TITLE
gsm-secrets: match collections with CEL "in" and stop chunking group bindings

### DIFF
--- a/pkg/gsm-secrets/config.go
+++ b/pkg/gsm-secrets/config.go
@@ -16,9 +16,8 @@ import (
 //
 // Collections owned by a normal ("claimed") group each get an updater service account, its SA
 // secret, an index secret, and service-account-scoped viewer/updater bindings limited to that
-// single collection. Each owning group additionally gets its own viewer/updater bindings; a
-// group's collections are chunked (at most MaxCollectionsPerGroupBinding per binding) so no
-// single binding exceeds GCP's IAM limits on operators per condition and bindings per role+member.
+// single collection. Each owning group additionally gets one viewer and one updater binding
+// covering all of its collections.
 //
 // Collections owned only by an "unclaimed" group (see group.Target.Unclaimed) are kept in the
 // active-collection set so their migrated data secrets are not deleted, but they get no service
@@ -104,8 +103,8 @@ func GetDesiredState(configFile string, config Config) ([]ServiceAccountInfo, ma
 		})
 	}
 
-	// Per claimed group: viewer/updater bindings for the group principal, chunked so each
-	// binding condition stays within GCP's IAM limits.
+	// Per claimed group: one viewer and one updater binding covering all of the group's
+	// collections, however many it owns.
 	for _, name := range groupNames {
 		groupCfg := groupConfig.Groups[name]
 		if groupCfg.Unclaimed || len(groupCfg.SecretCollections) == 0 {
@@ -118,26 +117,24 @@ func GetDesiredState(configFile string, config Config) ([]ServiceAccountInfo, ma
 		copy(collections, groupCfg.SecretCollections)
 		sort.Strings(collections)
 
-		for chunkIdx, chunk := range chunkCollections(collections, MaxCollectionsPerGroupBinding) {
-			desiredIAMBindings = append(desiredIAMBindings, &iampb.Binding{
-				Role:    config.GetSecretAccessorRole(),
-				Members: groupMembers,
-				Condition: &expr.Expr{
-					Expression:  BuildSecretAccessorRoleConditionExpressionForCollections(chunk),
-					Title:       GetSecretsViewerGroupConditionTitle(name, chunkIdx),
-					Description: GetSecretsViewerGroupConditionDescription(name, chunkIdx),
-				},
-			})
-			desiredIAMBindings = append(desiredIAMBindings, &iampb.Binding{
-				Role:    config.GetSecretUpdaterRole(),
-				Members: groupMembers,
-				Condition: &expr.Expr{
-					Expression:  BuildSecretUpdaterRoleConditionExpressionForCollections(chunk),
-					Title:       GetSecretsUpdaterGroupConditionTitle(name, chunkIdx),
-					Description: GetSecretsUpdaterGroupConditionDescription(name, chunkIdx),
-				},
-			})
-		}
+		desiredIAMBindings = append(desiredIAMBindings, &iampb.Binding{
+			Role:    config.GetSecretAccessorRole(),
+			Members: groupMembers,
+			Condition: &expr.Expr{
+				Expression:  BuildSecretAccessorRoleConditionExpressionForCollections(collections),
+				Title:       GetSecretsViewerGroupConditionTitle(name),
+				Description: GetSecretsViewerGroupConditionDescription(name),
+			},
+		})
+		desiredIAMBindings = append(desiredIAMBindings, &iampb.Binding{
+			Role:    config.GetSecretUpdaterRole(),
+			Members: groupMembers,
+			Condition: &expr.Expr{
+				Expression:  BuildSecretUpdaterRoleConditionExpressionForCollections(collections),
+				Title:       GetSecretsUpdaterGroupConditionTitle(name),
+				Description: GetSecretsUpdaterGroupConditionDescription(name),
+			},
+		})
 	}
 
 	return desiredSAs, desiredSecrets, desiredIAMBindings, desiredCollections, nil

--- a/pkg/gsm-secrets/iam.go
+++ b/pkg/gsm-secrets/iam.go
@@ -14,16 +14,20 @@ import (
 
 // The two roles need different templates because GCP checks their permissions on different
 // resources. The viewer only holds versions.access, checked on "projects/P/secrets/S/versions/V",
-// so anchoring on "/versions/" makes {s} stop at the secret name and match by equality. The
-// updater also holds secrets.get/update/delete, checked on the bare "projects/P/secrets/S",
-// where that anchor finds nothing and returns ""; the greedy template yields the secret name
-// there and "S/versions/V" on a version, both of which satisfy the prefix match.
+// so anchoring on "/versions/" makes {s} stop at the secret name. The updater also holds
+// secrets.get/update/delete, checked on the bare "projects/P/secrets/S", where that anchor finds
+// nothing and returns ""; anchoring on the "__" delimiter works on both resource types, since
+// extract stops at the first "__" and so yields the bare collection name even for "<c>____index"
+// and nested "<c>__group__field".
+//
+// Matching with "in" rather than chained "==" or startsWith() is what lets one binding cover a
+// whole group: "in" does not count against GCP's limit of 12 logical operators per condition.
 //
 // Dropping the "resource.type" guard is safe: an unmatched template returns "" and the
 // condition is false, so access fails closed.
 const (
 	viewerSecretNameTemplate  = `resource.name.extract("secrets/{s}/versions/")`
-	updaterSecretNameTemplate = `resource.name.extract("secrets/{secret}")`
+	updaterSecretNameTemplate = `resource.name.extract("secrets/{c}__")`
 )
 
 // BuildSecretAccessorRoleConditionExpression builds the IAM condition expression for secret accessor role
@@ -37,39 +41,33 @@ func BuildSecretUpdaterRoleConditionExpression(collection string) string {
 }
 
 // BuildSecretAccessorRoleConditionExpressionForCollections builds the viewer IAM condition
-// expression covering multiple collections. It is used for group bindings, where a group's
-// collections are chunked to keep the number of logical operators within GCP's limits.
+// expression covering multiple collections: each collection's updater service account secret
+// and its index secret, never its data secrets.
 func BuildSecretAccessorRoleConditionExpressionForCollections(collections []string) string {
-	var terms []string
+	var names []string
 	for _, collection := range collections {
-		terms = append(terms,
-			fmt.Sprintf(`%s == "%s%s"`, viewerSecretNameTemplate, collection, UpdaterSASecretSuffix),
-			fmt.Sprintf(`%s == "%s%s"`, viewerSecretNameTemplate, collection, IndexSecretSuffix),
+		names = append(names,
+			fmt.Sprintf("%s%s", collection, UpdaterSASecretSuffix),
+			fmt.Sprintf("%s%s", collection, IndexSecretSuffix),
 		)
 	}
-	return strings.Join(terms, " || ")
+	return fmt.Sprintf("%s in [%s]", viewerSecretNameTemplate, quoteJoin(names))
 }
 
 // BuildSecretUpdaterRoleConditionExpressionForCollections builds the updater IAM condition
-// expression covering multiple collections. It is used for group bindings, where a group's
-// collections are chunked to keep the number of logical operators within GCP's limits.
+// expression covering multiple collections: any secret in any of them.
 func BuildSecretUpdaterRoleConditionExpressionForCollections(collections []string) string {
-	var terms []string
-	for _, collection := range collections {
-		terms = append(terms, fmt.Sprintf(`%s.startsWith("%s__")`, updaterSecretNameTemplate, collection))
-	}
-	return strings.Join(terms, " || ")
+	return fmt.Sprintf("%s in [%s]", updaterSecretNameTemplate, quoteJoin(collections))
 }
 
-// chunkCollections splits a sorted slice of collections into consecutive chunks of at most
-// size. Chunking is deterministic so binding conditions stay stable across reconciler runs.
-func chunkCollections(collections []string, size int) [][]string {
-	var chunks [][]string
-	for i := 0; i < len(collections); i += size {
-		end := min(i+size, len(collections))
-		chunks = append(chunks, collections[i:end])
+// quoteJoin renders values as a comma-separated list of CEL string literals. Collection and
+// secret names are restricted to [a-z0-9_-], so no escaping is needed.
+func quoteJoin(values []string) string {
+	quoted := make([]string, 0, len(values))
+	for _, v := range values {
+		quoted = append(quoted, fmt.Sprintf("%q", v))
 	}
-	return chunks
+	return strings.Join(quoted, ", ")
 }
 
 // GetSecretsViewerConditionTitle returns the condition title for secrets viewer role
@@ -77,24 +75,24 @@ func GetSecretsViewerConditionTitle(collection string) string {
 	return fmt.Sprintf("%s%s", SecretsViewerConditionTitlePrefix, collection)
 }
 
-// GetSecretsViewerGroupConditionTitle returns the viewer condition title for a group binding chunk.
-func GetSecretsViewerGroupConditionTitle(group string, chunkIdx int) string {
-	return fmt.Sprintf("%sgroup %s (set %d)", SecretsViewerConditionTitlePrefix, group, chunkIdx+1)
+// GetSecretsViewerGroupConditionTitle returns the viewer condition title for a group binding.
+func GetSecretsViewerGroupConditionTitle(group string) string {
+	return fmt.Sprintf("%sgroup %s", SecretsViewerConditionTitlePrefix, group)
 }
 
-// GetSecretsUpdaterGroupConditionTitle returns the updater condition title for a group binding chunk.
-func GetSecretsUpdaterGroupConditionTitle(group string, chunkIdx int) string {
-	return fmt.Sprintf("%sgroup %s (set %d)", SecretsUpdaterConditionTitlePrefix, group, chunkIdx+1)
+// GetSecretsUpdaterGroupConditionTitle returns the updater condition title for a group binding.
+func GetSecretsUpdaterGroupConditionTitle(group string) string {
+	return fmt.Sprintf("%sgroup %s", SecretsUpdaterConditionTitlePrefix, group)
 }
 
-// GetSecretsViewerGroupConditionDescription returns the viewer condition description for a group binding chunk.
-func GetSecretsViewerGroupConditionDescription(group string, chunkIdx int) string {
-	return fmt.Sprintf("Managed by %s: Read access to secrets for group %s (set %d)", TestPlatform, group, chunkIdx+1)
+// GetSecretsViewerGroupConditionDescription returns the viewer condition description for a group binding.
+func GetSecretsViewerGroupConditionDescription(group string) string {
+	return fmt.Sprintf("Managed by %s: Read access to secrets for group %s", TestPlatform, group)
 }
 
-// GetSecretsUpdaterGroupConditionDescription returns the updater condition description for a group binding chunk.
-func GetSecretsUpdaterGroupConditionDescription(group string, chunkIdx int) string {
-	return fmt.Sprintf("Managed by %s: Create, update, and delete access to secrets for group %s (set %d)", TestPlatform, group, chunkIdx+1)
+// GetSecretsUpdaterGroupConditionDescription returns the updater condition description for a group binding.
+func GetSecretsUpdaterGroupConditionDescription(group string) string {
+	return fmt.Sprintf("Managed by %s: Create, update, and delete access to secrets for group %s", TestPlatform, group)
 }
 
 // GetSecretsUpdaterConditionTitle returns the condition title for secrets updater role
@@ -133,7 +131,9 @@ func IsManagedBinding(b *iampb.Binding) bool {
 
 	expr := b.Condition.Expression
 	hasSecretExtract := strings.Contains(expr, "resource.name.extract(")
-	hasExpectedPattern := strings.Contains(expr, "startsWith(") || strings.Contains(expr, "==")
+	hasExpectedPattern := strings.Contains(expr, " in [") ||
+		strings.Contains(expr, "startsWith(") ||
+		strings.Contains(expr, "==")
 
 	return hasSecretExtract && hasExpectedPattern
 }

--- a/pkg/gsm-secrets/iam_test.go
+++ b/pkg/gsm-secrets/iam_test.go
@@ -168,43 +168,31 @@ func TestToCanonicalIAMBinding(t *testing.T) {
 	}
 }
 
-func TestChunkCollections(t *testing.T) {
+func TestBuildConditionExpressions(t *testing.T) {
 	testCases := []struct {
-		name        string
-		collections []string
-		size        int
-		expected    [][]string
+		name            string
+		collections     []string
+		expectedViewer  string
+		expectedUpdater string
 	}{
 		{
-			name:        "empty",
-			collections: nil,
-			size:        5,
-			expected:    nil,
+			name:            "single collection",
+			collections:     []string{"alpha"},
+			expectedViewer:  `resource.name.extract("secrets/{s}/versions/") in ["alpha__updater-service-account", "alpha____index"]`,
+			expectedUpdater: `resource.name.extract("secrets/{c}__") in ["alpha"]`,
 		},
 		{
-			name:        "fewer than size",
-			collections: []string{"a", "b"},
-			size:        5,
-			expected:    [][]string{{"a", "b"}},
-		},
-		{
-			name:        "exact multiple of size",
-			collections: []string{"a", "b", "c", "d"},
-			size:        2,
-			expected:    [][]string{{"a", "b"}, {"c", "d"}},
-		},
-		{
-			name:        "size with remainder",
-			collections: []string{"a", "b", "c", "d", "e"},
-			size:        2,
-			expected:    [][]string{{"a", "b"}, {"c", "d"}, {"e"}},
+			name:            "multiple collections",
+			collections:     []string{"alpha", "beta"},
+			expectedViewer:  `resource.name.extract("secrets/{s}/versions/") in ["alpha__updater-service-account", "alpha____index", "beta__updater-service-account", "beta____index"]`,
+			expectedUpdater: `resource.name.extract("secrets/{c}__") in ["alpha", "beta"]`,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := chunkCollections(tc.collections, tc.size)
-			testhelper.Diff(t, "chunks", actual, tc.expected)
+			testhelper.Diff(t, "viewer", BuildSecretAccessorRoleConditionExpressionForCollections(tc.collections), tc.expectedViewer)
+			testhelper.Diff(t, "updater", BuildSecretUpdaterRoleConditionExpressionForCollections(tc.collections), tc.expectedUpdater)
 		})
 	}
 }
@@ -301,26 +289,26 @@ func TestIsManagedBinding(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "group viewer binding chunk",
+			name: "group viewer binding",
 			binding: &iampb.Binding{
 				Role:    config.GetSecretAccessorRole(),
 				Members: []string{"group:team-x@redhat.com"},
 				Condition: &expr.Expr{
-					Title:       GetSecretsViewerGroupConditionTitle("team-x", 0),
-					Description: GetSecretsViewerGroupConditionDescription("team-x", 0),
+					Title:       GetSecretsViewerGroupConditionTitle("team-x"),
+					Description: GetSecretsViewerGroupConditionDescription("team-x"),
 					Expression:  BuildSecretAccessorRoleConditionExpressionForCollections([]string{"a", "b"}),
 				},
 			},
 			expected: true,
 		},
 		{
-			name: "group updater binding chunk",
+			name: "group updater binding",
 			binding: &iampb.Binding{
 				Role:    config.GetSecretUpdaterRole(),
 				Members: []string{"group:team-x@redhat.com"},
 				Condition: &expr.Expr{
-					Title:       GetSecretsUpdaterGroupConditionTitle("team-x", 1),
-					Description: GetSecretsUpdaterGroupConditionDescription("team-x", 1),
+					Title:       GetSecretsUpdaterGroupConditionTitle("team-x"),
+					Description: GetSecretsUpdaterGroupConditionDescription("team-x"),
 					Expression:  BuildSecretUpdaterRoleConditionExpressionForCollections([]string{"a", "b"}),
 				},
 			},

--- a/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_basic_config.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_basic_config.yaml
@@ -1,8 +1,8 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets in collection-alpha
       collection'
-    expression: resource.name.extract("secrets/{s}/versions/") == "collection-alpha__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "collection-alpha____index"
+    expression: resource.name.extract("secrets/{s}/versions/") in ["collection-alpha__updater-service-account",
+      "collection-alpha____index"]
     title: Read access to secrets for collection-alpha
   members:
   - serviceAccount:collection-alpha-updater@test-project.iam.gserviceaccount.com
@@ -10,7 +10,7 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in collection-alpha collection'
-    expression: resource.name.extract("secrets/{secret}").startsWith("collection-alpha__")
+    expression: resource.name.extract("secrets/{c}__") in ["collection-alpha"]
     title: Create, update, and delete access for collection-alpha
   members:
   - serviceAccount:collection-alpha-updater@test-project.iam.gserviceaccount.com
@@ -18,8 +18,8 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets in shared-collection
       collection'
-    expression: resource.name.extract("secrets/{s}/versions/") == "shared-collection__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "shared-collection____index"
+    expression: resource.name.extract("secrets/{s}/versions/") in ["shared-collection__updater-service-account",
+      "shared-collection____index"]
     title: Read access to secrets for shared-collection
   members:
   - serviceAccount:shared-collection-updater@test-project.iam.gserviceaccount.com
@@ -27,7 +27,7 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in shared-collection collection'
-    expression: resource.name.extract("secrets/{secret}").startsWith("shared-collection__")
+    expression: resource.name.extract("secrets/{c}__") in ["shared-collection"]
     title: Create, update, and delete access for shared-collection
   members:
   - serviceAccount:shared-collection-updater@test-project.iam.gserviceaccount.com
@@ -35,8 +35,8 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets in some-collection-with-a-very-long-name
       collection'
-    expression: resource.name.extract("secrets/{s}/versions/") == "some-collection-with-a-very-long-name__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "some-collection-with-a-very-long-name____index"
+    expression: resource.name.extract("secrets/{s}/versions/") in ["some-collection-with-a-very-long-name__updater-service-account",
+      "some-collection-with-a-very-long-name____index"]
     title: Read access to secrets for some-collection-with-a-very-long-name
   members:
   - serviceAccount:ynbbgzp1q3u3iwp8edyqix-updater@test-project.iam.gserviceaccount.com
@@ -44,48 +44,41 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in some-collection-with-a-very-long-name collection'
-    expression: resource.name.extract("secrets/{secret}").startsWith("some-collection-with-a-very-long-name__")
+    expression: resource.name.extract("secrets/{c}__") in ["some-collection-with-a-very-long-name"]
     title: Create, update, and delete access for some-collection-with-a-very-long-name
   members:
   - serviceAccount:ynbbgzp1q3u3iwp8edyqix-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
-    description: 'Managed by test platform: Read access to secrets for group team-alpha
-      (set 1)'
-    expression: resource.name.extract("secrets/{s}/versions/") == "collection-alpha__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "collection-alpha____index"
-      || resource.name.extract("secrets/{s}/versions/") == "shared-collection__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "shared-collection____index"
-    title: Read access to secrets for group team-alpha (set 1)
+    description: 'Managed by test platform: Read access to secrets for group team-alpha'
+    expression: resource.name.extract("secrets/{s}/versions/") in ["collection-alpha__updater-service-account",
+      "collection-alpha____index", "shared-collection__updater-service-account", "shared-collection____index"]
+    title: Read access to secrets for group team-alpha
   members:
   - group:team-alpha@redhat.com
   role: projects/test-project/roles/openshift_ci_secrets_viewer
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
-      for group team-alpha (set 1)'
-    expression: resource.name.extract("secrets/{secret}").startsWith("collection-alpha__")
-      || resource.name.extract("secrets/{secret}").startsWith("shared-collection__")
-    title: Create, update, and delete access for group team-alpha (set 1)
+      for group team-alpha'
+    expression: resource.name.extract("secrets/{c}__") in ["collection-alpha", "shared-collection"]
+    title: Create, update, and delete access for group team-alpha
   members:
   - group:team-alpha@redhat.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
-    description: 'Managed by test platform: Read access to secrets for group team-beta
-      (set 1)'
-    expression: resource.name.extract("secrets/{s}/versions/") == "shared-collection__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "shared-collection____index"
-      || resource.name.extract("secrets/{s}/versions/") == "some-collection-with-a-very-long-name__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "some-collection-with-a-very-long-name____index"
-    title: Read access to secrets for group team-beta (set 1)
+    description: 'Managed by test platform: Read access to secrets for group team-beta'
+    expression: resource.name.extract("secrets/{s}/versions/") in ["shared-collection__updater-service-account",
+      "shared-collection____index", "some-collection-with-a-very-long-name__updater-service-account",
+      "some-collection-with-a-very-long-name____index"]
+    title: Read access to secrets for group team-beta
   members:
   - group:team-beta@redhat.com
   role: projects/test-project/roles/openshift_ci_secrets_viewer
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
-      for group team-beta (set 1)'
-    expression: resource.name.extract("secrets/{secret}").startsWith("shared-collection__")
-      || resource.name.extract("secrets/{secret}").startsWith("some-collection-with-a-very-long-name__")
-    title: Create, update, and delete access for group team-beta (set 1)
+      for group team-beta'
+    expression: resource.name.extract("secrets/{c}__") in ["shared-collection", "some-collection-with-a-very-long-name"]
+    title: Create, update, and delete access for group team-beta
   members:
   - group:team-beta@redhat.com
   role: projects/test-project/roles/openshift_ci_secrets_updater

--- a/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_chunked_config.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_chunked_config.yaml
@@ -1,7 +1,7 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets in at-01 collection'
-    expression: resource.name.extract("secrets/{s}/versions/") == "at-01__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "at-01____index"
+    expression: resource.name.extract("secrets/{s}/versions/") in ["at-01__updater-service-account",
+      "at-01____index"]
     title: Read access to secrets for at-01
   members:
   - serviceAccount:at-01-updater@test-project.iam.gserviceaccount.com
@@ -9,15 +9,15 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in at-01 collection'
-    expression: resource.name.extract("secrets/{secret}").startsWith("at-01__")
+    expression: resource.name.extract("secrets/{c}__") in ["at-01"]
     title: Create, update, and delete access for at-01
   members:
   - serviceAccount:at-01-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in bt-01 collection'
-    expression: resource.name.extract("secrets/{s}/versions/") == "bt-01__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "bt-01____index"
+    expression: resource.name.extract("secrets/{s}/versions/") in ["bt-01__updater-service-account",
+      "bt-01____index"]
     title: Read access to secrets for bt-01
   members:
   - serviceAccount:bt-01-updater@test-project.iam.gserviceaccount.com
@@ -25,15 +25,15 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in bt-01 collection'
-    expression: resource.name.extract("secrets/{secret}").startsWith("bt-01__")
+    expression: resource.name.extract("secrets/{c}__") in ["bt-01"]
     title: Create, update, and delete access for bt-01
   members:
   - serviceAccount:bt-01-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in bt-02 collection'
-    expression: resource.name.extract("secrets/{s}/versions/") == "bt-02__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "bt-02____index"
+    expression: resource.name.extract("secrets/{s}/versions/") in ["bt-02__updater-service-account",
+      "bt-02____index"]
     title: Read access to secrets for bt-02
   members:
   - serviceAccount:bt-02-updater@test-project.iam.gserviceaccount.com
@@ -41,15 +41,15 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in bt-02 collection'
-    expression: resource.name.extract("secrets/{secret}").startsWith("bt-02__")
+    expression: resource.name.extract("secrets/{c}__") in ["bt-02"]
     title: Create, update, and delete access for bt-02
   members:
   - serviceAccount:bt-02-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in bt-03 collection'
-    expression: resource.name.extract("secrets/{s}/versions/") == "bt-03__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "bt-03____index"
+    expression: resource.name.extract("secrets/{s}/versions/") in ["bt-03__updater-service-account",
+      "bt-03____index"]
     title: Read access to secrets for bt-03
   members:
   - serviceAccount:bt-03-updater@test-project.iam.gserviceaccount.com
@@ -57,15 +57,15 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in bt-03 collection'
-    expression: resource.name.extract("secrets/{secret}").startsWith("bt-03__")
+    expression: resource.name.extract("secrets/{c}__") in ["bt-03"]
     title: Create, update, and delete access for bt-03
   members:
   - serviceAccount:bt-03-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in bt-04 collection'
-    expression: resource.name.extract("secrets/{s}/versions/") == "bt-04__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "bt-04____index"
+    expression: resource.name.extract("secrets/{s}/versions/") in ["bt-04__updater-service-account",
+      "bt-04____index"]
     title: Read access to secrets for bt-04
   members:
   - serviceAccount:bt-04-updater@test-project.iam.gserviceaccount.com
@@ -73,15 +73,15 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in bt-04 collection'
-    expression: resource.name.extract("secrets/{secret}").startsWith("bt-04__")
+    expression: resource.name.extract("secrets/{c}__") in ["bt-04"]
     title: Create, update, and delete access for bt-04
   members:
   - serviceAccount:bt-04-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in bt-05 collection'
-    expression: resource.name.extract("secrets/{s}/versions/") == "bt-05__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "bt-05____index"
+    expression: resource.name.extract("secrets/{s}/versions/") in ["bt-05__updater-service-account",
+      "bt-05____index"]
     title: Read access to secrets for bt-05
   members:
   - serviceAccount:bt-05-updater@test-project.iam.gserviceaccount.com
@@ -89,15 +89,15 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in bt-05 collection'
-    expression: resource.name.extract("secrets/{secret}").startsWith("bt-05__")
+    expression: resource.name.extract("secrets/{c}__") in ["bt-05"]
     title: Create, update, and delete access for bt-05
   members:
   - serviceAccount:bt-05-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in bt-06 collection'
-    expression: resource.name.extract("secrets/{s}/versions/") == "bt-06__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "bt-06____index"
+    expression: resource.name.extract("secrets/{s}/versions/") in ["bt-06__updater-service-account",
+      "bt-06____index"]
     title: Read access to secrets for bt-06
   members:
   - serviceAccount:bt-06-updater@test-project.iam.gserviceaccount.com
@@ -105,15 +105,15 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in bt-06 collection'
-    expression: resource.name.extract("secrets/{secret}").startsWith("bt-06__")
+    expression: resource.name.extract("secrets/{c}__") in ["bt-06"]
     title: Create, update, and delete access for bt-06
   members:
   - serviceAccount:bt-06-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in bt-07 collection'
-    expression: resource.name.extract("secrets/{s}/versions/") == "bt-07__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "bt-07____index"
+    expression: resource.name.extract("secrets/{s}/versions/") in ["bt-07__updater-service-account",
+      "bt-07____index"]
     title: Read access to secrets for bt-07
   members:
   - serviceAccount:bt-07-updater@test-project.iam.gserviceaccount.com
@@ -121,15 +121,15 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in bt-07 collection'
-    expression: resource.name.extract("secrets/{secret}").startsWith("bt-07__")
+    expression: resource.name.extract("secrets/{c}__") in ["bt-07"]
     title: Create, update, and delete access for bt-07
   members:
   - serviceAccount:bt-07-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in bt-08 collection'
-    expression: resource.name.extract("secrets/{s}/versions/") == "bt-08__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "bt-08____index"
+    expression: resource.name.extract("secrets/{s}/versions/") in ["bt-08__updater-service-account",
+      "bt-08____index"]
     title: Read access to secrets for bt-08
   members:
   - serviceAccount:bt-08-updater@test-project.iam.gserviceaccount.com
@@ -137,15 +137,15 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in bt-08 collection'
-    expression: resource.name.extract("secrets/{secret}").startsWith("bt-08__")
+    expression: resource.name.extract("secrets/{c}__") in ["bt-08"]
     title: Create, update, and delete access for bt-08
   members:
   - serviceAccount:bt-08-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in bt-09 collection'
-    expression: resource.name.extract("secrets/{s}/versions/") == "bt-09__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "bt-09____index"
+    expression: resource.name.extract("secrets/{s}/versions/") in ["bt-09__updater-service-account",
+      "bt-09____index"]
     title: Read access to secrets for bt-09
   members:
   - serviceAccount:bt-09-updater@test-project.iam.gserviceaccount.com
@@ -153,15 +153,15 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in bt-09 collection'
-    expression: resource.name.extract("secrets/{secret}").startsWith("bt-09__")
+    expression: resource.name.extract("secrets/{c}__") in ["bt-09"]
     title: Create, update, and delete access for bt-09
   members:
   - serviceAccount:bt-09-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in bt-10 collection'
-    expression: resource.name.extract("secrets/{s}/versions/") == "bt-10__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "bt-10____index"
+    expression: resource.name.extract("secrets/{s}/versions/") in ["bt-10__updater-service-account",
+      "bt-10____index"]
     title: Read access to secrets for bt-10
   members:
   - serviceAccount:bt-10-updater@test-project.iam.gserviceaccount.com
@@ -169,15 +169,15 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in bt-10 collection'
-    expression: resource.name.extract("secrets/{secret}").startsWith("bt-10__")
+    expression: resource.name.extract("secrets/{c}__") in ["bt-10"]
     title: Create, update, and delete access for bt-10
   members:
   - serviceAccount:bt-10-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in bt-11 collection'
-    expression: resource.name.extract("secrets/{s}/versions/") == "bt-11__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "bt-11____index"
+    expression: resource.name.extract("secrets/{s}/versions/") in ["bt-11__updater-service-account",
+      "bt-11____index"]
     title: Read access to secrets for bt-11
   members:
   - serviceAccount:bt-11-updater@test-project.iam.gserviceaccount.com
@@ -185,15 +185,15 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in bt-11 collection'
-    expression: resource.name.extract("secrets/{secret}").startsWith("bt-11__")
+    expression: resource.name.extract("secrets/{c}__") in ["bt-11"]
     title: Create, update, and delete access for bt-11
   members:
   - serviceAccount:bt-11-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in bt-12 collection'
-    expression: resource.name.extract("secrets/{s}/versions/") == "bt-12__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "bt-12____index"
+    expression: resource.name.extract("secrets/{s}/versions/") in ["bt-12__updater-service-account",
+      "bt-12____index"]
     title: Read access to secrets for bt-12
   members:
   - serviceAccount:bt-12-updater@test-project.iam.gserviceaccount.com
@@ -201,15 +201,15 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in bt-12 collection'
-    expression: resource.name.extract("secrets/{secret}").startsWith("bt-12__")
+    expression: resource.name.extract("secrets/{c}__") in ["bt-12"]
     title: Create, update, and delete access for bt-12
   members:
   - serviceAccount:bt-12-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in st-01 collection'
-    expression: resource.name.extract("secrets/{s}/versions/") == "st-01__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "st-01____index"
+    expression: resource.name.extract("secrets/{s}/versions/") in ["st-01__updater-service-account",
+      "st-01____index"]
     title: Read access to secrets for st-01
   members:
   - serviceAccount:st-01-updater@test-project.iam.gserviceaccount.com
@@ -217,115 +217,62 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in st-01 collection'
-    expression: resource.name.extract("secrets/{secret}").startsWith("st-01__")
+    expression: resource.name.extract("secrets/{c}__") in ["st-01"]
     title: Create, update, and delete access for st-01
   members:
   - serviceAccount:st-01-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
-    description: 'Managed by test platform: Read access to secrets for group another-team
-      (set 1)'
-    expression: resource.name.extract("secrets/{s}/versions/") == "at-01__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "at-01____index" || resource.name.extract("secrets/{s}/versions/")
-      == "bt-01__updater-service-account" || resource.name.extract("secrets/{s}/versions/")
-      == "bt-01____index"
-    title: Read access to secrets for group another-team (set 1)
+    description: 'Managed by test platform: Read access to secrets for group another-team'
+    expression: resource.name.extract("secrets/{s}/versions/") in ["at-01__updater-service-account",
+      "at-01____index", "bt-01__updater-service-account", "bt-01____index"]
+    title: Read access to secrets for group another-team
   members:
   - group:another-team@redhat.com
   role: projects/test-project/roles/openshift_ci_secrets_viewer
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
-      for group another-team (set 1)'
-    expression: resource.name.extract("secrets/{secret}").startsWith("at-01__") ||
-      resource.name.extract("secrets/{secret}").startsWith("bt-01__")
-    title: Create, update, and delete access for group another-team (set 1)
+      for group another-team'
+    expression: resource.name.extract("secrets/{c}__") in ["at-01", "bt-01"]
+    title: Create, update, and delete access for group another-team
   members:
   - group:another-team@redhat.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
-    description: 'Managed by test platform: Read access to secrets for group big-team
-      (set 1)'
-    expression: resource.name.extract("secrets/{s}/versions/") == "bt-01__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "bt-01____index" || resource.name.extract("secrets/{s}/versions/")
-      == "bt-02__updater-service-account" || resource.name.extract("secrets/{s}/versions/")
-      == "bt-02____index" || resource.name.extract("secrets/{s}/versions/") == "bt-03__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "bt-03____index" || resource.name.extract("secrets/{s}/versions/")
-      == "bt-04__updater-service-account" || resource.name.extract("secrets/{s}/versions/")
-      == "bt-04____index" || resource.name.extract("secrets/{s}/versions/") == "bt-05__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "bt-05____index"
-    title: Read access to secrets for group big-team (set 1)
+    description: 'Managed by test platform: Read access to secrets for group big-team'
+    expression: resource.name.extract("secrets/{s}/versions/") in ["bt-01__updater-service-account",
+      "bt-01____index", "bt-02__updater-service-account", "bt-02____index", "bt-03__updater-service-account",
+      "bt-03____index", "bt-04__updater-service-account", "bt-04____index", "bt-05__updater-service-account",
+      "bt-05____index", "bt-06__updater-service-account", "bt-06____index", "bt-07__updater-service-account",
+      "bt-07____index", "bt-08__updater-service-account", "bt-08____index", "bt-09__updater-service-account",
+      "bt-09____index", "bt-10__updater-service-account", "bt-10____index", "bt-11__updater-service-account",
+      "bt-11____index", "bt-12__updater-service-account", "bt-12____index"]
+    title: Read access to secrets for group big-team
   members:
   - group:big-team@redhat.com
   role: projects/test-project/roles/openshift_ci_secrets_viewer
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
-      for group big-team (set 1)'
-    expression: resource.name.extract("secrets/{secret}").startsWith("bt-01__") ||
-      resource.name.extract("secrets/{secret}").startsWith("bt-02__") || resource.name.extract("secrets/{secret}").startsWith("bt-03__")
-      || resource.name.extract("secrets/{secret}").startsWith("bt-04__") || resource.name.extract("secrets/{secret}").startsWith("bt-05__")
-    title: Create, update, and delete access for group big-team (set 1)
+      for group big-team'
+    expression: resource.name.extract("secrets/{c}__") in ["bt-01", "bt-02", "bt-03",
+      "bt-04", "bt-05", "bt-06", "bt-07", "bt-08", "bt-09", "bt-10", "bt-11", "bt-12"]
+    title: Create, update, and delete access for group big-team
   members:
   - group:big-team@redhat.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
-    description: 'Managed by test platform: Read access to secrets for group big-team
-      (set 2)'
-    expression: resource.name.extract("secrets/{s}/versions/") == "bt-06__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "bt-06____index" || resource.name.extract("secrets/{s}/versions/")
-      == "bt-07__updater-service-account" || resource.name.extract("secrets/{s}/versions/")
-      == "bt-07____index" || resource.name.extract("secrets/{s}/versions/") == "bt-08__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "bt-08____index" || resource.name.extract("secrets/{s}/versions/")
-      == "bt-09__updater-service-account" || resource.name.extract("secrets/{s}/versions/")
-      == "bt-09____index" || resource.name.extract("secrets/{s}/versions/") == "bt-10__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "bt-10____index"
-    title: Read access to secrets for group big-team (set 2)
-  members:
-  - group:big-team@redhat.com
-  role: projects/test-project/roles/openshift_ci_secrets_viewer
-- condition:
-    description: 'Managed by test platform: Create, update, and delete access to secrets
-      for group big-team (set 2)'
-    expression: resource.name.extract("secrets/{secret}").startsWith("bt-06__") ||
-      resource.name.extract("secrets/{secret}").startsWith("bt-07__") || resource.name.extract("secrets/{secret}").startsWith("bt-08__")
-      || resource.name.extract("secrets/{secret}").startsWith("bt-09__") || resource.name.extract("secrets/{secret}").startsWith("bt-10__")
-    title: Create, update, and delete access for group big-team (set 2)
-  members:
-  - group:big-team@redhat.com
-  role: projects/test-project/roles/openshift_ci_secrets_updater
-- condition:
-    description: 'Managed by test platform: Read access to secrets for group big-team
-      (set 3)'
-    expression: resource.name.extract("secrets/{s}/versions/") == "bt-11__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "bt-11____index" || resource.name.extract("secrets/{s}/versions/")
-      == "bt-12__updater-service-account" || resource.name.extract("secrets/{s}/versions/")
-      == "bt-12____index"
-    title: Read access to secrets for group big-team (set 3)
-  members:
-  - group:big-team@redhat.com
-  role: projects/test-project/roles/openshift_ci_secrets_viewer
-- condition:
-    description: 'Managed by test platform: Create, update, and delete access to secrets
-      for group big-team (set 3)'
-    expression: resource.name.extract("secrets/{secret}").startsWith("bt-11__") ||
-      resource.name.extract("secrets/{secret}").startsWith("bt-12__")
-    title: Create, update, and delete access for group big-team (set 3)
-  members:
-  - group:big-team@redhat.com
-  role: projects/test-project/roles/openshift_ci_secrets_updater
-- condition:
-    description: 'Managed by test platform: Read access to secrets for group small-team
-      (set 1)'
-    expression: resource.name.extract("secrets/{s}/versions/") == "st-01__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "st-01____index"
-    title: Read access to secrets for group small-team (set 1)
+    description: 'Managed by test platform: Read access to secrets for group small-team'
+    expression: resource.name.extract("secrets/{s}/versions/") in ["st-01__updater-service-account",
+      "st-01____index"]
+    title: Read access to secrets for group small-team
   members:
   - group:small-team@redhat.com
   role: projects/test-project/roles/openshift_ci_secrets_viewer
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
-      for group small-team (set 1)'
-    expression: resource.name.extract("secrets/{secret}").startsWith("st-01__")
-    title: Create, update, and delete access for group small-team (set 1)
+      for group small-team'
+    expression: resource.name.extract("secrets/{c}__") in ["st-01"]
+    title: Create, update, and delete access for group small-team
   members:
   - group:small-team@redhat.com
   role: projects/test-project/roles/openshift_ci_secrets_updater

--- a/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_complex_config.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_complex_config.yaml
@@ -1,8 +1,8 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets in alpha-secrets
       collection'
-    expression: resource.name.extract("secrets/{s}/versions/") == "alpha-secrets__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "alpha-secrets____index"
+    expression: resource.name.extract("secrets/{s}/versions/") in ["alpha-secrets__updater-service-account",
+      "alpha-secrets____index"]
     title: Read access to secrets for alpha-secrets
   members:
   - serviceAccount:alpha-secrets-updater@test-project.iam.gserviceaccount.com
@@ -10,7 +10,7 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in alpha-secrets collection'
-    expression: resource.name.extract("secrets/{secret}").startsWith("alpha-secrets__")
+    expression: resource.name.extract("secrets/{c}__") in ["alpha-secrets"]
     title: Create, update, and delete access for alpha-secrets
   members:
   - serviceAccount:alpha-secrets-updater@test-project.iam.gserviceaccount.com
@@ -18,8 +18,8 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets in beta-delta-secrets
       collection'
-    expression: resource.name.extract("secrets/{s}/versions/") == "beta-delta-secrets__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "beta-delta-secrets____index"
+    expression: resource.name.extract("secrets/{s}/versions/") in ["beta-delta-secrets__updater-service-account",
+      "beta-delta-secrets____index"]
     title: Read access to secrets for beta-delta-secrets
   members:
   - serviceAccount:beta-delta-secrets-updater@test-project.iam.gserviceaccount.com
@@ -27,7 +27,7 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in beta-delta-secrets collection'
-    expression: resource.name.extract("secrets/{secret}").startsWith("beta-delta-secrets__")
+    expression: resource.name.extract("secrets/{c}__") in ["beta-delta-secrets"]
     title: Create, update, and delete access for beta-delta-secrets
   members:
   - serviceAccount:beta-delta-secrets-updater@test-project.iam.gserviceaccount.com
@@ -35,8 +35,8 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets in epsilon-secrets
       collection'
-    expression: resource.name.extract("secrets/{s}/versions/") == "epsilon-secrets__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "epsilon-secrets____index"
+    expression: resource.name.extract("secrets/{s}/versions/") in ["epsilon-secrets__updater-service-account",
+      "epsilon-secrets____index"]
     title: Read access to secrets for epsilon-secrets
   members:
   - serviceAccount:epsilon-secrets-updater@test-project.iam.gserviceaccount.com
@@ -44,76 +44,72 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in epsilon-secrets collection'
-    expression: resource.name.extract("secrets/{secret}").startsWith("epsilon-secrets__")
+    expression: resource.name.extract("secrets/{c}__") in ["epsilon-secrets"]
     title: Create, update, and delete access for epsilon-secrets
   members:
   - serviceAccount:epsilon-secrets-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
-    description: 'Managed by test platform: Read access to secrets for group team-alpha
-      (set 1)'
-    expression: resource.name.extract("secrets/{s}/versions/") == "alpha-secrets__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "alpha-secrets____index"
-    title: Read access to secrets for group team-alpha (set 1)
+    description: 'Managed by test platform: Read access to secrets for group team-alpha'
+    expression: resource.name.extract("secrets/{s}/versions/") in ["alpha-secrets__updater-service-account",
+      "alpha-secrets____index"]
+    title: Read access to secrets for group team-alpha
   members:
   - group:team-alpha@redhat.com
   role: projects/test-project/roles/openshift_ci_secrets_viewer
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
-      for group team-alpha (set 1)'
-    expression: resource.name.extract("secrets/{secret}").startsWith("alpha-secrets__")
-    title: Create, update, and delete access for group team-alpha (set 1)
+      for group team-alpha'
+    expression: resource.name.extract("secrets/{c}__") in ["alpha-secrets"]
+    title: Create, update, and delete access for group team-alpha
   members:
   - group:team-alpha@redhat.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
-    description: 'Managed by test platform: Read access to secrets for group team-beta
-      (set 1)'
-    expression: resource.name.extract("secrets/{s}/versions/") == "beta-delta-secrets__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "beta-delta-secrets____index"
-    title: Read access to secrets for group team-beta (set 1)
+    description: 'Managed by test platform: Read access to secrets for group team-beta'
+    expression: resource.name.extract("secrets/{s}/versions/") in ["beta-delta-secrets__updater-service-account",
+      "beta-delta-secrets____index"]
+    title: Read access to secrets for group team-beta
   members:
   - group:team-beta@redhat.com
   role: projects/test-project/roles/openshift_ci_secrets_viewer
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
-      for group team-beta (set 1)'
-    expression: resource.name.extract("secrets/{secret}").startsWith("beta-delta-secrets__")
-    title: Create, update, and delete access for group team-beta (set 1)
+      for group team-beta'
+    expression: resource.name.extract("secrets/{c}__") in ["beta-delta-secrets"]
+    title: Create, update, and delete access for group team-beta
   members:
   - group:team-beta@redhat.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
-    description: 'Managed by test platform: Read access to secrets for group team-delta
-      (set 1)'
-    expression: resource.name.extract("secrets/{s}/versions/") == "beta-delta-secrets__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "beta-delta-secrets____index"
-    title: Read access to secrets for group team-delta (set 1)
+    description: 'Managed by test platform: Read access to secrets for group team-delta'
+    expression: resource.name.extract("secrets/{s}/versions/") in ["beta-delta-secrets__updater-service-account",
+      "beta-delta-secrets____index"]
+    title: Read access to secrets for group team-delta
   members:
   - group:team-delta@redhat.com
   role: projects/test-project/roles/openshift_ci_secrets_viewer
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
-      for group team-delta (set 1)'
-    expression: resource.name.extract("secrets/{secret}").startsWith("beta-delta-secrets__")
-    title: Create, update, and delete access for group team-delta (set 1)
+      for group team-delta'
+    expression: resource.name.extract("secrets/{c}__") in ["beta-delta-secrets"]
+    title: Create, update, and delete access for group team-delta
   members:
   - group:team-delta@redhat.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
-    description: 'Managed by test platform: Read access to secrets for group team-epsilon
-      (set 1)'
-    expression: resource.name.extract("secrets/{s}/versions/") == "epsilon-secrets__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "epsilon-secrets____index"
-    title: Read access to secrets for group team-epsilon (set 1)
+    description: 'Managed by test platform: Read access to secrets for group team-epsilon'
+    expression: resource.name.extract("secrets/{s}/versions/") in ["epsilon-secrets__updater-service-account",
+      "epsilon-secrets____index"]
+    title: Read access to secrets for group team-epsilon
   members:
   - group:team-epsilon@redhat.com
   role: projects/test-project/roles/openshift_ci_secrets_viewer
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
-      for group team-epsilon (set 1)'
-    expression: resource.name.extract("secrets/{secret}").startsWith("epsilon-secrets__")
-    title: Create, update, and delete access for group team-epsilon (set 1)
+      for group team-epsilon'
+    expression: resource.name.extract("secrets/{c}__") in ["epsilon-secrets"]
+    title: Create, update, and delete access for group team-epsilon
   members:
   - group:team-epsilon@redhat.com
   role: projects/test-project/roles/openshift_ci_secrets_updater

--- a/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_one_secret_collection.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_one_secret_collection.yaml
@@ -1,8 +1,8 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets in collection-alpha
       collection'
-    expression: resource.name.extract("secrets/{s}/versions/") == "collection-alpha__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "collection-alpha____index"
+    expression: resource.name.extract("secrets/{s}/versions/") in ["collection-alpha__updater-service-account",
+      "collection-alpha____index"]
     title: Read access to secrets for collection-alpha
   members:
   - serviceAccount:collection-alpha-updater@test-project.iam.gserviceaccount.com
@@ -10,42 +10,40 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in collection-alpha collection'
-    expression: resource.name.extract("secrets/{secret}").startsWith("collection-alpha__")
+    expression: resource.name.extract("secrets/{c}__") in ["collection-alpha"]
     title: Create, update, and delete access for collection-alpha
   members:
   - serviceAccount:collection-alpha-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
-    description: 'Managed by test platform: Read access to secrets for group team-alpha
-      (set 1)'
-    expression: resource.name.extract("secrets/{s}/versions/") == "collection-alpha__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "collection-alpha____index"
-    title: Read access to secrets for group team-alpha (set 1)
+    description: 'Managed by test platform: Read access to secrets for group team-alpha'
+    expression: resource.name.extract("secrets/{s}/versions/") in ["collection-alpha__updater-service-account",
+      "collection-alpha____index"]
+    title: Read access to secrets for group team-alpha
   members:
   - group:team-alpha@redhat.com
   role: projects/test-project/roles/openshift_ci_secrets_viewer
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
-      for group team-alpha (set 1)'
-    expression: resource.name.extract("secrets/{secret}").startsWith("collection-alpha__")
-    title: Create, update, and delete access for group team-alpha (set 1)
+      for group team-alpha'
+    expression: resource.name.extract("secrets/{c}__") in ["collection-alpha"]
+    title: Create, update, and delete access for group team-alpha
   members:
   - group:team-alpha@redhat.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
-    description: 'Managed by test platform: Read access to secrets for group team-beta
-      (set 1)'
-    expression: resource.name.extract("secrets/{s}/versions/") == "collection-alpha__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "collection-alpha____index"
-    title: Read access to secrets for group team-beta (set 1)
+    description: 'Managed by test platform: Read access to secrets for group team-beta'
+    expression: resource.name.extract("secrets/{s}/versions/") in ["collection-alpha__updater-service-account",
+      "collection-alpha____index"]
+    title: Read access to secrets for group team-beta
   members:
   - group:team-beta@redhat.com
   role: projects/test-project/roles/openshift_ci_secrets_viewer
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
-      for group team-beta (set 1)'
-    expression: resource.name.extract("secrets/{secret}").startsWith("collection-alpha__")
-    title: Create, update, and delete access for group team-beta (set 1)
+      for group team-beta'
+    expression: resource.name.extract("secrets/{c}__") in ["collection-alpha"]
+    title: Create, update, and delete access for group team-beta
   members:
   - group:team-beta@redhat.com
   role: projects/test-project/roles/openshift_ci_secrets_updater

--- a/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_unclaimed_config.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_unclaimed_config.yaml
@@ -1,7 +1,7 @@
 - condition:
     description: 'Managed by test platform: Read access to secrets in claimed-a collection'
-    expression: resource.name.extract("secrets/{s}/versions/") == "claimed-a__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "claimed-a____index"
+    expression: resource.name.extract("secrets/{s}/versions/") in ["claimed-a__updater-service-account",
+      "claimed-a____index"]
     title: Read access to secrets for claimed-a
   members:
   - serviceAccount:claimed-a-updater@test-project.iam.gserviceaccount.com
@@ -9,15 +9,15 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in claimed-a collection'
-    expression: resource.name.extract("secrets/{secret}").startsWith("claimed-a__")
+    expression: resource.name.extract("secrets/{c}__") in ["claimed-a"]
     title: Create, update, and delete access for claimed-a
   members:
   - serviceAccount:claimed-a-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in claimed-b collection'
-    expression: resource.name.extract("secrets/{s}/versions/") == "claimed-b__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "claimed-b____index"
+    expression: resource.name.extract("secrets/{s}/versions/") in ["claimed-b__updater-service-account",
+      "claimed-b____index"]
     title: Read access to secrets for claimed-b
   members:
   - serviceAccount:claimed-b-updater@test-project.iam.gserviceaccount.com
@@ -25,28 +25,24 @@
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
       in claimed-b collection'
-    expression: resource.name.extract("secrets/{secret}").startsWith("claimed-b__")
+    expression: resource.name.extract("secrets/{c}__") in ["claimed-b"]
     title: Create, update, and delete access for claimed-b
   members:
   - serviceAccount:claimed-b-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
-    description: 'Managed by test platform: Read access to secrets for group owner-team
-      (set 1)'
-    expression: resource.name.extract("secrets/{s}/versions/") == "claimed-a__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "claimed-a____index" ||
-      resource.name.extract("secrets/{s}/versions/") == "claimed-b__updater-service-account"
-      || resource.name.extract("secrets/{s}/versions/") == "claimed-b____index"
-    title: Read access to secrets for group owner-team (set 1)
+    description: 'Managed by test platform: Read access to secrets for group owner-team'
+    expression: resource.name.extract("secrets/{s}/versions/") in ["claimed-a__updater-service-account",
+      "claimed-a____index", "claimed-b__updater-service-account", "claimed-b____index"]
+    title: Read access to secrets for group owner-team
   members:
   - group:owner-team@redhat.com
   role: projects/test-project/roles/openshift_ci_secrets_viewer
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
-      for group owner-team (set 1)'
-    expression: resource.name.extract("secrets/{secret}").startsWith("claimed-a__")
-      || resource.name.extract("secrets/{secret}").startsWith("claimed-b__")
-    title: Create, update, and delete access for group owner-team (set 1)
+      for group owner-team'
+    expression: resource.name.extract("secrets/{c}__") in ["claimed-a", "claimed-b"]
+    title: Create, update, and delete access for group owner-team
   members:
   - group:owner-team@redhat.com
   role: projects/test-project/roles/openshift_ci_secrets_updater

--- a/pkg/gsm-secrets/types.go
+++ b/pkg/gsm-secrets/types.go
@@ -35,12 +35,6 @@ const (
 	// IAM binding condition description templates
 	SecretsViewerConditionDescriptionTemplate  = "Managed by %s: Read access to secrets in %s collection"
 	SecretsUpdaterConditionDescriptionTemplate = "Managed by %s: Create, update, and delete access to secrets in %s collection"
-
-	// MaxCollectionsPerGroupBinding is the maximum number of collections referenced by a
-	// single group IAM binding condition. GCP allows at most 12 logical operators (&&, ||, !)
-	// per condition expression. The viewer condition uses 2N-1 operators for N collections,
-	// so N=5 (9 operators) stays within the limit.
-	MaxCollectionsPerGroupBinding = 5
 )
 
 type Config struct {

--- a/test/e2e/gsm-secret-sync/gsm-e2e_test.go
+++ b/test/e2e/gsm-secret-sync/gsm-e2e_test.go
@@ -47,6 +47,8 @@ const (
 	// GCS lock bucket configuration
 	gcsBucketEnvVar = "GCS_E2E_LOCK_BUCKET"
 	lockObjectName  = "gsm-secret-sync-e2e-lock"
+
+	multiCollectionGroup = "test-platform-gsm-secrets-owners"
 )
 
 var lockObjectBackoff = wait.Backoff{
@@ -417,6 +419,20 @@ func TestInitialCreate(t *testing.T) {
 	if !tr.compareStates(actualState, expectedState) {
 		t.Fatal("initial create test failed")
 	}
+
+	// A group gets exactly one viewer and one updater binding however many collections it
+	// owns; the old operator-limited form split this group across several.
+	groupBindings := 0
+	for _, binding := range actualState.IAMBindings {
+		for _, member := range binding.Members {
+			if member == fmt.Sprintf("group:%s@redhat.com", multiCollectionGroup) {
+				groupBindings++
+			}
+		}
+	}
+	if groupBindings != 2 {
+		t.Errorf("expected 2 bindings for group %s, got %d", multiCollectionGroup, groupBindings)
+	}
 }
 
 func TestIdempotency(t *testing.T) {
@@ -540,9 +556,10 @@ func TestUnclaimedCollectionPreserved(t *testing.T) {
 		}
 	}
 
-	// No managed IAM binding may reference the unclaimed collection.
+	// No managed IAM binding may reference the unclaimed collection. The updater lists the
+	// bare collection and the viewer lists its secrets, so match the start of either form.
 	for _, binding := range state.IAMBindings {
-		if binding.Condition != nil && strings.Contains(binding.Condition.Expression, unclaimedCollection+"__") {
+		if binding.Condition != nil && strings.Contains(binding.Condition.Expression, `"`+unclaimedCollection) {
 			t.Errorf("unexpected managed IAM binding referencing unclaimed collection: %s", binding.Condition.Title)
 		}
 	}

--- a/test/e2e/gsm-secret-sync/testdata/config-create.yaml
+++ b/test/e2e/gsm-secret-sync/testdata/config-create.yaml
@@ -15,11 +15,10 @@ groups:
   team-noop:
     cluster_groups:
     - dp-managed
-  # Owns more than MaxCollectionsPerGroupBinding collections, so its bindings are
-  # chunked. The first chunk holds 5 collections and exercises the largest viewer
-  # condition (11 logical operators) GCP will accept. This must be a group that
-  # actually exists in the directory, otherwise SetIamPolicy rejects its bindings
-  # with "Group ... does not exist".
+  # Owns several collections, so its two bindings carry multi-element "in" lists and
+  # prove SetIamPolicy accepts a single binding covering a whole group. This must be a
+  # group that actually exists in the directory, otherwise SetIamPolicy rejects its
+  # bindings with "Group ... does not exist".
   test-platform-gsm-secrets-owners:
     secret_collections:
     - large-secrets-01


### PR DESCRIPTION
Follow-up to #5396. 

Each collection was a separate comparison joined by `||`. GCP allows at most **12 logical operators** per condition, so a group owning many collections had to be split across several bindings — that's what `MaxCollectionsPerGroupBinding = 5` and `chunkCollections()` were for.

CEL's `in` expresses the same match as one membership test, and `in` is **not** counted as a logical operator. So a group gets one viewer and one updater binding however many collections it owns, and the chunking is deleted.

## Before / after conditions, a group owning `alpha` and `beta` collections

VIEWER, before:
```
resource.name.extract("secrets/{s}/versions/") == "alpha__updater-service-account" || resource.name.extract("secrets/{s}/versions/") == "alpha____index" || resource.name.extract("secrets/{s}/versions/") == "beta__updater-service-account" || resource.name.extract("secrets/{s}/versions/") == "beta____index"
```

VIEWER, after:
```
resource.name.extract("secrets/{s}/versions/") in ["alpha__updater-service-account", "alpha____index", "beta__updater-service-account", "beta____index"]
```

UPDATER, before:
```
resource.name.extract("secrets/{secret}").startsWith("alpha__") || resource.name.extract("secrets/{secret}").startsWith("beta__")
```

UPDATER, after:
```
resource.name.extract("secrets/{c}__") in ["alpha", "beta"]
```

## Effect

At the ~115 collections / ~50 groups we expect immediately post-migration: policy size **60.5KB -> 43.4KB** (cap is ~67KB), bindings **114 -> 100**.

Both forms were A/B tested against real GCP on dev, and the updater form confirmed on prod with a 23-collection list, before any code was written. 
Most of the diff is regenerated test fixtures.
