### PR TITLE
prowgen: strip newly-generated label in --from-file mode

### DIFF
--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -375,6 +375,8 @@ func WriteToDir(jobDir, org, repo string, jobConfig *prowconfig.JobConfig, gener
 			if err != nil {
 				return err
 			}
+		} else {
+			stripNewlyGeneratedLabel(jobConfig, generator)
 		}
 		sortConfigFields(jobConfig)
 		if err := writeFunc(filepath.Join(jobDirForComponent, file), jobConfig); err != nil {
@@ -709,6 +711,29 @@ func staleSelectorFor(generator Generator, pruneLabels labels.Set) (labels.Selec
 		ls = ls.Add(*req)
 	}
 	return ls, nil
+}
+
+func stripNewlyGeneratedLabel(jobConfig *prowconfig.JobConfig, generator Generator) {
+	key := string(generator)
+	for _, jobs := range jobConfig.PresubmitsStatic {
+		for i := range jobs {
+			if jobs[i].Labels[key] == string(newlyGenerated) {
+				delete(jobs[i].Labels, key)
+			}
+		}
+	}
+	for _, jobs := range jobConfig.PostsubmitsStatic {
+		for i := range jobs {
+			if jobs[i].Labels[key] == string(newlyGenerated) {
+				delete(jobs[i].Labels, key)
+			}
+		}
+	}
+	for i := range jobConfig.Periodics {
+		if jobConfig.Periodics[i].Labels[key] == string(newlyGenerated) {
+			delete(jobConfig.Periodics[i].Labels, key)
+		}
+	}
 }
 
 // Prune removes all generated jobs of the supplied Generator with values that are NOT newly-generated.

--- a/test/integration/ci-operator-prowgen/output/from-file/norehearsals/duper/norehearsals-duper-master-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/from-file/norehearsals/duper/norehearsals-duper-master-postsubmits.yaml
@@ -9,7 +9,6 @@ postsubmits:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
-      prowgen: newly-generated
     max_concurrency: 1
     name: branch-ci-norehearsals-duper-master-upload-results
     spec:

--- a/test/integration/ci-operator-prowgen/output/from-file/norehearsals/duper/norehearsals-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/from-file/norehearsals/duper/norehearsals-duper-master-presubmits.yaml
@@ -11,7 +11,6 @@ presubmits:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
-      prowgen: newly-generated
     name: pull-ci-norehearsals-duper-master-lint
     rerun_command: /test lint
     spec:
@@ -73,7 +72,6 @@ presubmits:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
-      prowgen: newly-generated
     name: pull-ci-norehearsals-duper-master-unit
     rerun_command: /test unit
     spec:

--- a/test/integration/ci-operator-prowgen/output/from-file/super/duper/super-duper-master-periodics.yaml
+++ b/test/integration/ci-operator-prowgen/output/from-file/super/duper/super-duper-master-periodics.yaml
@@ -14,7 +14,6 @@ periodics:
   labels:
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    prowgen: newly-generated
   name: periodic-ci-super-duper-master-e2e-aws-nightly
   spec:
     containers:
@@ -78,7 +77,6 @@ periodics:
   labels:
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    prowgen: newly-generated
   name: periodic-ci-super-duper-master-e2e-aws-nightly-interval
   spec:
     containers:
@@ -142,7 +140,6 @@ periodics:
   labels:
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    prowgen: newly-generated
   name: periodic-ci-super-duper-master-e2e-nightly
   spec:
     containers:
@@ -207,7 +204,6 @@ periodics:
     ci-operator.openshift.io/release-controller: "true"
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    prowgen: newly-generated
   name: periodic-ci-super-duper-master-informer
   spec:
     containers:

--- a/test/integration/ci-operator-prowgen/output/from-file/super/duper/super-duper-master-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/from-file/super/duper/super-duper-master-postsubmits.yaml
@@ -11,7 +11,6 @@ postsubmits:
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
-      prowgen: newly-generated
     max_concurrency: 1
     name: branch-ci-super-duper-master-images
     spec:
@@ -71,7 +70,6 @@ postsubmits:
       - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
-      prowgen: newly-generated
     max_concurrency: 6
     name: branch-ci-super-duper-master-upload-results
     spec:

--- a/test/integration/ci-operator-prowgen/output/from-file/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/from-file/super/duper/super-duper-master-presubmits.yaml
@@ -13,7 +13,6 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-      prowgen: newly-generated
     name: pull-ci-super-duper-master-ci-index
     rerun_command: /test ci-index
     spec:
@@ -69,7 +68,6 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-      prowgen: newly-generated
     name: pull-ci-super-duper-master-ci-index-my-bundle
     optional: true
     rerun_command: /test ci-index-my-bundle
@@ -126,7 +124,6 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-      prowgen: newly-generated
     name: pull-ci-super-duper-master-e2e
     rerun_command: /test e2e
     spec:
@@ -190,7 +187,6 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-      prowgen: newly-generated
     name: pull-ci-super-duper-master-images
     rerun_command: /test images
     spec:
@@ -247,7 +243,6 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-      prowgen: newly-generated
     name: pull-ci-super-duper-master-lint
     rerun_command: /test lint
     spec:
@@ -313,7 +308,6 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-      prowgen: newly-generated
     name: pull-ci-super-duper-master-optional-job
     optional: true
     rerun_command: /test optional-job
@@ -388,7 +382,6 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-      prowgen: newly-generated
     name: pull-ci-super-duper-master-registry
     rerun_command: /test registry
     spec:
@@ -464,7 +457,6 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-      prowgen: newly-generated
     name: pull-ci-super-duper-master-registry-with-profile
     rerun_command: /test registry-with-profile
     spec:
@@ -538,7 +530,6 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-      prowgen: newly-generated
     name: pull-ci-super-duper-master-steps
     rerun_command: /test steps
     spec:
@@ -612,7 +603,6 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-      prowgen: newly-generated
     name: pull-ci-super-duper-master-unit
     rerun_command: /test unit
     spec:


### PR DESCRIPTION
## Summary
- The internal `prowgen: newly-generated` label is used by the prune cycle to identify stale jobs during full directory generation (`--from-dir`). In `--from-file` mode, pruning is skipped, so the label was leaking into written job configs.
- Strip the label before writing when `pruneAll=false`, matching the behavior of the `Prune()` path which already removes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

`prowgen` now removes the internal `prowgen: newly-generated` label when processing jobs with `--from-file`. This prevents stale labels in generated Prow configurations when pruning is disabled.

The cleanup applies to presubmits, postsubmits, and periodics. Existing pruning behavior remains unchanged. Integration fixtures now reflect the corrected output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->