### PR TITLE
gsm-secrets: give unclaimed collections an index, and stop listing the service account in it

### DIFF
--- a/pkg/gsm-secrets/config.go
+++ b/pkg/gsm-secrets/config.go
@@ -22,9 +22,9 @@ import (
 // group.Target.UpdaterServiceAccounts. Group members are unaffected either way: the group
 // bindings already cover every collection the group owns.
 //
-// Collections owned only by an "unclaimed" group (see group.Target.Unclaimed) are kept in the
-// active-collection set so their migrated data secrets are not deleted, but they get no service
-// account, no SA/index secrets, and no bindings until they are moved under a normal group.
+// Collections owned only by an "unclaimed" group (see group.Target.Unclaimed) get an index
+// secret and nothing else: no service account, no SA secret and no bindings, until they are
+// moved under a normal group.
 //
 // Returns desired service account specs, secret specs, IAM binding specs, and the set of active collections.
 func GetDesiredState(configFile string, config Config) ([]ServiceAccountInfo, map[string]GCPSecret, []*iampb.Binding, map[string]bool, error) {
@@ -57,8 +57,16 @@ func GetDesiredState(configFile string, config Config) ([]ServiceAccountInfo, ma
 	desiredCollections := make(map[string]bool)
 	var desiredIAMBindings []*iampb.Binding
 
-	// Keep every referenced collection alive so its migrated data secrets are not deleted,
-	// including unclaimed collections that have no service account or bindings yet.
+	// Keep every referenced collection alive so its migrated data secrets are not deleted.
+	// Unclaimed ones get an index secret too, so that listing them works and so that a later
+	// claim does not start from a missing index.
+	for _, collection := range sets.List(unclaimedCollections) {
+		desiredSecrets[GetIndexSecretName(collection)] = GCPSecret{
+			Name:       GetIndexSecretName(collection),
+			Type:       SecretTypeIndex,
+			Collection: collection,
+		}
+	}
 	for _, collection := range claimedCollections.Union(unclaimedCollections).UnsortedList() {
 		desiredCollections[collection] = true
 	}

--- a/pkg/gsm-secrets/secrets.go
+++ b/pkg/gsm-secrets/secrets.go
@@ -71,35 +71,41 @@ func ExtractCollectionFromSecretName(secretName string) string {
 	return collection
 }
 
-// VerifyIndexSecretContent verifies that the index secret content is correct.
-// At this point we assume that the index secret only contains the updater service account secret name.
+// EmptyIndexSecretContent is the index content for a collection holding no secrets.
+const EmptyIndexSecretContent = "[]"
+
+// VerifyIndexSecretContent verifies that a fresh collection's index secret is empty.
 func VerifyIndexSecretContent(payload []byte) error {
-	expectedContent := "- updater-service-account"
 	actualContent := strings.TrimSpace(string(payload))
 
-	if actualContent != expectedContent {
-		return fmt.Errorf("index secret content mismatch: expected %q, got %q", expectedContent, actualContent)
+	if actualContent != EmptyIndexSecretContent {
+		return fmt.Errorf("index secret content mismatch: expected %q, got %q", EmptyIndexSecretContent, actualContent)
 	}
 
 	return nil
 }
 
-// ConstructIndexSecretContent constructs the index secret content from the secretsList,
-// with UpdaterSASecretName automatically added in this function.
+// ConstructIndexSecretContent constructs the index secret content from the secretsList.
+// The updater service account secret is not listed: it is reached with the CLI's get-sa, and
+// listing it would go stale, since index content is only written when the index is created.
 func ConstructIndexSecretContent(secretsList []string) []byte {
-	secretsList = append(secretsList, UpdaterSASecretName)
-	sort.Strings(secretsList)
+	if len(secretsList) == 0 {
+		return []byte(EmptyIndexSecretContent)
+	}
+	sorted := make([]string, len(secretsList))
+	copy(sorted, secretsList)
+	sort.Strings(sorted)
 
 	var formattedSecrets []string
-	for _, secret := range secretsList {
+	for _, secret := range sorted {
 		formattedSecrets = append(formattedSecrets, fmt.Sprintf("- %s", secret))
 	}
 
 	return []byte(strings.Join(formattedSecrets, "\n"))
 }
 
-// ParseIndexSecretContent parses the index secret YAML content and returns the list of secret names,
-// filtering out the UpdaterSASecretName which is automatically added by ConstructIndexSecretContent.
+// ParseIndexSecretContent parses the index secret YAML content and returns the list of secret
+// names. UpdaterSASecretName is filtered out for indexes created before it stopped being written.
 func ParseIndexSecretContent(content []byte) []string {
 	var allSecrets []string
 	if err := yaml.Unmarshal(content, &allSecrets); err != nil {

--- a/pkg/gsm-secrets/secrets_test.go
+++ b/pkg/gsm-secrets/secrets_test.go
@@ -52,17 +52,22 @@ func TestVerifyIndexSecretContent(t *testing.T) {
 		expectedError error
 	}{
 		{
-			name:    "test-collection-updater-sa",
-			payload: fmt.Appendf(nil, "- updater-service-account"),
+			name:    "empty",
+			payload: fmt.Appendf(nil, "[]"),
 		},
 		{
-			name:    "test-collection-updater-sa-with-newline",
-			payload: fmt.Appendf(nil, "- updater-service-account\n"),
+			name:    "empty with newline",
+			payload: fmt.Appendf(nil, "[]\n"),
 		},
 		{
-			name:          "test-collection-updater-sa-with-multiple-lines",
-			payload:       fmt.Appendf(nil, "- updater-service-account\n- another-service-account"),
-			expectedError: fmt.Errorf("index secret content mismatch: expected %q, got %q", "- updater-service-account\n- another-service-account", "- updater-service-account\n- another-service-account"),
+			name:          "not empty",
+			payload:       fmt.Appendf(nil, "- a-secret\n- another-secret"),
+			expectedError: fmt.Errorf("index secret content mismatch"),
+		},
+		{
+			name:          "legacy updater service account entry",
+			payload:       fmt.Appendf(nil, "- updater-service-account"),
+			expectedError: fmt.Errorf("index secret content mismatch"),
 		},
 	}
 

--- a/pkg/gsm-secrets/testdata/zz_fixture_secrets_TestGetDesiredState_unclaimed_config.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_secrets_TestGetDesiredState_unclaimed_config.yaml
@@ -14,3 +14,19 @@ claimed-b____index:
   Payload: null
   ResourceName: ""
   Type: 2
+unclaimed-x____index:
+  Annotations: null
+  Collection: unclaimed-x
+  Labels: null
+  Name: unclaimed-x____index
+  Payload: null
+  ResourceName: ""
+  Type: 2
+unclaimed-y____index:
+  Annotations: null
+  Collection: unclaimed-y
+  Labels: null
+  Name: unclaimed-y____index
+  Payload: null
+  ResourceName: ""
+  Type: 2

--- a/test/e2e/gsm-secret-sync/gsm-e2e_test.go
+++ b/test/e2e/gsm-secret-sync/gsm-e2e_test.go
@@ -564,11 +564,14 @@ func TestUnclaimedCollectionPreserved(t *testing.T) {
 		}
 	}
 
-	// No managed SA/index secret may be created for the unclaimed collection.
+	// The unclaimed collection gets an index secret, but no SA secret.
 	for name, s := range state.Secrets {
-		if s.Collection == unclaimedCollection && (s.Type == gsm.SecretTypeSA || s.Type == gsm.SecretTypeIndex) {
-			t.Errorf("unexpected managed secret for unclaimed collection: %s (type %v)", name, s.Type)
+		if s.Collection == unclaimedCollection && s.Type == gsm.SecretTypeSA {
+			t.Errorf("unexpected service account secret for unclaimed collection: %s", name)
 		}
+	}
+	if _, ok := state.Secrets[gsm.GetIndexSecretName(unclaimedCollection)]; !ok {
+		t.Errorf("no index secret for unclaimed collection %q", unclaimedCollection)
 	}
 
 	// No managed IAM binding may reference the unclaimed collection. The updater lists the


### PR DESCRIPTION
Don't add the `updater-service-account` string to the new index secrets created by the reconciler.