### PR TITLE
sanitizer: add atomic cluster-only mode

### DIFF
--- a/cmd/pod-scaler/metrics.go
+++ b/cmd/pod-scaler/metrics.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )

--- a/cmd/pod-scaler/metrics_test.go
+++ b/cmd/pod-scaler/metrics_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )

--- a/cmd/sanitize-prow-jobs/README.md
+++ b/cmd/sanitize-prow-jobs/README.md
@@ -4,3 +4,6 @@
 
 * Makes sure all jobs are formatted the same way to keep diffs small
 * Applies defaults to them
+
+Use `--cluster-only` to apply only cluster assignments. Changed files are
+replaced atomically.

--- a/cmd/sanitize-prow-jobs/main.go
+++ b/cmd/sanitize-prow-jobs/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -15,6 +16,7 @@ type options struct {
 	prowJobConfigDir  string
 	configPath        string
 	clusterConfigPath string
+	clusterOnly       bool
 
 	help bool
 }
@@ -25,9 +27,20 @@ func bindOptions(flag *flag.FlagSet) *options {
 	flag.StringVar(&opt.prowJobConfigDir, "prow-jobs-dir", "", "Path to a root of directory structure with Prow job config files (ci-operator/jobs in openshift/release)")
 	flag.StringVar(&opt.configPath, "config-path", "", "Path to the config file (core-services/sanitize-prow-jobs/_config.yaml in openshift/release)")
 	flag.StringVar(&opt.clusterConfigPath, "cluster-config-path", "core-services/sanitize-prow-jobs/_clusters.yaml", "Path to the config file (core-services/sanitize-prow-jobs/_clusters.yaml in openshift/release)")
-	flag.BoolVar(&opt.help, "h", false, "Show help for ci-operator-prowgen")
+	flag.BoolVar(&opt.clusterOnly, "cluster-only", false, "Only apply cluster assignments; write changed files atomically.")
+	flag.BoolVar(&opt.help, "h", false, "Show help for sanitize-prow-jobs")
 
 	return opt
+}
+
+func (o options) validate() error {
+	if o.prowJobConfigDir == "" {
+		return fmt.Errorf("mandatory argument --prow-jobs-dir wasn't set")
+	}
+	if o.configPath == "" {
+		return fmt.Errorf("mandatory argument --config-path wasn't set")
+	}
+	return nil
 }
 
 func main() {
@@ -42,13 +55,14 @@ func main() {
 		os.Exit(0)
 	}
 
-	if len(opt.prowJobConfigDir) == 0 {
-		logrus.Fatal("mandatory argument --prow-jobs-dir wasn't set")
-	}
-	if len(opt.configPath) == 0 {
-		logrus.Fatal("mandatory argument --config-path wasn't set")
+	if err := opt.validate(); err != nil {
+		logrus.Fatal(err)
 	}
 
+	args := flagSet.Args()
+	if len(args) == 0 {
+		args = append(args, "")
+	}
 	config, err := dispatcher.LoadConfig(opt.configPath)
 	if err != nil {
 		logrus.WithError(err).Fatalf("Failed to load config from %q", opt.configPath)
@@ -63,12 +77,14 @@ func main() {
 	if err := config.Validate(); err != nil {
 		logrus.WithError(err).Fatal("Failed to validate the config")
 	}
-	args := flagSet.Args()
-	if len(args) == 0 {
-		args = append(args, "")
-	}
 	for _, subDir := range args {
 		subDir = filepath.Join(opt.prowJobConfigDir, subDir)
+		if opt.clusterOnly {
+			if err := sanitizer.ApplyDefaultClusterAssignments(subDir, config, blocked, cm); err != nil {
+				logrus.WithError(err).Fatal("Failed to apply default cluster assignments")
+			}
+			continue
+		}
 		if err := sanitizer.DeterminizeJobs(subDir, config, nil, blocked, cm); err != nil {
 			logrus.WithError(err).Fatal("Failed to determinize")
 		}

--- a/cmd/sanitize-prow-jobs/main_test.go
+++ b/cmd/sanitize-prow-jobs/main_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOptionsValidate(t *testing.T) {
+	testCases := []struct {
+		name        string
+		options     options
+		errorSubstr string
+	}{
+		{
+			name:        "missing jobs directory",
+			options:     options{configPath: "config.yaml"},
+			errorSubstr: "--prow-jobs-dir",
+		},
+		{
+			name:        "missing assignment source",
+			options:     options{prowJobConfigDir: "jobs"},
+			errorSubstr: "--config-path",
+		},
+		{
+			name:    "config mode",
+			options: options{prowJobConfigDir: "jobs", configPath: "config.yaml"},
+		},
+		{
+			name:    "cluster-only mode",
+			options: options{prowJobConfigDir: "jobs", configPath: "config.yaml", clusterOnly: true},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := testCase.options.validate()
+			if testCase.errorSubstr == "" {
+				if err != nil {
+					t.Fatalf("validate() returned an unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), testCase.errorSubstr) {
+				t.Fatalf("validate() error = %v, want an error containing %q", err, testCase.errorSubstr)
+			}
+		})
+	}
+}

--- a/pkg/sanitizer/assignments.go
+++ b/pkg/sanitizer/assignments.go
@@ -1,0 +1,110 @@
+package sanitizer
+
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"strings"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	prowconfig "sigs.k8s.io/prow/pkg/config"
+	"sigs.k8s.io/yaml"
+
+	"github.com/openshift/ci-tools/pkg/dispatcher"
+	"github.com/openshift/ci-tools/pkg/jobconfig"
+	"github.com/openshift/ci-tools/pkg/util/gzip"
+)
+
+// ApplyDefaultClusterAssignments applies the configured cluster rules atomically.
+func ApplyDefaultClusterAssignments(prowJobConfigDir string, config *dispatcher.Config, blocked sets.Set[string], cm dispatcher.ClusterMap) error {
+	return applyClusterAssignmentsToFiles(prowJobConfigDir, func(path string, jobConfig *prowconfig.JobConfig) (bool, error) {
+		return applyDefaultClusterAssignments(path, jobConfig, config, blocked, cm)
+	})
+}
+
+func applyClusterAssignmentsToFiles(prowJobConfigDir string, apply func(string, *prowconfig.JobConfig) (bool, error)) error {
+	var errs []error
+	if err := filepath.WalkDir(prowJobConfigDir, func(path string, info fs.DirEntry, err error) error {
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to walk file/directory %q: %w", path, err))
+			return nil
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".yaml") {
+			return nil
+		}
+
+		data, err := gzip.ReadFileMaybeGZIP(path)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to read file %q: %w", path, err))
+			return nil
+		}
+
+		jobConfig := &prowconfig.JobConfig{}
+		if err := yaml.Unmarshal(data, jobConfig); err != nil {
+			errs = append(errs, fmt.Errorf("failed to unmarshal file %q: %w", path, err))
+			return nil
+		}
+
+		changed, err := apply(path, jobConfig)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to apply cluster assignments to file %q: %w", path, err))
+			return nil
+		}
+		if !changed {
+			return nil
+		}
+
+		if err := jobconfig.WriteToFileAtomic(path, jobConfig); err != nil {
+			errs = append(errs, fmt.Errorf("failed to atomically write file %q: %w", path, err))
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to walk Prow job configs: %w", err)
+	}
+	return utilerrors.NewAggregate(errs)
+}
+
+func applyDefaultClusterAssignments(path string, jobConfig *prowconfig.JobConfig, config *dispatcher.Config, blocked sets.Set[string], cm dispatcher.ClusterMap) (bool, error) {
+	mostUsedCluster := dispatcher.FindMostUsedCluster(jobConfig)
+	changed := false
+
+	for orgRepo := range jobConfig.PresubmitsStatic {
+		for idx := range jobConfig.PresubmitsStatic[orgRepo] {
+			jobChanged, err := applyDefaultClusterAssignment(&jobConfig.PresubmitsStatic[orgRepo][idx].JobBase, path, config, mostUsedCluster, blocked, cm)
+			if err != nil {
+				return false, err
+			}
+			changed = changed || jobChanged
+		}
+	}
+	for orgRepo := range jobConfig.PostsubmitsStatic {
+		for idx := range jobConfig.PostsubmitsStatic[orgRepo] {
+			jobChanged, err := applyDefaultClusterAssignment(&jobConfig.PostsubmitsStatic[orgRepo][idx].JobBase, path, config, mostUsedCluster, blocked, cm)
+			if err != nil {
+				return false, err
+			}
+			changed = changed || jobChanged
+		}
+	}
+	for idx := range jobConfig.Periodics {
+		jobChanged, err := applyDefaultClusterAssignment(&jobConfig.Periodics[idx].JobBase, path, config, mostUsedCluster, blocked, cm)
+		if err != nil {
+			return false, err
+		}
+		changed = changed || jobChanged
+	}
+	return changed, nil
+}
+
+func applyDefaultClusterAssignment(jobBase *prowconfig.JobBase, path string, config *dispatcher.Config, mostUsedCluster string, blocked sets.Set[string], cm dispatcher.ClusterMap) (bool, error) {
+	cluster, err := determineCluster(*jobBase, config, nil, path, mostUsedCluster, blocked, cm)
+	if err != nil {
+		return false, err
+	}
+	if jobBase.Cluster == cluster {
+		return false, nil
+	}
+	jobBase.Cluster = cluster
+	return true, nil
+}

--- a/pkg/sanitizer/assignments_test.go
+++ b/pkg/sanitizer/assignments_test.go
@@ -1,0 +1,61 @@
+package sanitizer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	prowconfig "sigs.k8s.io/prow/pkg/config"
+	"sigs.k8s.io/yaml"
+
+	"github.com/openshift/ci-tools/pkg/dispatcher"
+)
+
+func TestApplyDefaultClusterAssignmentsOnlyChangesCluster(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "jobs.yaml")
+	jobConfig := prowconfig.JobConfig{
+		PresubmitsStatic: map[string][]prowconfig.Presubmit{
+			"org/repo": {{JobBase: prowconfig.JobBase{Name: "presubmit", Agent: "kubernetes"}, Brancher: prowconfig.Brancher{Branches: []string{"main"}}}},
+		},
+	}
+	writeJobConfig(t, path, jobConfig)
+
+	if err := ApplyDefaultClusterAssignments(dir, &dispatcher.Config{Default: "api.ci"}, sets.New[string](), dispatcher.ClusterMap{}); err != nil {
+		t.Fatalf("ApplyDefaultClusterAssignments() returned an error: %v", err)
+	}
+
+	actual := readJobConfig(t, path)
+	job := actual.PresubmitsStatic["org/repo"][0]
+	if job.Cluster != "api.ci" {
+		t.Errorf("cluster = %q, want %q", job.Cluster, "api.ci")
+	}
+	if len(job.Branches) != 1 || job.Branches[0] != "main" {
+		t.Errorf("branches = %v, want [main]", job.Branches)
+	}
+}
+
+func writeJobConfig(t *testing.T, path string, jobConfig prowconfig.JobConfig) {
+	t.Helper()
+	data, err := yaml.Marshal(jobConfig)
+	if err != nil {
+		t.Fatalf("failed to marshal job config: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o664); err != nil {
+		t.Fatalf("failed to write job config: %v", err)
+	}
+}
+
+func readJobConfig(t *testing.T, path string) prowconfig.JobConfig {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read job config: %v", err)
+	}
+	var jobConfig prowconfig.JobConfig
+	if err := yaml.Unmarshal(data, &jobConfig); err != nil {
+		t.Fatalf("failed to unmarshal job config: %v", err)
+	}
+	return jobConfig
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updates `sanitize-prow-jobs` with a `--cluster-only` mode that assigns dispatcher clusters to presubmits, postsubmits, and periodics without full job determinization.

The sanitizer changes only files with updated cluster assignments and replaces them atomically. It validates mode-specific options and preserves existing job configuration fields, including branch settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->