### PR TITLE
fix: omit visibility from private-org-peribolos-sync output

### DIFF
--- a/cmd/private-org-peribolos-sync/main.go
+++ b/cmd/private-org-peribolos-sync/main.go
@@ -133,7 +133,6 @@ func main() {
 
 func generateRepositories(gc gitHubClient, orgRepos map[string]sets.Set[string], logger *logrus.Entry, onlyOrg string, flattenOrgs []string) map[string]org.Repo {
 	peribolosRepos := make(map[string]org.Repo)
-	visibility := github.RepoVisibilityPrivate
 
 	// Create a set of flattened orgs for efficient lookup
 	// Start with the default flattened orgs for backwards compatibility
@@ -159,7 +158,6 @@ func generateRepositories(gc gitHubClient, orgRepos map[string]sets.Set[string],
 			peribolosRepos[destRepoName] = org.PruneRepoDefaults(org.Repo{
 				Description:      &fullRepo.Description,
 				HomePage:         &fullRepo.Homepage,
-				Visibility:       &visibility, // all repositories in private org should be private
 				HasIssues:        &fullRepo.HasIssues,
 				HasProjects:      &fullRepo.HasProjects,
 				HasWiki:          &fullRepo.HasWiki,

--- a/cmd/private-org-peribolos-sync/main_test.go
+++ b/cmd/private-org-peribolos-sync/main_test.go
@@ -9,7 +9,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/prow/pkg/config/org"
-	"sigs.k8s.io/prow/pkg/github"
 	"sigs.k8s.io/prow/pkg/github/fakegithub"
 
 	"github.com/openshift/ci-tools/pkg/config"
@@ -17,7 +16,6 @@ import (
 
 func TestGenerateRepositories(t *testing.T) {
 	pntrBool := func(b bool) *bool { return &b }
-	privateVisibility := github.RepoVisibilityPrivate
 	pntrString := func(s string) *string { return &s }
 
 	testCases := []struct {
@@ -42,7 +40,6 @@ func TestGenerateRepositories(t *testing.T) {
 					AllowMergeCommit: pntrBool(false),
 					AllowRebaseMerge: pntrBool(false),
 					Description:      pntrString("Test Repo: repo1"),
-					Visibility:       &privateVisibility,
 				},
 				"repo2": {
 					HasProjects:      pntrBool(false),
@@ -50,7 +47,6 @@ func TestGenerateRepositories(t *testing.T) {
 					AllowMergeCommit: pntrBool(false),
 					AllowRebaseMerge: pntrBool(false),
 					Description:      pntrString("Test Repo: repo2"),
-					Visibility:       &privateVisibility,
 				},
 				"testshift-repo3": {
 					HasProjects:      pntrBool(false),
@@ -58,7 +54,6 @@ func TestGenerateRepositories(t *testing.T) {
 					AllowMergeCommit: pntrBool(false),
 					AllowRebaseMerge: pntrBool(false),
 					Description:      pntrString("Test Repo: repo3"),
-					Visibility:       &privateVisibility,
 				},
 				"testshift-repo4": {
 					HasProjects:      pntrBool(false),
@@ -66,7 +61,6 @@ func TestGenerateRepositories(t *testing.T) {
 					AllowMergeCommit: pntrBool(false),
 					AllowRebaseMerge: pntrBool(false),
 					Description:      pntrString("Test Repo: repo4"),
-					Visibility:       &privateVisibility,
 				},
 			},
 		},
@@ -85,7 +79,6 @@ func TestGenerateRepositories(t *testing.T) {
 					AllowMergeCommit: pntrBool(false),
 					AllowRebaseMerge: pntrBool(false),
 					Description:      pntrString("Test Repo: must-gather"),
-					Visibility:       &privateVisibility,
 				},
 				"migtools-must-gather": {
 					HasProjects:      pntrBool(false),
@@ -93,7 +86,6 @@ func TestGenerateRepositories(t *testing.T) {
 					AllowMergeCommit: pntrBool(false),
 					AllowRebaseMerge: pntrBool(false),
 					Description:      pntrString("Test Repo: must-gather"),
-					Visibility:       &privateVisibility,
 				},
 				"migtools-crane": {
 					HasProjects:      pntrBool(false),
@@ -101,7 +93,6 @@ func TestGenerateRepositories(t *testing.T) {
 					AllowMergeCommit: pntrBool(false),
 					AllowRebaseMerge: pntrBool(false),
 					Description:      pntrString("Test Repo: crane"),
-					Visibility:       &privateVisibility,
 				},
 			},
 		},
@@ -122,7 +113,6 @@ func TestGenerateRepositories(t *testing.T) {
 					AllowMergeCommit: pntrBool(false),
 					AllowRebaseMerge: pntrBool(false),
 					Description:      pntrString("Test Repo: installer"),
-					Visibility:       &privateVisibility,
 				},
 				"crane": {
 					HasProjects:      pntrBool(false),
@@ -130,7 +120,6 @@ func TestGenerateRepositories(t *testing.T) {
 					AllowMergeCommit: pntrBool(false),
 					AllowRebaseMerge: pntrBool(false),
 					Description:      pntrString("Test Repo: crane"),
-					Visibility:       &privateVisibility,
 				},
 				"ocp-build-data": {
 					HasProjects:      pntrBool(false),
@@ -138,7 +127,6 @@ func TestGenerateRepositories(t *testing.T) {
 					AllowMergeCommit: pntrBool(false),
 					AllowRebaseMerge: pntrBool(false),
 					Description:      pntrString("Test Repo: ocp-build-data"),
-					Visibility:       &privateVisibility,
 				},
 				"custom-org-custom-repo": {
 					HasProjects:      pntrBool(false),
@@ -146,7 +134,6 @@ func TestGenerateRepositories(t *testing.T) {
 					AllowMergeCommit: pntrBool(false),
 					AllowRebaseMerge: pntrBool(false),
 					Description:      pntrString("Test Repo: custom-repo"),
-					Visibility:       &privateVisibility,
 				},
 			},
 		},
@@ -169,7 +156,6 @@ func TestGenerateRepositories(t *testing.T) {
 					AllowMergeCommit: pntrBool(false),
 					AllowRebaseMerge: pntrBool(false),
 					Description:      pntrString("Test Repo: ocp-build-data"),
-					Visibility:       &privateVisibility,
 				},
 				"operator-sdk": {
 					HasProjects:      pntrBool(false),
@@ -177,7 +163,6 @@ func TestGenerateRepositories(t *testing.T) {
 					AllowMergeCommit: pntrBool(false),
 					AllowRebaseMerge: pntrBool(false),
 					Description:      pntrString("Test Repo: operator-sdk"),
-					Visibility:       &privateVisibility,
 				},
 				"cloud-event-proxy": {
 					HasProjects:      pntrBool(false),
@@ -185,7 +170,6 @@ func TestGenerateRepositories(t *testing.T) {
 					AllowMergeCommit: pntrBool(false),
 					AllowRebaseMerge: pntrBool(false),
 					Description:      pntrString("Test Repo: cloud-event-proxy"),
-					Visibility:       &privateVisibility,
 				},
 				"assisted-installer": {
 					HasProjects:      pntrBool(false),
@@ -193,7 +177,6 @@ func TestGenerateRepositories(t *testing.T) {
 					AllowMergeCommit: pntrBool(false),
 					AllowRebaseMerge: pntrBool(false),
 					Description:      pntrString("Test Repo: assisted-installer"),
-					Visibility:       &privateVisibility,
 				},
 				"logging-fluentd": {
 					HasProjects:      pntrBool(false),
@@ -201,7 +184,6 @@ func TestGenerateRepositories(t *testing.T) {
 					AllowMergeCommit: pntrBool(false),
 					AllowRebaseMerge: pntrBool(false),
 					Description:      pntrString("Test Repo: logging-fluentd"),
-					Visibility:       &privateVisibility,
 				},
 				"other-org-some-repo": {
 					HasProjects:      pntrBool(false),
@@ -209,7 +191,6 @@ func TestGenerateRepositories(t *testing.T) {
 					AllowMergeCommit: pntrBool(false),
 					AllowRebaseMerge: pntrBool(false),
 					Description:      pntrString("Test Repo: some-repo"),
-					Visibility:       &privateVisibility,
 				},
 			},
 		},


### PR DESCRIPTION
- Stop writing `visibility`/`private` in `private-org-peribolos-sync` generated openshift-priv repo config
- `periodic-org-sync` strips `openshift-priv` before `peribolos --fix-repos`; visibility there is unused and caused bulk churn in auto-sync PRs to openshift/config


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

`private-org-peribolos-sync` no longer generates `visibility` or `private` for `openshift-priv` repositories. This prevents unused fields from causing bulk churn in automated `openshift/config` sync pull requests.

Tests: `go test ./cmd/private-org-peribolos-sync/...`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->