### PR TITLE
ci-secret-bootstrap: make GSM take precedence over Vault on merge

### DIFF
--- a/cmd/ci-secret-bootstrap/main.go
+++ b/cmd/ci-secret-bootstrap/main.go
@@ -1261,10 +1261,7 @@ func reconcileSecrets(o options, vaultClient secrets.ReadOnlyClient, gsmClient *
 		}
 
 		if gsmSecretsMap != nil {
-			secretsMap, err = mergeSecretMaps(secretsMap, gsmSecretsMap)
-			if err != nil {
-				errs = append(errs, err)
-			}
+			secretsMap = mergeSecretMaps(secretsMap, gsmSecretsMap)
 		}
 	}
 
@@ -1296,12 +1293,12 @@ func reconcileSecrets(o options, vaultClient secrets.ReadOnlyClient, gsmClient *
 // secret is produced by both sources the GSM copy wins and the Vault copy is dropped. Overrides
 // are logged at warning level (they are expected while a secret exists in both systems), not
 // returned as errors, so an overlapping secret does not fail the whole sync.
-func mergeSecretMaps(vaultSecrets, gsmSecrets map[string][]*coreapi.Secret) (map[string][]*coreapi.Secret, error) {
+func mergeSecretMaps(vaultSecrets, gsmSecrets map[string][]*coreapi.Secret) map[string][]*coreapi.Secret {
 	if len(gsmSecrets) == 0 {
-		return vaultSecrets, nil
+		return vaultSecrets
 	}
 	if len(vaultSecrets) == 0 {
-		return gsmSecrets, nil
+		return gsmSecrets
 	}
 
 	// Track the position of each secret per cluster so the merged output is deterministic:
@@ -1341,7 +1338,7 @@ func mergeSecretMaps(vaultSecrets, gsmSecrets map[string][]*coreapi.Secret) (map
 		}
 	}
 
-	return merged, nil
+	return merged
 }
 
 // collectionGroupKey is used to track auto-discovered fields for a collection+group pair

--- a/cmd/ci-secret-bootstrap/main.go
+++ b/cmd/ci-secret-bootstrap/main.go
@@ -1291,8 +1291,11 @@ func reconcileSecrets(o options, vaultClient secrets.ReadOnlyClient, gsmClient *
 	return errs
 }
 
-// mergeSecretMaps combines Vault and GSM secret maps, with Vault taking precedence on conflicts.
-// Returns the merged map and any conflict errors encountered.
+// mergeSecretMaps combines Vault and GSM secret maps, with GSM taking precedence on conflicts.
+// GSM is the authoritative source during and after the Vault->GSM migration, so when the same
+// secret is produced by both sources the GSM copy wins and the Vault copy is dropped. Overrides
+// are logged at warning level (they are expected while a secret exists in both systems), not
+// returned as errors, so an overlapping secret does not fail the whole sync.
 func mergeSecretMaps(vaultSecrets, gsmSecrets map[string][]*coreapi.Secret) (map[string][]*coreapi.Secret, error) {
 	if len(gsmSecrets) == 0 {
 		return vaultSecrets, nil
@@ -1301,42 +1304,44 @@ func mergeSecretMaps(vaultSecrets, gsmSecrets map[string][]*coreapi.Secret) (map
 		return gsmSecrets, nil
 	}
 
-	vaultIndex := make(map[string]map[types.NamespacedName]bool)
-	for cluster, secretList := range vaultSecrets {
-		if vaultIndex[cluster] == nil {
-			vaultIndex[cluster] = make(map[types.NamespacedName]bool)
+	// Track the position of each secret per cluster so the merged output is deterministic:
+	// Vault secrets keep their original order, GSM-only secrets are appended after them, and a
+	// GSM secret that overrides a Vault secret keeps the Vault entry's position.
+	byCluster := make(map[string]map[types.NamespacedName]*coreapi.Secret)
+	order := make(map[string][]types.NamespacedName)
+
+	insert := func(cluster string, secret *coreapi.Secret, fromGSM bool) {
+		nsName := types.NamespacedName{Namespace: secret.Namespace, Name: secret.Name}
+		if byCluster[cluster] == nil {
+			byCluster[cluster] = make(map[types.NamespacedName]*coreapi.Secret)
 		}
+		if _, exists := byCluster[cluster][nsName]; !exists {
+			order[cluster] = append(order[cluster], nsName)
+		} else if fromGSM {
+			logrus.Warnf("GSM secret %s/%s on cluster %s overrides Vault (GSM takes precedence)", secret.Namespace, secret.Name, cluster)
+		}
+		byCluster[cluster][nsName] = secret
+	}
+
+	for cluster, secretList := range vaultSecrets {
 		for _, secret := range secretList {
-			nsName := types.NamespacedName{Namespace: secret.Namespace, Name: secret.Name}
-			vaultIndex[cluster][nsName] = true
+			insert(cluster, secret, false)
 		}
 	}
-
-	var errs []error
-	merged := make(map[string][]*coreapi.Secret)
-
-	for cluster, secretList := range vaultSecrets {
-		merged[cluster] = make([]*coreapi.Secret, len(secretList))
-		copy(merged[cluster], secretList)
-	}
-
 	for cluster, secretList := range gsmSecrets {
 		for _, secret := range secretList {
-			nsName := types.NamespacedName{Namespace: secret.Namespace, Name: secret.Name}
-
-			if vaultIndex[cluster] != nil && vaultIndex[cluster][nsName] {
-				errs = append(errs, fmt.Errorf(
-					"conflict: GSM secret %s/%s on cluster %s conflicts with Vault (Vault takes precedence)",
-					secret.Namespace, secret.Name, cluster,
-				))
-				continue
-			}
-
-			merged[cluster] = append(merged[cluster], secret)
+			insert(cluster, secret, true)
 		}
 	}
 
-	return merged, utilerrors.NewAggregate(errs)
+	merged := make(map[string][]*coreapi.Secret, len(byCluster))
+	for cluster, nsNames := range order {
+		for _, nsName := range nsNames {
+			merged[cluster] = append(merged[cluster], byCluster[cluster][nsName])
+		}
+	}
+
+	return merged, nil
 }
 
 // collectionGroupKey is used to track auto-discovered fields for a collection+group pair

--- a/cmd/ci-secret-bootstrap/main_test.go
+++ b/cmd/ci-secret-bootstrap/main_test.go
@@ -4516,7 +4516,7 @@ func TestMergeSecretMaps(t *testing.T) {
 			},
 		},
 		{
-			name: "conflict - same secret in both (vault wins)",
+			name: "conflict - same secret in both (gsm wins)",
 			vaultSecrets: map[string][]*coreapi.Secret{
 				"build01": {
 					{
@@ -4537,36 +4537,34 @@ func TestMergeSecretMaps(t *testing.T) {
 				"build01": {
 					{
 						ObjectMeta: metav1.ObjectMeta{Name: "shared-secret", Namespace: "ci"},
-						Data:       map[string][]byte{"key": []byte("vault-value")},
+						Data:       map[string][]byte{"key": []byte("gsm-value")},
 					},
 				},
 			},
-			expectedError: "conflict: GSM secret ci/shared-secret on cluster build01 conflicts with Vault",
 		},
 		{
-			name: "multiple conflicts",
+			name: "multiple conflicts (gsm wins)",
 			vaultSecrets: map[string][]*coreapi.Secret{
 				"build01": {
-					{ObjectMeta: metav1.ObjectMeta{Name: "secret1", Namespace: "ci"}},
-					{ObjectMeta: metav1.ObjectMeta{Name: "secret2", Namespace: "ci"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "secret1", Namespace: "ci"}, Data: map[string][]byte{"key": []byte("vault-value")}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "secret2", Namespace: "ci"}, Data: map[string][]byte{"key": []byte("vault-value")}},
 				},
 			},
 			gsmSecrets: map[string][]*coreapi.Secret{
 				"build01": {
-					{ObjectMeta: metav1.ObjectMeta{Name: "secret1", Namespace: "ci"}},
-					{ObjectMeta: metav1.ObjectMeta{Name: "secret2", Namespace: "ci"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "secret1", Namespace: "ci"}, Data: map[string][]byte{"key": []byte("gsm-value")}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "secret2", Namespace: "ci"}, Data: map[string][]byte{"key": []byte("gsm-value")}},
 				},
 			},
 			expected: map[string][]*coreapi.Secret{
 				"build01": {
-					{ObjectMeta: metav1.ObjectMeta{Name: "secret1", Namespace: "ci"}},
-					{ObjectMeta: metav1.ObjectMeta{Name: "secret2", Namespace: "ci"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "secret1", Namespace: "ci"}, Data: map[string][]byte{"key": []byte("gsm-value")}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "secret2", Namespace: "ci"}, Data: map[string][]byte{"key": []byte("gsm-value")}},
 				},
 			},
-			expectedError: "conflict: GSM secret ci/secret1 on cluster build01 conflicts with Vault",
 		},
 		{
-			name: "mixed - some conflicts, some no conflicts",
+			name: "mixed - some conflicts, some no conflicts (gsm wins conflicts)",
 			vaultSecrets: map[string][]*coreapi.Secret{
 				"build01": {
 					{ObjectMeta: metav1.ObjectMeta{Name: "vault-only", Namespace: "ci"}},
@@ -4582,11 +4580,10 @@ func TestMergeSecretMaps(t *testing.T) {
 			expected: map[string][]*coreapi.Secret{
 				"build01": {
 					{ObjectMeta: metav1.ObjectMeta{Name: "vault-only", Namespace: "ci"}},
-					{ObjectMeta: metav1.ObjectMeta{Name: "shared", Namespace: "ci"}, Data: map[string][]byte{"key": []byte("vault-value")}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "shared", Namespace: "ci"}, Data: map[string][]byte{"key": []byte("gsm-value")}},
 					{ObjectMeta: metav1.ObjectMeta{Name: "gsm-only", Namespace: "ci"}},
 				},
 			},
-			expectedError: "conflict: GSM secret ci/shared on cluster build01 conflicts with Vault",
 		},
 		{
 			name: "different clusters",

--- a/cmd/ci-secret-bootstrap/main_test.go
+++ b/cmd/ci-secret-bootstrap/main_test.go
@@ -4456,11 +4456,10 @@ func TestConstructDockerConfigJSONFromGSM(t *testing.T) {
 
 func TestMergeSecretMaps(t *testing.T) {
 	testCases := []struct {
-		name          string
-		vaultSecrets  map[string][]*coreapi.Secret
-		gsmSecrets    map[string][]*coreapi.Secret
-		expected      map[string][]*coreapi.Secret
-		expectedError string
+		name         string
+		vaultSecrets map[string][]*coreapi.Secret
+		gsmSecrets   map[string][]*coreapi.Secret
+		expected     map[string][]*coreapi.Secret
 	}{
 		{
 			name:         "both maps empty",
@@ -4629,21 +4628,7 @@ func TestMergeSecretMaps(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := mergeSecretMaps(tc.vaultSecrets, tc.gsmSecrets)
-
-			if tc.expectedError != "" {
-				if err == nil {
-					t.Fatalf("expected error containing %q, got nil", tc.expectedError)
-				}
-				if !strings.Contains(err.Error(), tc.expectedError) {
-					t.Fatalf("expected error containing %q, got %q", tc.expectedError, err.Error())
-				}
-			} else {
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-			}
-
+			actual := mergeSecretMaps(tc.vaultSecrets, tc.gsmSecrets)
 			equal(t, "merged secrets", tc.expected, actual)
 		})
 	}


### PR DESCRIPTION
During and after the Vault->GSM migration, GSM is the authoritative source. When the same `namespace/name` secret is produced by both the Vault path (including selfservice `fetchUserSecrets`) and a GSM bundle, the GSM copy now wins and the Vault copy is dropped. Overlaps are logged at warning level instead of being returned as errors, so a secret that exists in both systems during the transition does not fail the sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Updates `ci-secret-bootstrap` to treat GSM as authoritative during the Vault-to-GSM migration. When Vault and GSM provide the same `cluster/namespace/name` secret, the tool keeps the GSM secret and logs a warning instead of returning an error. This includes secrets from selfservice `fetchUserSecrets`, so synchronization succeeds while both systems contain the secret.

Vault ordering remains stable. GSM-only secrets are appended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->