### PR TITLE
Forward Slack mute commands to alert proxy

### DIFF
--- a/cmd/slack-bot/alert_proxy_test.go
+++ b/cmd/slack-bot/alert_proxy_test.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slackevents"
+
+	alertproxyforward "github.com/openshift/ci-tools/pkg/slack/alertproxy"
+	eventhandler "github.com/openshift/ci-tools/pkg/slack/events"
+	interactionhandler "github.com/openshift/ci-tools/pkg/slack/interactions"
+)
+
+func TestValidateAlertProxyEndpointURL(t *testing.T) {
+	for _, value := range []string{
+		"http://alert-proxy.ci.svc:8080/interactions",
+		"https://alert-proxy.ci.svc.cluster.local:8080/interactions",
+	} {
+		if err := validateAlertProxyEndpointURL(value, "/interactions"); err != nil {
+			t.Errorf("validateAlertProxyEndpointURL(%q): %v", value, err)
+		}
+	}
+	for _, value := range []string{
+		"/interactions",
+		"ftp://alert-proxy.ci.svc:8080/interactions",
+		"https://alert-proxy.example.com:8080/interactions",
+		"http://alert-proxy.ci.svc:8443/interactions",
+		"http://alert-proxy.ci.svc:8080/mentions",
+		"http://alert-proxy.ci.svc:8080/interactions?target=x",
+	} {
+		if err := validateAlertProxyEndpointURL(value, "/interactions"); err == nil {
+			t.Errorf("validateAlertProxyEndpointURL(%q) succeeded", value)
+		}
+	}
+}
+
+func TestAlertProxyOptionValidation(t *testing.T) {
+	base := gatherOptions(flag.NewFlagSet("validation", flag.ContinueOnError),
+		"--slack-token-path=/token",
+		"--slack-signing-secret-path=/signing",
+		"--pager-duty-token-file=/pager-duty",
+		"--prow-config-path=/prow-config",
+	)
+	testCases := []struct {
+		name    string
+		mutate  func(*options)
+		wantErr bool
+	}{
+		{name: "disabled"},
+		{name: "interaction", mutate: func(o *options) {
+			o.alertProxyInteractionURL = "http://alert-proxy.ci.svc:8080/interactions"
+			o.alertProxyForwarderSecretPath = "/forwarder"
+		}},
+		{name: "mention", mutate: func(o *options) {
+			o.alertProxyMentionURL = "http://alert-proxy.ci.svc:8080/mentions"
+			o.alertProxyForwarderSecretPath = "/forwarder"
+		}},
+		{name: "missing secret", mutate: func(o *options) {
+			o.alertProxyInteractionURL = "http://alert-proxy.ci.svc:8080/interactions"
+		}, wantErr: true},
+		{name: "orphan secret", mutate: func(o *options) { o.alertProxyForwarderSecretPath = "/forwarder" }, wantErr: true},
+		{name: "missing mention channel", mutate: func(o *options) {
+			o.alertProxyMentionURL = "http://alert-proxy.ci.svc:8080/mentions"
+			o.alertProxyForwarderSecretPath = "/forwarder"
+			o.alertProxyChannelID = ""
+		}, wantErr: true},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			o := base
+			if testCase.mutate != nil {
+				testCase.mutate(&o)
+			}
+			if err := o.Validate(); (err != nil) != testCase.wantErr {
+				t.Fatalf("Validate() error = %v, wantErr %t", err, testCase.wantErr)
+			}
+		})
+	}
+}
+
+func TestComposeEventRoutesOrder(t *testing.T) {
+	var calls []string
+	partial := func(name string, claim bool) eventhandler.PartialHandler {
+		return eventhandler.PartialHandlerFunc(name, func(*slackevents.EventsAPIEvent, *logrus.Entry) (bool, error) {
+			calls = append(calls, name)
+			return claim, nil
+		})
+	}
+	base := eventhandler.HandlerFunc("base", func(*slackevents.EventsAPIEvent, *logrus.Entry) error {
+		calls = append(calls, "base")
+		return nil
+	})
+	for _, testCase := range []struct {
+		name       string
+		alertClaim bool
+		want       []string
+	}{
+		{name: "alert proxy claims first", alertClaim: true, want: []string{"alert-proxy"}},
+		{name: "fall through in order", want: []string{"alert-proxy", "dispatcher", "base"}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			calls = nil
+			routes := composeEventRoutes(base, partial("alert-proxy", testCase.alertClaim), partial("dispatcher", false))
+			if err := routes.Handle(&slackevents.EventsAPIEvent{}, logrus.NewEntry(logrus.New())); err != nil {
+				t.Fatalf("Handle() error: %v", err)
+			}
+			if !slices.Equal(calls, testCase.want) {
+				t.Fatalf("calls = %#v, want %#v", calls, testCase.want)
+			}
+		})
+	}
+}
+
+func signedSlackInteraction(body, secret string) *http.Request {
+	request := httptest.NewRequest(http.MethodPost, "/slack/interactive-endpoint", strings.NewReader(body))
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte("v0:" + timestamp + ":" + body))
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("X-Slack-Request-Timestamp", timestamp)
+	request.Header.Set("X-Slack-Signature", "v0="+hex.EncodeToString(mac.Sum(nil)))
+	return request
+}
+
+func interactionBody(actionID string) string {
+	payload := `{"type":"block_actions","trigger_id":"Tr-1","channel":{"id":"CHY2E1BL4"},"user":{"id":"U1"},"actions":[{"action_id":"` + actionID + `","block_id":"controls"}]}`
+	return "payload=" + url.QueryEscape(payload) + "&preserve=%2f%2F+%20"
+}
+
+type ephemeralCall struct{ channel, user string }
+
+type fakeEphemeralMessenger struct{ calls chan ephemeralCall }
+
+func (f *fakeEphemeralMessenger) PostEphemeralContext(_ context.Context, channelID, userID string, _ ...slack.MsgOption) (string, error) {
+	f.calls <- ephemeralCall{channel: channelID, user: userID}
+	return "", nil
+}
+
+func TestInteractionForwarding(t *testing.T) {
+	type forwardedRequest struct {
+		body   []byte
+		header http.Header
+	}
+	forwarded := make(chan forwardedRequest, 1)
+	proxy := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		body, _ := io.ReadAll(request.Body)
+		forwarded <- forwardedRequest{body: body, header: request.Header.Clone()}
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`{"response_action":"clear"}`))
+	}))
+	defer proxy.Close()
+
+	fallbackCalled := false
+	fallback := interactionhandler.HandlerFunc("fallback", func(*slack.InteractionCallback, *logrus.Entry) ([]byte, error) {
+		fallbackCalled = true
+		return nil, errors.New("claimed callback reached fallback")
+	})
+	body := interactionBody("alert-proxy:ack:a1")
+	endpoint := handleInteraction(
+		func() []byte { return []byte("slack-secret") }, proxy.URL,
+		alertproxyforward.NewRelay(func() []byte { return []byte("forwarder-secret") }), nil, fallback,
+	)
+	response := httptest.NewRecorder()
+	endpoint.ServeHTTP(response, signedSlackInteraction(body, "slack-secret"))
+	if response.Code != http.StatusOK || response.Body.String() != `{"response_action":"clear"}` || fallbackCalled {
+		t.Fatalf("status=%d body=%q fallbackCalled=%t", response.Code, response.Body.String(), fallbackCalled)
+	}
+	request := <-forwarded
+	if string(request.body) != body || request.header.Get("X-Slack-Signature") == "" || request.header.Get(alertproxyforward.SignatureHeader) == "" {
+		t.Fatalf("forwarded body=%q headers=%#v", request.body, request.header)
+	}
+}
+
+func TestInteractionFallback(t *testing.T) {
+	proxyCalled := make(chan struct{}, 1)
+	proxy := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { proxyCalled <- struct{}{} }))
+	defer proxy.Close()
+	fallback := interactionhandler.HandlerFunc("fallback", func(*slack.InteractionCallback, *logrus.Entry) ([]byte, error) {
+		return []byte(`{"fallback":true}`), nil
+	})
+	endpoint := handleInteraction(
+		func() []byte { return []byte("slack-secret") }, proxy.URL,
+		alertproxyforward.NewRelay(func() []byte { return []byte("forwarder-secret") }), nil, fallback,
+	)
+	response := httptest.NewRecorder()
+	endpoint.ServeHTTP(response, signedSlackInteraction(interactionBody("incident:open"), "slack-secret"))
+	if response.Body.String() != `{"fallback":true}` {
+		t.Fatalf("response = %q", response.Body.String())
+	}
+	select {
+	case <-proxyCalled:
+		t.Fatal("unclaimed interaction was forwarded")
+	default:
+	}
+}
+
+func TestInteractionForwardingFailure(t *testing.T) {
+	proxy := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		http.Error(writer, "unavailable", http.StatusServiceUnavailable)
+	}))
+	defer proxy.Close()
+	messenger := &fakeEphemeralMessenger{calls: make(chan ephemeralCall, 1)}
+	endpoint := handleInteraction(
+		func() []byte { return []byte("slack-secret") }, proxy.URL,
+		alertproxyforward.NewRelay(func() []byte { return []byte("forwarder-secret") }), messenger, nil,
+	)
+	response := httptest.NewRecorder()
+	endpoint.ServeHTTP(response, signedSlackInteraction(interactionBody("alert-proxy:ack:a1"), "slack-secret"))
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", response.Code)
+	}
+	select {
+	case call := <-messenger.calls:
+		if call != (ephemeralCall{channel: "CHY2E1BL4", user: "U1"}) {
+			t.Fatalf("ephemeral call = %#v", call)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ephemeral failure message was not posted")
+	}
+}

--- a/cmd/slack-bot/alert_proxy_test.go
+++ b/cmd/slack-bot/alert_proxy_test.go
@@ -47,6 +47,14 @@ func TestValidateAlertProxyEndpointURL(t *testing.T) {
 			t.Errorf("validateAlertProxyEndpointURL(%q) succeeded", value)
 		}
 	}
+	const marker = "do-not-log"
+	err := validateAlertProxyEndpointURL("https://user:"+marker+"@example.invalid/interactions?token="+marker, "/interactions")
+	if err == nil {
+		t.Fatal("sensitive endpoint succeeded validation")
+	}
+	if strings.Contains(err.Error(), marker) {
+		t.Fatalf("validation error exposed endpoint data: %v", err)
+	}
 }
 
 func TestAlertProxyOptionValidation(t *testing.T) {

--- a/cmd/slack-bot/main.go
+++ b/cmd/slack-bot/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -118,23 +119,23 @@ const (
 func validateAlertProxyEndpointURL(value, expectedPath string) error {
 	parsed, err := url.ParseRequestURI(value)
 	if err != nil || !parsed.IsAbs() || parsed.Host == "" {
-		return fmt.Errorf("must be an absolute URL: %q", value)
+		return errors.New("must be an absolute URL")
 	}
 	if parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
-		return fmt.Errorf("must not contain user information, a query, or a fragment: %q", value)
+		return errors.New("must not contain user information, a query, or a fragment")
 	}
 	if parsed.Scheme != "http" && parsed.Scheme != "https" {
-		return fmt.Errorf("scheme must be HTTP or HTTPS: %q", value)
+		return errors.New("scheme must be HTTP or HTTPS")
 	}
 	host := strings.ToLower(strings.TrimSuffix(parsed.Hostname(), "."))
 	if host != alertProxyServiceHost && host != alertProxyServiceFullyQualifiedHost {
-		return fmt.Errorf("must target the alert-proxy service in namespace ci: %q", value)
+		return errors.New("must target the alert-proxy service in namespace ci")
 	}
 	if parsed.Port() != alertProxyServicePort {
-		return fmt.Errorf("must target alert-proxy service port %s: %q", alertProxyServicePort, value)
+		return fmt.Errorf("must target alert-proxy service port %s", alertProxyServicePort)
 	}
 	if parsed.EscapedPath() != expectedPath {
-		return fmt.Errorf("path must be %s: %q", expectedPath, value)
+		return fmt.Errorf("path must be %s", expectedPath)
 	}
 	return nil
 }

--- a/cmd/slack-bot/main.go
+++ b/cmd/slack-bot/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -40,6 +41,7 @@ import (
 	"github.com/openshift/ci-tools/pkg/dispatcher"
 	"github.com/openshift/ci-tools/pkg/jira"
 	"github.com/openshift/ci-tools/pkg/pagerdutyutil"
+	alertproxyforward "github.com/openshift/ci-tools/pkg/slack/alertproxy"
 	dispatchcommand "github.com/openshift/ci-tools/pkg/slack/dispatcher"
 	eventhandler "github.com/openshift/ci-tools/pkg/slack/events"
 	"github.com/openshift/ci-tools/pkg/slack/events/helpdesk"
@@ -78,6 +80,11 @@ type options struct {
 	enableDispatchCapacity        bool
 	enableDispatchDrain           bool
 	enableDispatchCapabilityScope bool
+
+	alertProxyInteractionURL      string
+	alertProxyMentionURL          string
+	alertProxyForwarderSecretPath string
+	alertProxyChannelID           string
 }
 
 func validateDispatcherControlURL(value string) error {
@@ -100,6 +107,36 @@ func validateDispatcherControlURL(value string) error {
 	default:
 		return fmt.Errorf("scheme must be HTTPS, or HTTP for an in-cluster Kubernetes service: %q", value)
 	}
+}
+
+const (
+	alertProxyServiceHost               = "alert-proxy.ci.svc"
+	alertProxyServiceFullyQualifiedHost = "alert-proxy.ci.svc.cluster.local"
+	alertProxyServicePort               = "8080"
+)
+
+func validateAlertProxyEndpointURL(value, expectedPath string) error {
+	parsed, err := url.ParseRequestURI(value)
+	if err != nil || !parsed.IsAbs() || parsed.Host == "" {
+		return fmt.Errorf("must be an absolute URL: %q", value)
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return fmt.Errorf("must not contain user information, a query, or a fragment: %q", value)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("scheme must be HTTP or HTTPS: %q", value)
+	}
+	host := strings.ToLower(strings.TrimSuffix(parsed.Hostname(), "."))
+	if host != alertProxyServiceHost && host != alertProxyServiceFullyQualifiedHost {
+		return fmt.Errorf("must target the alert-proxy service in namespace ci: %q", value)
+	}
+	if parsed.Port() != alertProxyServicePort {
+		return fmt.Errorf("must target alert-proxy service port %s: %q", alertProxyServicePort, value)
+	}
+	if parsed.EscapedPath() != expectedPath {
+		return fmt.Errorf("path must be %s: %q", expectedPath, value)
+	}
+	return nil
 }
 
 func (o *options) Validate() error {
@@ -136,6 +173,27 @@ func (o *options) Validate() error {
 	}
 	if o.enableDispatchCapabilityScope && !o.enableDispatchCapacity {
 		return fmt.Errorf("--enable-dispatch-capability-scope requires --enable-dispatch-capacity")
+	}
+
+	hasAlertProxyEndpoint := o.alertProxyInteractionURL != "" || o.alertProxyMentionURL != ""
+	if o.alertProxyInteractionURL != "" {
+		if err := validateAlertProxyEndpointURL(o.alertProxyInteractionURL, "/interactions"); err != nil {
+			return fmt.Errorf("invalid --alert-proxy-interaction-url: %w", err)
+		}
+	}
+	if o.alertProxyMentionURL != "" {
+		if err := validateAlertProxyEndpointURL(o.alertProxyMentionURL, "/mentions"); err != nil {
+			return fmt.Errorf("invalid --alert-proxy-mention-url: %w", err)
+		}
+		if o.alertProxyChannelID == "" {
+			return fmt.Errorf("--alert-proxy-channel-id is required when alert-proxy mentions are configured")
+		}
+	}
+	if hasAlertProxyEndpoint && o.alertProxyForwarderSecretPath == "" {
+		return fmt.Errorf("--alert-proxy-forwarder-secret-path is required when an alert-proxy endpoint is configured")
+	}
+	if !hasAlertProxyEndpoint && o.alertProxyForwarderSecretPath != "" {
+		return fmt.Errorf("an alert-proxy endpoint URL is required when --alert-proxy-forwarder-secret-path is set")
 	}
 
 	for _, group := range []flagutil.OptionGroup{&o.instrumentationOptions, &o.jiraOptions, &o.pagerDutyOptions, &o.prowconfig} {
@@ -176,6 +234,10 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	fs.BoolVar(&o.enableDispatchCapacity, "enable-dispatch-capacity", false, "Enable applying and cancelling whole-cluster capacity overrides after shadow validation.")
 	fs.BoolVar(&o.enableDispatchDrain, "enable-dispatch-drain", false, "Enable whole-cluster drains after capacity operations meet their SLO.")
 	fs.BoolVar(&o.enableDispatchCapabilityScope, "enable-dispatch-capability-scope", false, "Enable capability-scoped controls after metadata coverage is audited.")
+	fs.StringVar(&o.alertProxyInteractionURL, "alert-proxy-interaction-url", "", "Full in-cluster URL for forwarding alert-proxy Slack interactions. Empty disables forwarding.")
+	fs.StringVar(&o.alertProxyMentionURL, "alert-proxy-mention-url", "", "Full in-cluster URL for forwarding @dptp-bot ci-alerts mentions. Empty disables forwarding.")
+	fs.StringVar(&o.alertProxyForwarderSecretPath, "alert-proxy-forwarder-secret-path", "", "Path to the HMAC secret used only for alert-proxy forwarding.")
+	fs.StringVar(&o.alertProxyChannelID, "alert-proxy-channel-id", "CHY2E1BL4", "Immutable Slack channel ID for #ops-testplatform.")
 
 	if err := fs.Parse(args); err != nil {
 		logrus.WithError(err).Fatal("Could not parse args.")
@@ -194,10 +256,15 @@ var (
 		Name: "slack_bot_dispatch_command_denials_total",
 		Help: "Number of tp-dispatch mentions rejected at the Slack channel boundary.",
 	})
+	alertProxyForwards = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "slack_bot_interaction_forwards_total",
+		Help: "Number of alert-proxy Slack callbacks forwarded by kind and result.",
+	}, []string{"kind", "result"})
 )
 
 func init() {
 	prometheus.MustRegister(dispatchCommandDenials)
+	prometheus.MustRegister(alertProxyForwards)
 }
 
 func addSchemes() error {
@@ -238,6 +305,9 @@ func main() {
 	if o.dispatcherControlTokenPath != "" {
 		secretPaths = append(secretPaths, o.dispatcherControlTokenPath)
 	}
+	if o.alertProxyForwarderSecretPath != "" {
+		secretPaths = append(secretPaths, o.alertProxyForwarderSecretPath)
+	}
 	if err := secret.Add(secretPaths...); err != nil {
 		logrus.WithError(err).Fatal("Error starting secrets agent.")
 	}
@@ -270,6 +340,7 @@ func main() {
 	}
 
 	eventRoutes := eventrouter.ForEvents(slackClient, issueFiler, kubeClient, configAgent.Config, gcsClient, keywordsConfig, o.helpdeskAlias, o.forumChannelId, o.reviewRequestWorkflowID, o.namespace, o.supportRequestChannelID, o.supportRequestThreshold, o.requireWorkflowsInForum)
+	var dispatchMentionHandler eventhandler.PartialHandler
 	if o.dispatcherControlURL != "" {
 		controlClient := dispatcher.NewControlClient(o.dispatcherControlURL, secret.GetTokenGenerator(o.dispatcherControlTokenPath))
 		dispatchHandler, err := dispatchcommand.NewHandler(controlClient, dispatchcommand.Options{
@@ -288,8 +359,20 @@ func main() {
 			logrus.WithError(err).Fatal("Failed to configure dispatcher Slack mentions")
 		}
 		go dispatchHandler.Run(interrupts.Context())
-		eventRoutes = eventhandler.MultiHandler(dispatchHandler.MentionHandler(), eventhandler.PartialFromHandler(eventRoutes))
+		dispatchMentionHandler = dispatchHandler.MentionHandler()
 	}
+
+	var alertProxyRelay *alertproxyforward.Relay
+	var alertProxyMentionHandler eventhandler.PartialHandler
+	if o.alertProxyForwarderSecretPath != "" {
+		alertProxyRelay = alertproxyforward.NewRelay(secret.GetTokenGenerator(o.alertProxyForwarderSecretPath))
+	}
+	if o.alertProxyMentionURL != "" {
+		alertProxyMentionHandler = alertProxyRelay.MentionHandler(o.alertProxyMentionURL, o.alertProxyChannelID, func(result string) {
+			alertProxyForwards.WithLabelValues("mention", result).Inc()
+		})
+	}
+	eventRoutes = composeEventRoutes(eventRoutes, alertProxyMentionHandler, dispatchMentionHandler)
 
 	metrics.ExposeMetrics("slack-bot", config.PushGateway{}, o.instrumentationOptions.MetricsPort)
 	simplifier := simplifypath.NewSimplifier(l("", // shadow element mimicing the root
@@ -307,7 +390,7 @@ func main() {
 	mux := http.NewServeMux()
 	// handle the root to allow for a simple uptime probe
 	mux.Handle("/", handler(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) { writer.WriteHeader(http.StatusOK) })))
-	mux.Handle("/slack/interactive-endpoint", handler(handleInteraction(secret.GetTokenGenerator(o.slackSigningSecretPath), interactionrouter.ForModals(issueFiler, slackClient))))
+	mux.Handle("/slack/interactive-endpoint", handler(handleInteraction(secret.GetTokenGenerator(o.slackSigningSecretPath), o.alertProxyInteractionURL, alertProxyRelay, slackClient, interactionrouter.ForModals(issueFiler, slackClient))))
 	mux.Handle("/slack/events-endpoint", handler(handleEvent(secret.GetTokenGenerator(o.slackSigningSecretPath), eventRoutes)))
 	server := &http.Server{Addr: ":" + strconv.Itoa(o.port), Handler: mux}
 
@@ -362,6 +445,23 @@ func verifiedBody(logger *logrus.Entry, request *http.Request, signingSecret fun
 	return body, true
 }
 
+// composeEventRoutes keeps the reserved ci-alerts route ahead of the optional
+// dispatcher route and the generic mention handler inside base.
+func composeEventRoutes(base eventhandler.Handler, alertProxy, dispatcher eventhandler.PartialHandler) eventhandler.Handler {
+	var routes []eventhandler.PartialHandler
+	if alertProxy != nil {
+		routes = append(routes, alertProxy)
+	}
+	if dispatcher != nil {
+		routes = append(routes, dispatcher)
+	}
+	if len(routes) == 0 {
+		return base
+	}
+	routes = append(routes, eventhandler.PartialFromHandler(base))
+	return eventhandler.MultiHandler(routes...)
+}
+
 func handleEvent(signingSecret func() []byte, handler eventhandler.Handler) http.HandlerFunc {
 	return func(writer http.ResponseWriter, request *http.Request) {
 		logger := logrus.WithField("api", "events")
@@ -407,11 +507,16 @@ func handleEvent(signingSecret func() []byte, handler eventhandler.Handler) http
 	}
 }
 
-func handleInteraction(signingSecret func() []byte, handler interactionhandler.Handler) http.HandlerFunc {
+type ephemeralMessenger interface {
+	PostEphemeralContext(ctx context.Context, channelID, userID string, options ...slack.MsgOption) (string, error)
+}
+
+func handleInteraction(signingSecret func() []byte, proxyURL string, relay *alertproxyforward.Relay, messenger ephemeralMessenger, handler interactionhandler.Handler) http.HandlerFunc {
 	return func(writer http.ResponseWriter, request *http.Request) {
 		logger := logrus.WithField("api", "interactionhandler")
 		logger.Debug("Got an interaction payload.")
-		if _, ok := verifiedBody(logger, request, signingSecret); !ok {
+		body, ok := verifiedBody(logger, request, signingSecret)
+		if !ok {
 			writer.WriteHeader(http.StatusInternalServerError)
 			return
 		}
@@ -425,6 +530,31 @@ func handleInteraction(signingSecret func() []byte, handler interactionhandler.H
 		}
 		logger.WithField("interaction", callback).Trace("Read an interaction payload.")
 		logger = logger.WithFields(fieldsFor(&callback))
+
+		if proxyURL != "" && alertproxyforward.Claims(&callback) {
+			response, err := relay.RelayInteraction(request.Context(), proxyURL, request.Header, body)
+			if err != nil || response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+				alertProxyForwards.WithLabelValues("interaction", "error").Inc()
+				if err != nil {
+					logger.WithError(err).Error("Failed to forward alert-proxy interaction")
+				} else {
+					logger.WithField("status", response.StatusCode).Error("Alert-proxy interaction endpoint returned an error")
+				}
+				writer.WriteHeader(http.StatusOK)
+				postAlertProxyUnavailable(messenger, &callback, logger)
+				return
+			}
+			alertProxyForwards.WithLabelValues("interaction", "success").Inc()
+			if contentType := response.Header.Get("Content-Type"); contentType != "" {
+				writer.Header().Set("Content-Type", contentType)
+			}
+			writer.Header().Set("Content-Length", strconv.Itoa(len(response.Body)))
+			writer.WriteHeader(response.StatusCode)
+			if _, err := writer.Write(response.Body); err != nil {
+				logger.WithError(err).Error("Failed to send alert-proxy interaction response")
+			}
+			return
+		}
 		response, err := handler.Handle(&callback, logger)
 		if err != nil {
 			logger.WithError(err).Error("Failed to handle interaction payload.")
@@ -440,6 +570,30 @@ func handleInteraction(signingSecret func() []byte, handler interactionhandler.H
 			logger.WithError(err).Error("Failed to send interaction payload response.")
 		}
 	}
+}
+
+func postAlertProxyUnavailable(messenger ephemeralMessenger, callback *slack.InteractionCallback, logger *logrus.Entry) {
+	if messenger == nil {
+		return
+	}
+	channelID := callback.Channel.ID
+	if channelID == "" {
+		channelID = callback.Container.ChannelID
+	}
+	if channelID == "" || callback.User.ID == "" {
+		logger.Warn("Cannot post alert-proxy unavailable response without a Slack channel and user")
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		if _, err := messenger.PostEphemeralContext(
+			ctx, channelID, callback.User.ID,
+			slack.MsgOptionText("Alert actions are temporarily unavailable. Please try again.", false),
+		); err != nil {
+			logger.WithError(err).Warn("Failed to post alert-proxy unavailable response")
+		}
+	}()
 }
 
 func fieldsFor(interactionCallback *slack.InteractionCallback) logrus.Fields {

--- a/pkg/slack/alertproxy/forwarder.go
+++ b/pkg/slack/alertproxy/forwarder.go
@@ -1,0 +1,253 @@
+package alertproxy
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slackevents"
+
+	"github.com/openshift/ci-tools/pkg/slack/events"
+)
+
+const (
+	// InteractionPrefix is reserved for callbacks owned by alert-proxy.
+	InteractionPrefix = "alert-proxy:"
+
+	TimestampHeader = "X-Alert-Proxy-Timestamp"
+	SignatureHeader = "X-Alert-Proxy-Signature"
+
+	mentionCommandPrefix = "ci-alerts"
+	signatureVersion     = "v1"
+	defaultRelayTimeout  = 2 * time.Second
+	maxResponseBytes     = 1 << 20
+)
+
+// MentionEnvelope is the authenticated representation of a ci-alerts app mention.
+// IssuedAt is also sent, in decimal form, in TimestampHeader.
+type MentionEnvelope struct {
+	EventID  string `json:"eventID"`
+	IssuedAt int64  `json:"issuedAt"`
+	Channel  string `json:"channel"`
+	User     string `json:"user"`
+	ThreadTS string `json:"threadTS"`
+	Text     string `json:"text"`
+}
+
+// Response is the response from a successfully reached alert-proxy endpoint.
+type Response struct {
+	StatusCode int
+	Header     http.Header
+	Body       []byte
+}
+
+// Relay signs and forwards alert-proxy requests. The secret is read for every
+// request so rotation through the Prow secret agent does not require a restart.
+type Relay struct {
+	secret func() []byte
+	client *http.Client
+	now    func() time.Time
+}
+
+func NewRelay(secret func() []byte) *Relay {
+	return &Relay{
+		secret: secret,
+		client: &http.Client{
+			Timeout: defaultRelayTimeout,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+		now: time.Now,
+	}
+}
+
+// Claims reports whether any alert-proxy-owned routing field carries the
+// reserved prefix. Parsing is intentionally separate from forwarding so the
+// caller can relay Slack's original request body byte-for-byte.
+func Claims(callback *slack.InteractionCallback) bool {
+	if callback == nil {
+		return false
+	}
+	if hasPrefix(callback.CallbackID) || hasPrefix(callback.View.CallbackID) || hasPrefix(callback.View.PrivateMetadata) {
+		return true
+	}
+	for _, action := range callback.ActionCallback.BlockActions {
+		if action != nil && hasPrefix(action.ActionID) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasPrefix(value string) bool {
+	return strings.HasPrefix(value, InteractionPrefix)
+}
+
+// RelayInteraction forwards Slack's exact form body and original headers,
+// adding the alert-proxy forwarder authentication headers.
+func (r *Relay) RelayInteraction(ctx context.Context, target string, originalHeaders http.Header, body []byte) (*Response, error) {
+	if r == nil {
+		return nil, fmt.Errorf("alert-proxy relay is not configured")
+	}
+	return r.relay(ctx, target, originalHeaders, body, r.now().Unix())
+}
+
+// MentionHandler claims exact `ci-alerts` app mentions and forwards a newly
+// authenticated envelope. Unrelated mentions fall through to the existing
+// generic mention handler.
+func (r *Relay) MentionHandler(target, channelID string, observe func(result string)) events.PartialHandler {
+	return events.PartialHandlerFunc(mentionCommandPrefix, func(callback *slackevents.EventsAPIEvent, logger *logrus.Entry) (bool, error) {
+		if callback.Type != slackevents.CallbackEvent {
+			return false, nil
+		}
+		event, ok := callback.InnerEvent.Data.(*slackevents.AppMentionEvent)
+		if !ok {
+			return false, nil
+		}
+		mentionedUserID, text, routed := commandTextFromMention(event.Text)
+		if !routed {
+			return false, nil
+		}
+		if !authenticatedUser(callback, mentionedUserID) {
+			observeResult(observe, "invalid")
+			logger.WithField("mentioned_user_id", mentionedUserID).Warn("ignored alert-proxy command whose leading mention is not an authenticated bot user")
+			return true, nil
+		}
+		if event.Channel != channelID {
+			observeResult(observe, "denied")
+			logger.WithFields(logrus.Fields{"channel_id": event.Channel, "route": mentionCommandPrefix}).Warn("denied alert-proxy Slack mention outside the configured channel")
+			return true, nil
+		}
+		if event.BotID != "" || event.User == "" {
+			observeResult(observe, "invalid")
+			logger.WithField("bot_id", event.BotID).Warn("ignored alert-proxy mention without a human user")
+			return true, nil
+		}
+
+		eventID := eventID(callback)
+		if eventID == "" {
+			observeResult(observe, "invalid")
+			return true, fmt.Errorf("alert-proxy mention is missing its Slack event ID")
+		}
+		threadTS := event.ThreadTimeStamp
+		if threadTS == "" {
+			threadTS = event.TimeStamp
+		}
+		issuedAt := r.now().Unix()
+		body, err := json.Marshal(MentionEnvelope{
+			EventID: eventID, IssuedAt: issuedAt, Channel: event.Channel,
+			User: event.User, ThreadTS: threadTS, Text: text,
+		})
+		if err != nil {
+			observeResult(observe, "error")
+			return true, fmt.Errorf("marshal alert-proxy mention envelope: %w", err)
+		}
+		headers := make(http.Header)
+		headers.Set("Content-Type", "application/json")
+		response, err := r.relay(context.Background(), target, headers, body, issuedAt)
+		if err != nil {
+			observeResult(observe, "error")
+			return true, err
+		}
+		if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+			observeResult(observe, "error")
+			return true, fmt.Errorf("alert-proxy mention endpoint returned HTTP %d", response.StatusCode)
+		}
+		observeResult(observe, "success")
+		return true, nil
+	})
+}
+
+func commandTextFromMention(text string) (string, string, bool) {
+	tokens := strings.Fields(text)
+	if len(tokens) < 2 || !strings.HasPrefix(tokens[0], "<@") || !strings.HasSuffix(tokens[0], ">") || tokens[1] != mentionCommandPrefix {
+		return "", "", false
+	}
+	mentionedUserID := strings.TrimSuffix(strings.TrimPrefix(tokens[0], "<@"), ">")
+	if mentionedUserID == "" || strings.ContainsAny(mentionedUserID, "<>|") {
+		return "", "", false
+	}
+	return mentionedUserID, strings.Join(tokens[2:], " "), true
+}
+
+func authenticatedUser(callback *slackevents.EventsAPIEvent, userID string) bool {
+	outer, ok := callback.Data.(*slackevents.EventsAPICallbackEvent)
+	if !ok {
+		return false
+	}
+	for _, authenticatedUserID := range outer.AuthedUsers {
+		if authenticatedUserID == userID {
+			return true
+		}
+	}
+	return false
+}
+
+func eventID(callback *slackevents.EventsAPIEvent) string {
+	outer, ok := callback.Data.(*slackevents.EventsAPICallbackEvent)
+	if !ok {
+		return ""
+	}
+	return outer.EventID
+}
+
+func observeResult(observe func(string), result string) {
+	if observe != nil {
+		observe(result)
+	}
+}
+
+func (r *Relay) relay(ctx context.Context, target string, headers http.Header, body []byte, issuedAt int64) (*Response, error) {
+	if r == nil || r.secret == nil {
+		return nil, fmt.Errorf("alert-proxy relay secret is not configured")
+	}
+	secret := r.secret()
+	if len(secret) == 0 {
+		return nil, fmt.Errorf("alert-proxy relay secret is empty")
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, target, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create alert-proxy relay request: %w", err)
+	}
+	request.Header = headers.Clone()
+	if request.Header == nil {
+		request.Header = make(http.Header)
+	}
+	timestamp := strconv.FormatInt(issuedAt, 10)
+	request.Header.Set(TimestampHeader, timestamp)
+	request.Header.Set(SignatureHeader, sign(timestamp, body, secret))
+
+	response, err := r.client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("forward request to alert-proxy: %w", err)
+	}
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(io.LimitReader(response.Body, maxResponseBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read alert-proxy response: %w", err)
+	}
+	if len(responseBody) > maxResponseBytes {
+		return nil, fmt.Errorf("alert-proxy response exceeds %d bytes", maxResponseBytes)
+	}
+	return &Response{StatusCode: response.StatusCode, Header: response.Header.Clone(), Body: responseBody}, nil
+}
+
+func sign(timestamp string, body, secret []byte) string {
+	mac := hmac.New(sha256.New, secret)
+	_, _ = mac.Write([]byte(signatureVersion + ":" + timestamp + ":"))
+	_, _ = mac.Write(body)
+	return signatureVersion + "=" + hex.EncodeToString(mac.Sum(nil))
+}

--- a/pkg/slack/alertproxy/forwarder.go
+++ b/pkg/slack/alertproxy/forwarder.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -209,6 +210,17 @@ func observeResult(observe func(string), result string) {
 	}
 }
 
+func redactedRelayError(operation string, err error) error {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return fmt.Errorf("%s: %w", operation, context.Canceled)
+	case errors.Is(err, context.DeadlineExceeded):
+		return fmt.Errorf("%s: %w", operation, context.DeadlineExceeded)
+	default:
+		return fmt.Errorf("%s failed", operation)
+	}
+}
+
 func (r *Relay) relay(ctx context.Context, target string, headers http.Header, body []byte, issuedAt int64) (*Response, error) {
 	if r == nil || r.secret == nil {
 		return nil, fmt.Errorf("alert-proxy relay secret is not configured")
@@ -220,7 +232,7 @@ func (r *Relay) relay(ctx context.Context, target string, headers http.Header, b
 
 	request, err := http.NewRequestWithContext(ctx, http.MethodPost, target, bytes.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("create alert-proxy relay request: %w", err)
+		return nil, redactedRelayError("create alert-proxy relay request", err)
 	}
 	request.Header = headers.Clone()
 	if request.Header == nil {
@@ -232,12 +244,12 @@ func (r *Relay) relay(ctx context.Context, target string, headers http.Header, b
 
 	response, err := r.client.Do(request)
 	if err != nil {
-		return nil, fmt.Errorf("forward request to alert-proxy: %w", err)
+		return nil, redactedRelayError("forward request to alert-proxy", err)
 	}
 	defer response.Body.Close()
 	responseBody, err := io.ReadAll(io.LimitReader(response.Body, maxResponseBytes+1))
 	if err != nil {
-		return nil, fmt.Errorf("read alert-proxy response: %w", err)
+		return nil, redactedRelayError("read alert-proxy response", err)
 	}
 	if len(responseBody) > maxResponseBytes {
 		return nil, fmt.Errorf("alert-proxy response exceeds %d bytes", maxResponseBytes)

--- a/pkg/slack/alertproxy/forwarder_test.go
+++ b/pkg/slack/alertproxy/forwarder_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -107,6 +109,24 @@ func TestRelayInteraction(t *testing.T) {
 	rotated := <-requests
 	if rotated.header.Get(SignatureHeader) == request.header.Get(SignatureHeader) || secretReads != 2 {
 		t.Fatalf("secret rotation was not observed: reads=%d signatures=(%q, %q)", secretReads, request.header.Get(SignatureHeader), rotated.header.Get(SignatureHeader))
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func TestRelayErrorsDoNotExposeTarget(t *testing.T) {
+	const marker = "do-not-log"
+	relay := NewRelay(func() []byte { return []byte("secret") })
+	relay.client.Transport = roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("transport error containing " + marker)
+	})
+	_, err := relay.RelayInteraction(context.Background(), "https://user:"+marker+"@example.invalid/interactions?token="+marker, nil, nil)
+	if err == nil || strings.Contains(err.Error(), marker) {
+		t.Fatalf("relay error exposed request data: %v", err)
 	}
 }
 

--- a/pkg/slack/alertproxy/forwarder_test.go
+++ b/pkg/slack/alertproxy/forwarder_test.go
@@ -1,0 +1,210 @@
+package alertproxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slackevents"
+)
+
+func TestClaims(t *testing.T) {
+	testCases := []struct {
+		name     string
+		callback *slack.InteractionCallback
+		want     bool
+	}{
+		{name: "unrelated", callback: &slack.InteractionCallback{CallbackID: "incident"}},
+		{name: "callback", callback: &slack.InteractionCallback{CallbackID: "alert-proxy:ack:a1"}, want: true},
+		{name: "view", callback: &slack.InteractionCallback{View: slack.View{CallbackID: "alert-proxy:silence:a1"}}, want: true},
+		{name: "view metadata", callback: &slack.InteractionCallback{View: slack.View{PrivateMetadata: "alert-proxy:submit:a1"}}, want: true},
+		{name: "block action", callback: &slack.InteractionCallback{ActionCallback: slack.ActionCallbacks{BlockActions: []*slack.BlockAction{{ActionID: "alert-proxy:unsilence:a1"}}}}, want: true},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := Claims(testCase.callback); got != testCase.want {
+				t.Fatalf("Claims() = %t, want %t", got, testCase.want)
+			}
+		})
+	}
+}
+
+type capturedRequest struct {
+	body   []byte
+	header http.Header
+	method string
+	path   string
+}
+
+func TestRelayInteraction(t *testing.T) {
+	const timestamp = int64(1788850923)
+	body := []byte(`payload=%7B%22type%22%3A%22block_actions%22%2C%22value%22%3A%22a%2Bb%22%7D&keep=%2f%2F+%20`)
+	headers := http.Header{
+		"Content-Type":              {"application/x-www-form-urlencoded"},
+		"X-Slack-Request-Timestamp": {"1788850900"},
+		"X-Slack-Signature":         {"v0=slack-signature"},
+		TimestampHeader:             {"attacker-timestamp"},
+		SignatureHeader:             {"attacker-signature"},
+	}
+	requests := make(chan capturedRequest, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		gotBody, err := io.ReadAll(request.Body)
+		if err != nil {
+			http.Error(writer, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		requests <- capturedRequest{body: gotBody, header: request.Header.Clone(), method: request.Method, path: request.URL.Path}
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusAccepted)
+		_, _ = writer.Write([]byte(`{"response_action":"clear"}`))
+	}))
+	defer server.Close()
+
+	secret := []byte("forwarder-secret")
+	secretReads := 0
+	relay := NewRelay(func() []byte {
+		secretReads++
+		return secret
+	})
+	relay.now = func() time.Time { return time.Unix(timestamp, 0) }
+	response, err := relay.RelayInteraction(context.Background(), server.URL+"/interactions", headers, body)
+	if err != nil {
+		t.Fatalf("RelayInteraction() error: %v", err)
+	}
+	request := <-requests
+	if request.method != http.MethodPost || request.path != "/interactions" || !bytes.Equal(request.body, body) {
+		t.Fatalf("forwarded request = %s %s %q", request.method, request.path, request.body)
+	}
+	if request.header.Get("Content-Type") != "application/x-www-form-urlencoded" ||
+		request.header.Get("X-Slack-Request-Timestamp") != "1788850900" ||
+		request.header.Get("X-Slack-Signature") != "v0=slack-signature" ||
+		request.header.Get(TimestampHeader) != "1788850923" ||
+		request.header.Get(SignatureHeader) != "v1=f5ae6fed5e77487ec3b0c9631ec538e2489ae063df1d92d2752ef38462d8571c" {
+		t.Fatalf("forwarded headers are incorrect: %#v", request.header)
+	}
+	if response.StatusCode != http.StatusAccepted || response.Header.Get("Content-Type") != "application/json" || string(response.Body) != `{"response_action":"clear"}` {
+		t.Fatalf("unexpected response: %#v", response)
+	}
+	if headers.Get(TimestampHeader) != "attacker-timestamp" || headers.Get(SignatureHeader) != "attacker-signature" {
+		t.Fatalf("input headers were mutated: %#v", headers)
+	}
+	if relay.client.Timeout != 2*time.Second {
+		t.Fatalf("relay timeout = %s, want 2s", relay.client.Timeout)
+	}
+
+	secret = []byte("rotated-secret")
+	if _, err := relay.RelayInteraction(context.Background(), server.URL, nil, body); err != nil {
+		t.Fatalf("RelayInteraction() after rotation: %v", err)
+	}
+	rotated := <-requests
+	if rotated.header.Get(SignatureHeader) == request.header.Get(SignatureHeader) || secretReads != 2 {
+		t.Fatalf("secret rotation was not observed: reads=%d signatures=(%q, %q)", secretReads, request.header.Get(SignatureHeader), rotated.header.Get(SignatureHeader))
+	}
+}
+
+func TestRelayDoesNotFollowRedirects(t *testing.T) {
+	var destinationRequests atomic.Int32
+	destination := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		destinationRequests.Add(1)
+	}))
+	defer destination.Close()
+	redirect := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		http.Redirect(writer, request, destination.URL, http.StatusFound)
+	}))
+	defer redirect.Close()
+
+	response, err := NewRelay(func() []byte { return []byte("secret") }).RelayInteraction(context.Background(), redirect.URL, nil, nil)
+	if err != nil {
+		t.Fatalf("RelayInteraction() error: %v", err)
+	}
+	if response.StatusCode != http.StatusFound || destinationRequests.Load() != 0 {
+		t.Fatalf("status=%d destination requests=%d", response.StatusCode, destinationRequests.Load())
+	}
+}
+
+func mentionCallback(text, channel, user, botID string) *slackevents.EventsAPIEvent {
+	return &slackevents.EventsAPIEvent{
+		Type: slackevents.CallbackEvent,
+		Data: &slackevents.EventsAPICallbackEvent{EventID: "Ev-123", AuthedUsers: []string{"BOT"}},
+		InnerEvent: slackevents.EventsAPIInnerEvent{Data: &slackevents.AppMentionEvent{
+			Type: slackevents.AppMention, Text: text, Channel: channel, User: user, BotID: botID,
+			TimeStamp: "100.1", ThreadTimeStamp: "99.1",
+		}},
+	}
+}
+
+func TestMentionHandler(t *testing.T) {
+	const timestamp = int64(1788850923)
+	requests := make(chan capturedRequest, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		body, _ := io.ReadAll(request.Body)
+		requests <- capturedRequest{body: body, header: request.Header.Clone()}
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	relay := NewRelay(func() []byte { return []byte("forwarder-secret") })
+	relay.now = func() time.Time { return time.Unix(timestamp, 0) }
+	var result string
+	handler := relay.MentionHandler(server.URL, "CHY2E1BL4", func(got string) { result = got })
+	handled, err := handler.Handle(
+		mentionCallback("<@BOT> ci-alerts   silence AlertA 2h planned work", "CHY2E1BL4", "U-admin", ""),
+		logrus.NewEntry(logrus.New()),
+	)
+	if err != nil || !handled || result != "success" {
+		t.Fatalf("Handle() = (%t, %v), result=%q", handled, err, result)
+	}
+	request := <-requests
+	var envelope MentionEnvelope
+	if err := json.Unmarshal(request.body, &envelope); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	want := (MentionEnvelope{EventID: "Ev-123", IssuedAt: timestamp, Channel: "CHY2E1BL4", User: "U-admin", ThreadTS: "99.1", Text: "silence AlertA 2h planned work"})
+	if envelope != want || request.header.Get("Content-Type") != "application/json" {
+		t.Fatalf("envelope=%#v headers=%#v, want %#v", envelope, request.header, want)
+	}
+}
+
+func TestMentionHandlerBoundaries(t *testing.T) {
+	var forwarded atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		forwarded.Add(1)
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	unauthenticated := mentionCallback("<@BOT> ci-alerts list", "CHY2E1BL4", "U1", "")
+	unauthenticated.Data.(*slackevents.EventsAPICallbackEvent).AuthedUsers = []string{"OTHER"}
+	testCases := []struct {
+		name        string
+		callback    *slackevents.EventsAPIEvent
+		wantHandled bool
+		wantResult  string
+	}{
+		{name: "unrelated command", callback: mentionCallback("<@BOT> help", "CHY2E1BL4", "U1", "")},
+		{name: "unauthenticated bot identity", callback: unauthenticated, wantHandled: true, wantResult: "invalid"},
+		{name: "wrong channel", callback: mentionCallback("<@BOT> ci-alerts list", "C-other", "U1", ""), wantHandled: true, wantResult: "denied"},
+		{name: "bot actor", callback: mentionCallback("<@BOT> ci-alerts list", "CHY2E1BL4", "U1", "B1"), wantHandled: true, wantResult: "invalid"},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var result string
+			handler := NewRelay(func() []byte { return []byte("secret") }).MentionHandler(server.URL, "CHY2E1BL4", func(got string) { result = got })
+			handled, err := handler.Handle(testCase.callback, logrus.NewEntry(logrus.New()))
+			if err != nil || handled != testCase.wantHandled || result != testCase.wantResult {
+				t.Fatalf("Handle() = (%t, %v), result=%q", handled, err, result)
+			}
+		})
+	}
+	if forwarded.Load() != 0 {
+		t.Fatalf("forwarded %d rejected mentions", forwarded.Load())
+	}
+}


### PR DESCRIPTION
Add bounded, signed forwarding for Slack mute commands while preserving exact mention and authenticated-user identity. Wire the forwarder into slack-bot and cover validation, routing, secret reload, timeout, and redirect behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Updates `slack-bot` to forward supported Slack mute commands and authorized `ci-alerts` mentions to an alert proxy.

- Preserves original interaction bodies and authenticated Slack user identity.
- Signs forwarded requests with the current proxy secret.
- Validates in-cluster alert-proxy endpoints and authorized mentions.
- Applies bounded response reads, request timeouts, and redirect blocking.
- Reloads the forwarding secret for each request.
- Redacts sensitive endpoint data from relay errors.
- Sends an ephemeral Slack message when forwarding fails.
- Keeps unrelated interactions on the existing local handling path.
- Adds routing, validation, forwarding, fallback, secret rotation, timeout, redirect, response, and redaction tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->