### PR TITLE
DPTP-5272: add authoritative decrease prometheus metrics

### DIFF
--- a/cmd/pod-scaler/admission.go
+++ b/cmd/pod-scaler/admission.go
@@ -1290,6 +1290,7 @@ func applyAuthoritativeLimitDecrease(recommended, configured *corev1.ResourceReq
 				}
 			}
 			if !mode.apply {
+				recordAuthoritativeDecrease(decreaseModeDryRun, field, target.resourceType, workloadType, configuredValue, determined, reductionCapped)
 				fieldLogger.WithFields(logrus.Fields{
 					"event":                "authoritative_decrease_dry_run",
 					"workloadClass":        workloadClass,
@@ -1300,6 +1301,7 @@ func applyAuthoritativeLimitDecrease(recommended, configured *corev1.ResourceReq
 				}).Infof("authoritative %s decrease dry-run", target.resourceType)
 				continue
 			}
+			recordAuthoritativeDecrease(decreaseModeApplied, field, target.resourceType, workloadType, configuredValue, determined, reductionCapped)
 			fieldLogger.WithFields(logrus.Fields{
 				"event":                "authoritative_decrease_applied",
 				"workloadClass":        workloadClass,

--- a/cmd/pod-scaler/metrics.go
+++ b/cmd/pod-scaler/metrics.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+const (
+	decreaseModeApplied = "applied"
+	decreaseModeDryRun  = "dry_run"
+)
+
+var (
+	authoritativeDecreaseTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "pod_scaler_authoritative_decrease_total",
+		Help: "Authoritative resource decreases considered by pod-scaler admission, by mode, resource dimension, workload type, and whether max-reduction capped the decrease.",
+	}, []string{"mode", "resource", "workload_type", "reduction_capped"})
+
+	authoritativeReductionRatio = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "pod_scaler_authoritative_reduction_ratio",
+		Help:    "Fraction of configured CPU/memory removed by authoritative decrease (0-1), by mode, resource dimension, and workload type.",
+		Buckets: []float64{0.05, 0.10, 0.15, 0.20, 0.25, 0.30, 0.40, 0.50},
+	}, []string{"mode", "resource", "workload_type"})
+
+	authoritativeSavingsCPUMillicores = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "pod_scaler_authoritative_savings_cpu_millicores_total",
+		Help: "Cumulative CPU millicores between configured and decreased authoritative values.",
+	}, []string{"mode", "resource", "workload_type"})
+
+	authoritativeSavingsMemoryBytes = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "pod_scaler_authoritative_savings_memory_bytes_total",
+		Help: "Cumulative memory bytes between configured and decreased authoritative values.",
+	}, []string{"mode", "resource", "workload_type"})
+)
+
+func init() {
+	prometheus.MustRegister(
+		authoritativeDecreaseTotal,
+		authoritativeReductionRatio,
+		authoritativeSavingsCPUMillicores,
+		authoritativeSavingsMemoryBytes,
+	)
+}
+
+// authoritativeResourceLabel maps admission resource fields to prometheus label values.
+func authoritativeResourceLabel(field corev1.ResourceName, resourceType string) string {
+	switch {
+	case field == corev1.ResourceCPU && resourceType == "request":
+		return "cpu_request"
+	case field == corev1.ResourceCPU && resourceType == "limit":
+		return "cpu_limit"
+	case field == corev1.ResourceMemory && resourceType == "request":
+		return "memory_request"
+	case field == corev1.ResourceMemory && resourceType == "limit":
+		return "memory_limit"
+	default:
+		return "unknown"
+	}
+}
+
+// normalizeWorkloadType returns a non-empty workload type label for metrics.
+func normalizeWorkloadType(workloadType string) string {
+	if workloadType == "" {
+		return "unknown"
+	}
+	return workloadType
+}
+
+// recordAuthoritativeDecrease updates authoritative decrease counters, histograms, and savings totals.
+func recordAuthoritativeDecrease(mode string, field corev1.ResourceName, resourceType string, workloadType string, configured, determined resource.Quantity, reductionCapped bool) {
+	resourceLabel := authoritativeResourceLabel(field, resourceType)
+	workloadType = normalizeWorkloadType(workloadType)
+	capped := strconv.FormatBool(reductionCapped)
+
+	authoritativeDecreaseTotal.WithLabelValues(mode, resourceLabel, workloadType, capped).Inc()
+
+	configuredFloat := configured.AsApproximateFloat64()
+	determinedFloat := determined.AsApproximateFloat64()
+	if configuredFloat > 0 && determinedFloat < configuredFloat {
+		authoritativeReductionRatio.WithLabelValues(mode, resourceLabel, workloadType).Observe(1.0 - determinedFloat/configuredFloat)
+	}
+
+	savings := configured.DeepCopy()
+	savings.Sub(determined)
+	if savings.Sign() <= 0 {
+		return
+	}
+
+	switch field {
+	case corev1.ResourceCPU:
+		authoritativeSavingsCPUMillicores.WithLabelValues(mode, resourceLabel, workloadType).Add(float64(savings.MilliValue()))
+	case corev1.ResourceMemory:
+		authoritativeSavingsMemoryBytes.WithLabelValues(mode, resourceLabel, workloadType).Add(float64(savings.Value()))
+	}
+}

--- a/cmd/pod-scaler/metrics_test.go
+++ b/cmd/pod-scaler/metrics_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// TestAuthoritativeResourceLabel checks prometheus resource label mapping.
+func TestAuthoritativeResourceLabel(t *testing.T) {
+	tests := []struct {
+		field        corev1.ResourceName
+		resourceType string
+		want         string
+	}{
+		{corev1.ResourceCPU, "request", "cpu_request"},
+		{corev1.ResourceCPU, "limit", "cpu_limit"},
+		{corev1.ResourceMemory, "request", "memory_request"},
+		{corev1.ResourceMemory, "limit", "memory_limit"},
+		{corev1.ResourceStorage, "request", "unknown"},
+	}
+	for _, tt := range tests {
+		got := authoritativeResourceLabel(tt.field, tt.resourceType)
+		if got != tt.want {
+			t.Errorf("authoritativeResourceLabel(%v, %q) = %q, want %q", tt.field, tt.resourceType, got, tt.want)
+		}
+	}
+}
+
+// TestNormalizeWorkloadType checks workload type label normalization.
+func TestNormalizeWorkloadType(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{in: "", want: "unknown"},
+		{in: "step", want: "step"},
+		{in: "prowjob", want: "prowjob"},
+	}
+	for _, tt := range tests {
+		if got := normalizeWorkloadType(tt.in); got != tt.want {
+			t.Errorf("normalizeWorkloadType(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+// TestRecordAuthoritativeDecrease checks authoritative decrease metric recording.
+func TestRecordAuthoritativeDecrease(t *testing.T) {
+	t.Run("applied cpu request", func(t *testing.T) {
+		workload := "metrics-test-applied-cpu"
+		beforeDecrease := counterValue(authoritativeDecreaseTotal.WithLabelValues(decreaseModeApplied, "cpu_request", workload, "false"))
+		beforeSavings := counterValue(authoritativeSavingsCPUMillicores.WithLabelValues(decreaseModeApplied, "cpu_request", workload))
+		recordAuthoritativeDecrease(decreaseModeApplied, corev1.ResourceCPU, "request", workload, resource.MustParse("2"), resource.MustParse("1500m"), false)
+		if counterValue(authoritativeDecreaseTotal.WithLabelValues(decreaseModeApplied, "cpu_request", workload, "false")) != beforeDecrease+1 {
+			t.Fatalf("decrease counter not incremented")
+		}
+		if got := counterValue(authoritativeSavingsCPUMillicores.WithLabelValues(decreaseModeApplied, "cpu_request", workload)); got != beforeSavings+500 {
+			t.Fatalf("cpu savings counter mismatch: got %v want %v", got, beforeSavings+500)
+		}
+	})
+	t.Run("applied records histogram observation", func(t *testing.T) {
+		workload := "metrics-test-histogram"
+		beforeCount := histogramSampleCount(decreaseModeApplied, "cpu_request", workload)
+		recordAuthoritativeDecrease(decreaseModeApplied, corev1.ResourceCPU, "request", workload, resource.MustParse("1000m"), resource.MustParse("800m"), false)
+		if got := histogramSampleCount(decreaseModeApplied, "cpu_request", workload); got != beforeCount+1 {
+			t.Fatalf("histogram sample count want %d got %d", beforeCount+1, got)
+		}
+	})
+	t.Run("dry run memory limit capped", func(t *testing.T) {
+		workload := "metrics-test-dry-run-mem"
+		beforeDecrease := counterValue(authoritativeDecreaseTotal.WithLabelValues(decreaseModeDryRun, "memory_limit", workload, "true"))
+		beforeSavings := counterValue(authoritativeSavingsMemoryBytes.WithLabelValues(decreaseModeDryRun, "memory_limit", workload))
+		recordAuthoritativeDecrease(decreaseModeDryRun, corev1.ResourceMemory, "limit", workload, resource.MustParse("4Gi"), resource.MustParse("3Gi"), true)
+		if counterValue(authoritativeDecreaseTotal.WithLabelValues(decreaseModeDryRun, "memory_limit", workload, "true")) != beforeDecrease+1 {
+			t.Fatalf("dry-run decrease counter not incremented")
+		}
+		oneGi := resource.MustParse("1Gi")
+		wantDelta := float64(oneGi.Value())
+		if got := counterValue(authoritativeSavingsMemoryBytes.WithLabelValues(decreaseModeDryRun, "memory_limit", workload)); got != beforeSavings+wantDelta {
+			t.Fatalf("memory savings counter mismatch: got %v want %v", got, beforeSavings+wantDelta)
+		}
+	})
+}
+
+func counterValue(counter prometheus.Counter) float64 {
+	metric, ok := counter.(prometheus.Metric)
+	if !ok {
+		return 0
+	}
+	var dtoMetric dto.Metric
+	if err := metric.Write(&dtoMetric); err != nil || dtoMetric.Counter == nil {
+		return 0
+	}
+	return *dtoMetric.Counter.Value
+}
+
+func histogramSampleCount(mode, resourceLabel, workload string) uint64 {
+	metric, ok := authoritativeReductionRatio.WithLabelValues(mode, resourceLabel, workload).(prometheus.Metric)
+	if !ok {
+		return 0
+	}
+	var dtoMetric dto.Metric
+	if err := metric.Write(&dtoMetric); err != nil || dtoMetric.Histogram == nil {
+		return 0
+	}
+	return *dtoMetric.Histogram.SampleCount
+}


### PR DESCRIPTION
Expose admission counters, savings totals, and reduction-ratio histograms split by cpu/memory request/limit, workload_type, applied vs dry_run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

The `pod-scaler` now exports Prometheus telemetry for authoritative CPU and memory decreases in both applied and dry-run modes.

Operators can track admission counts, cumulative savings, and reduction ratios by resource, request or limit, workload type, and cap status. Added tests cover label mapping, workload normalization, counters, savings, and histograms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->