### PR TITLE
Ephemeral Cluster Controller: enable gsm

### DIFF
--- a/pkg/controller/ephemeralcluster/reconciler.go
+++ b/pkg/controller/ephemeralcluster/reconciler.go
@@ -392,6 +392,7 @@ func (r *reconciler) generateCIOperatorConfig(log *logrus.Entry, ec *ephemeralcl
 	}
 
 	return &api.ReleaseBuildConfiguration{
+		Prowgen: &api.ProwgenOverrides{EnableSecretsStoreCSIDriver: true},
 		InputConfiguration: api.InputConfiguration{
 			BuildRootImage: ec.Spec.CIOperator.BuildRootImage,
 			BaseImages:     baseImages,

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestReconcileCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestReconcileCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
@@ -34,7 +34,11 @@ items:
     pod_spec:
       containers:
       - args:
+        - --enable-secrets-store-csi-driver=true
         - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --gsm-config=/etc/gsm-config/gsm-config.yaml
+        - --gsm-credentials-file=/etc/gsm-credentials/key.json
+        - --gsm-project-config=/etc/gsm-config/gsm-project-config.yaml
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
@@ -66,6 +70,8 @@ items:
                 namespace: ""
                 registry: quay.io/fedora/fedora:43
                 tag: ""
+            prowgen:
+              enable_secrets_store_csi_driver: true
             releases:
               initial:
                 integration:
@@ -135,6 +141,12 @@ items:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /etc/gsm-config
+          name: gsm-config
+          readOnly: true
+        - mountPath: /etc/gsm-credentials
+          name: gsm-sa-key
+          readOnly: true
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
@@ -155,6 +167,15 @@ items:
       - name: ci-pull-credentials
         secret:
           secretName: ci-pull-credentials
+      - configMap:
+          name: gsm-config
+        name: gsm-config
+      - csi:
+          driver: secrets-store.csi.k8s.io
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: ci-operator-sa-key-spc
+        name: gsm-sa-key
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestReconcileCreateProwJob_Hive_cluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestReconcileCreateProwJob_Hive_cluster_request_creates_a_ProwJob.yaml
@@ -32,7 +32,11 @@ items:
     pod_spec:
       containers:
       - args:
+        - --enable-secrets-store-csi-driver=true
         - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --gsm-config=/etc/gsm-config/gsm-config.yaml
+        - --gsm-credentials-file=/etc/gsm-credentials/key.json
+        - --gsm-project-config=/etc/gsm-config/gsm-project-config.yaml
         - --hive-kubeconfig=/secrets/hive-hive-credentials/kubeconfig
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
@@ -69,6 +73,8 @@ items:
                 namespace: ""
                 registry: quay.io/fedora/fedora:43
                 tag: ""
+            prowgen:
+              enable_secrets_store_csi_driver: true
             resources:
               '*':
                 limits:
@@ -138,6 +144,12 @@ items:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /etc/gsm-config
+          name: gsm-config
+          readOnly: true
+        - mountPath: /etc/gsm-credentials
+          name: gsm-sa-key
+          readOnly: true
         - mountPath: /secrets/hive-hive-credentials
           name: hive-hive-credentials
           readOnly: true
@@ -161,6 +173,15 @@ items:
       - name: ci-pull-credentials
         secret:
           secretName: ci-pull-credentials
+      - configMap:
+          name: gsm-config
+        name: gsm-config
+      - csi:
+          driver: secrets-store.csi.k8s.io
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: ci-operator-sa-key-spc
+        name: gsm-sa-key
       - name: hive-hive-credentials
         secret:
           secretName: hive-hive-credentials

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestReconcileCreateProwJob_Privileged_tenant.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestReconcileCreateProwJob_Privileged_tenant.yaml
@@ -34,7 +34,11 @@ items:
     pod_spec:
       containers:
       - args:
+        - --enable-secrets-store-csi-driver=true
         - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --gsm-config=/etc/gsm-config/gsm-config.yaml
+        - --gsm-credentials-file=/etc/gsm-credentials/key.json
+        - --gsm-project-config=/etc/gsm-config/gsm-project-config.yaml
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
@@ -66,6 +70,8 @@ items:
                 namespace: ""
                 registry: quay.io/fedora/fedora:43
                 tag: ""
+            prowgen:
+              enable_secrets_store_csi_driver: true
             releases:
               initial:
                 integration:
@@ -135,6 +141,12 @@ items:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /etc/gsm-config
+          name: gsm-config
+          readOnly: true
+        - mountPath: /etc/gsm-credentials
+          name: gsm-sa-key
+          readOnly: true
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
@@ -155,6 +167,15 @@ items:
       - name: ci-pull-credentials
         secret:
           secretName: ci-pull-credentials
+      - configMap:
+          name: gsm-config
+        name: gsm-config
+      - csi:
+          driver: secrets-store.csi.k8s.io
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: ci-operator-sa-key-spc
+        name: gsm-sa-key
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher


### PR DESCRIPTION
As we are in the middle of transitioning from Vault to Google Secret Manager, the ci-operator flag `--enable-secrets-store-csi-driver=true` is needed to keep up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Enables the Secrets Store CSI Driver in Ephemeral Cluster Controller ProwJobs. Generated `ci-operator` configurations now pass `--enable-secrets-store-csi-driver=true` and include the Google Secret Manager configuration, credentials, mounts, and CSI volume. This supports the Google Secret Manager transition for ephemeral cluster CI jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->