### PR TITLE
Prefix multi-stage JUnit steps with context

### DIFF
--- a/pkg/steps/multi_stage/run.go
+++ b/pkg/steps/multi_stage/run.go
@@ -46,7 +46,7 @@ func (s *multiStageTestStep) runSteps(
 			s.flags |= hasPrevErrs
 		}
 	}()
-	if err := s.runPods(ctx, pods, bestEffortSteps); err != nil {
+	if err := s.runPods(ctx, phase, pods, bestEffortSteps); err != nil {
 		errs = append(errs, err)
 	}
 	select {
@@ -81,10 +81,10 @@ func (s *multiStageTestStep) runSteps(
 	return err
 }
 
-func (s *multiStageTestStep) runPods(ctx context.Context, pods []coreapi.Pod, bestEffortSteps sets.Set[string]) error {
+func (s *multiStageTestStep) runPods(ctx context.Context, phase string, pods []coreapi.Pod, bestEffortSteps sets.Set[string]) error {
 	var errs []error
 	for _, pod := range pods {
-		err := s.runPod(ctx, &pod, base_steps.NewTestCaseNotifier(util.NopNotifier), util.WaitForPodFlag(0))
+		err := s.runPod(ctx, phase, &pod, base_steps.NewTestCaseNotifier(util.NopNotifier), util.WaitForPodFlag(0))
 		if err == nil {
 			continue
 		}
@@ -113,7 +113,7 @@ func (s *multiStageTestStep) runObservers(ctx, textCtx context.Context, pods []c
 			}
 		}(pod)
 		go func(p coreapi.Pod) {
-			err := s.runPod(textCtx, &p, base_steps.NewTestCaseNotifier(util.NopNotifier), util.Interruptible)
+			err := s.runPod(textCtx, "observer", &p, base_steps.NewTestCaseNotifier(util.NopNotifier), util.Interruptible)
 			if ctx.Err() == nil {
 				// when the observer is cancelled, we get an error here that we need to ignore, as it's not an error
 				// for the Pod to be deleted when it's cancelled, it's just expected
@@ -134,8 +134,8 @@ func (s *multiStageTestStep) runObservers(ctx, textCtx context.Context, pods []c
 	done <- struct{}{}
 }
 
-func (s *multiStageTestStep) runPod(ctx context.Context, pod *coreapi.Pod, notifier *base_steps.TestCaseNotifier, flags util.WaitForPodFlag) error {
-	junitName, err := s.junitNameForPod(pod)
+func (s *multiStageTestStep) runPod(ctx context.Context, phase string, pod *coreapi.Pod, notifier *base_steps.TestCaseNotifier, flags util.WaitForPodFlag) error {
+	junitName, err := s.junitNameForPod(phase, pod)
 	if err != nil {
 		return err
 	}
@@ -208,7 +208,7 @@ func (s *multiStageTestStep) runPod(ctx context.Context, pod *coreapi.Pod, notif
 	return nil
 }
 
-func (s *multiStageTestStep) junitNameForPod(pod *coreapi.Pod) (string, error) {
+func (s *multiStageTestStep) junitNameForPod(phase string, pod *coreapi.Pod) (string, error) {
 	if pod == nil {
 		return "", fmt.Errorf("multi-stage test %q cannot determine JUnit name for nil pod", s.name)
 	}
@@ -216,5 +216,5 @@ func (s *multiStageTestStep) junitNameForPod(pod *coreapi.Pod) (string, error) {
 	if stepName == "" {
 		return "", fmt.Errorf("multi-stage test %q pod %q is missing required label %q", s.name, pod.Name, base_steps.LabelMetadataStep)
 	}
-	return fmt.Sprintf("Run multi-stage step %s", stepName), nil
+	return fmt.Sprintf("Run multi-stage step %s:%s", phase, stepName), nil
 }

--- a/pkg/steps/multi_stage/run_test.go
+++ b/pkg/steps/multi_stage/run_test.go
@@ -586,51 +586,51 @@ func TestJUnit(t *testing.T) {
 	}{{
 		name: "no step fails",
 		expected: []string{
-			"Run multi-stage step pre0",
-			"Run multi-stage step ipi-install-install-stableinitial",
+			"Run multi-stage step pre:pre0",
+			"Run multi-stage step pre:ipi-install-install-stableinitial",
 			"Run multi-stage test pre phase",
-			"Run multi-stage step test0",
-			"Run multi-stage step test1",
+			"Run multi-stage step test:test0",
+			"Run multi-stage step test:test1",
 			"Run multi-stage test test phase",
-			"Run multi-stage step post0",
-			"Run multi-stage step post1",
+			"Run multi-stage step post:post0",
+			"Run multi-stage step post:post1",
 			"Run multi-stage test post phase",
 		},
 	}, {
 		name:     "failure in a pre step",
 		failures: sets.New[string](multiStageTestAlias + "-pre0"),
 		expected: []string{
-			"Run multi-stage step pre0",
+			"Run multi-stage step pre:pre0",
 			"Run multi-stage test pre phase",
-			"Run multi-stage step post0",
-			"Run multi-stage step post1",
+			"Run multi-stage step post:post0",
+			"Run multi-stage step post:post1",
 			"Run multi-stage test post phase",
 		},
 	}, {
 		name:     "failure in a test step",
 		failures: sets.New[string](multiStageTestAlias + "-test0"),
 		expected: []string{
-			"Run multi-stage step pre0",
-			"Run multi-stage step ipi-install-install-stableinitial",
+			"Run multi-stage step pre:pre0",
+			"Run multi-stage step pre:ipi-install-install-stableinitial",
 			"Run multi-stage test pre phase",
-			"Run multi-stage step test0",
+			"Run multi-stage step test:test0",
 			"Run multi-stage test test phase",
-			"Run multi-stage step post0",
-			"Run multi-stage step post1",
+			"Run multi-stage step post:post0",
+			"Run multi-stage step post:post1",
 			"Run multi-stage test post phase",
 		},
 	}, {
 		name:     "failure in a post step",
 		failures: sets.New[string](multiStageTestAlias + "-post1"),
 		expected: []string{
-			"Run multi-stage step pre0",
-			"Run multi-stage step ipi-install-install-stableinitial",
+			"Run multi-stage step pre:pre0",
+			"Run multi-stage step pre:ipi-install-install-stableinitial",
 			"Run multi-stage test pre phase",
-			"Run multi-stage step test0",
-			"Run multi-stage step test1",
+			"Run multi-stage step test:test0",
+			"Run multi-stage step test:test1",
 			"Run multi-stage test test phase",
-			"Run multi-stage step post0",
-			"Run multi-stage step post1",
+			"Run multi-stage step post:post0",
+			"Run multi-stage step post:post1",
 			"Run multi-stage test post phase",
 		},
 	}} {
@@ -701,15 +701,15 @@ func TestJUnitNameForPod(t *testing.T) {
 		Labels: map[string]string{steps.LabelMetadataStep: "ipi-install-install-stableinitial"},
 	}}
 
-	name, err := step.junitNameForPod(pod)
+	name, err := step.junitNameForPod("pre", pod)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if name != "Run multi-stage step ipi-install-install-stableinitial" {
+	if name != "Run multi-stage step pre:ipi-install-install-stableinitial" {
 		t.Errorf("unexpected JUnit name: %q", name)
 	}
 
-	_, err = step.junitNameForPod(nil)
+	_, err = step.junitNameForPod("pre", nil)
 	wantErr := `multi-stage test "e2e-aws" cannot determine JUnit name for nil pod`
 	if err == nil || err.Error() != wantErr {
 		t.Fatalf("expected %q, got %v", wantErr, err)
@@ -718,7 +718,7 @@ func TestJUnitNameForPod(t *testing.T) {
 
 func TestRunPodRequiresStepMetadataLabel(t *testing.T) {
 	step := &multiStageTestStep{name: "e2e-aws"}
-	err := step.runPod(context.Background(), &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "generated-step"}}, nil, 0)
+	err := step.runPod(context.Background(), "test", &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "generated-step"}}, nil, 0)
 	want := `multi-stage test "e2e-aws" pod "generated-step" is missing required label "ci.openshift.io/metadata.step"`
 	if err == nil || err.Error() != want {
 		t.Fatalf("expected %q, got %v", want, err)

--- a/test/e2e/multi-stage/artifacts/multi-stage-junit_operator.xml
+++ b/test/e2e/multi-stage/artifacts/multi-stage-junit_operator.xml
@@ -4,22 +4,22 @@
     <testcase name="Find the input image os and tag it into the pipeline" time="whatever">
       <properties></properties>
     </testcase>
-    <testcase name="Run multi-stage step ipi-install-install-stableinitial" time="whatever">
+    <testcase name="Run multi-stage step post:post0" time="whatever">
       <properties></properties>
     </testcase>
-    <testcase name="Run multi-stage step post0" time="whatever">
+    <testcase name="Run multi-stage step post:post1" time="whatever">
       <properties></properties>
     </testcase>
-    <testcase name="Run multi-stage step post1" time="whatever">
+    <testcase name="Run multi-stage step pre:ipi-install-install-stableinitial" time="whatever">
       <properties></properties>
     </testcase>
-    <testcase name="Run multi-stage step pre0" time="whatever">
+    <testcase name="Run multi-stage step pre:pre0" time="whatever">
       <properties></properties>
     </testcase>
-    <testcase name="Run multi-stage step test0" time="whatever">
+    <testcase name="Run multi-stage step test:test0" time="whatever">
       <properties></properties>
     </testcase>
-    <testcase name="Run multi-stage step test1" time="whatever">
+    <testcase name="Run multi-stage step test:test1" time="whatever">
       <properties></properties>
     </testcase>
     <testcase name="Run multi-stage test post phase" time="whatever">

--- a/test/e2e/observer/artifacts/multi-observers-junit_operator.xml
+++ b/test/e2e/observer/artifacts/multi-observers-junit_operator.xml
@@ -4,20 +4,20 @@
     <testcase name="Find the input image os and tag it into the pipeline" time="whatever">
       <properties></properties>
     </testcase>
-    <testcase name="Run multi-stage step check-shared-dir" time="whatever">
-      <properties></properties>
-    </testcase>
-    <testcase name="Run multi-stage step create-kubeconfig" time="whatever">
-      <properties></properties>
-    </testcase>
-    <testcase name="Run multi-stage step failing-observer" time="whatever">
+    <testcase name="Run multi-stage step observer:failing-observer" time="whatever">
       <properties></properties>
       <failure message="">+ echo &#39;this is going to fail&#39;&#xA;this is going to fail&#xA;+ exit 1&#xA;{&#34;component&#34;:&#34;entrypoint&#34;,&#34;error&#34;:&#34;wrapped process failed: exit status 1&#34;,&#34;file&#34;:&#34;sigs.k8s.io/prow/pkg/entrypoint/run.go&#34;,&#34;func&#34;:&#34;sigs.k8s.io/prow/pkg/entrypoint.Options.internalRun&#34;,&#34;level&#34;:&#34;error&#34;,&#34;msg&#34;:&#34;Error executing test process&#34;,&#34;severity&#34;:&#34;error&#34;,&#34;time&#34;:&#34;whatever&#34;}&#xA;error: failed to execute wrapped command: exit status 1&#xA;</failure>
     </testcase>
-    <testcase name="Run multi-stage step inject-observer" time="whatever">
+    <testcase name="Run multi-stage step observer:observer" time="whatever">
       <properties></properties>
     </testcase>
-    <testcase name="Run multi-stage step observer" time="whatever">
+    <testcase name="Run multi-stage step post:check-shared-dir" time="whatever">
+      <properties></properties>
+    </testcase>
+    <testcase name="Run multi-stage step pre:inject-observer" time="whatever">
+      <properties></properties>
+    </testcase>
+    <testcase name="Run multi-stage step test:create-kubeconfig" time="whatever">
       <properties></properties>
     </testcase>
     <testcase name="Run multi-stage test post phase" time="whatever">

--- a/test/e2e/observer/artifacts/simple-observer-junit_operator.xml
+++ b/test/e2e/observer/artifacts/simple-observer-junit_operator.xml
@@ -4,13 +4,13 @@
     <testcase name="Find the input image os and tag it into the pipeline" time="whatever">
       <properties></properties>
     </testcase>
-    <testcase name="Run multi-stage step check-shared-dir" time="whatever">
+    <testcase name="Run multi-stage step observer:observer" time="whatever">
       <properties></properties>
     </testcase>
-    <testcase name="Run multi-stage step create-kubeconfig" time="whatever">
+    <testcase name="Run multi-stage step post:check-shared-dir" time="whatever">
       <properties></properties>
     </testcase>
-    <testcase name="Run multi-stage step observer" time="whatever">
+    <testcase name="Run multi-stage step test:create-kubeconfig" time="whatever">
       <properties></properties>
     </testcase>
     <testcase name="Run multi-stage test post phase" time="whatever">


### PR DESCRIPTION
Include pre, test, post, or observer in each multi-stage step testcase name. This makes an isolated result explain whether the step sets up the environment, performs the test, tears it down, or observes it.

The tradeoff is that the same step run in different contexts is tracked as separate testcases, which can fragment its result history. Running one step in multiple contexts should be rare, and the added context is more useful for understanding individual results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Multi-stage CI test execution now prefixes JUnit testcase names with their execution context: `pre`, `test`, `post`, or `observer`. This lets CI users and operators distinguish setup, test, teardown, and observation steps. Steps with the same name in different contexts are tracked as separate testcases, which can fragment result history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->